### PR TITLE
add `abs`, `||`, `&&` and `&&!` to Real

### DIFF
--- a/src/compute/Compiler.scala
+++ b/src/compute/Compiler.scala
@@ -153,20 +153,24 @@ object Compiler {
       case DivideOp   => 1
       case MultiplyOp => 2
       case SubtractOp => 3
+      case OrOp       => 4
+      case AndOp      => 5
+      case AndNotOp   => 6
     }
     List(encode(store, opcode), left, right)
   }
 
   private def unary(load: Int, store: Int, op: UnaryOp): Seq[Int] = {
     val opcode = op match {
-      case ExpOp => 4
-      case LogOp => 5
+      case ExpOp => 7
+      case LogOp => 8
+      case AbsOp => 9
     }
     List(encode(store, opcode), load)
   }
 
   private def sum(store: Int, seq: Seq[Int]): Seq[Int] = {
-    encode(store, 6) :: seq.size :: seq.toList
+    encode(store, 10) :: seq.size :: seq.toList
   }
 
   private val bitmask = ((1 << addressBits) - 1)
@@ -191,11 +195,25 @@ object Compiler {
           heap(next()) * heap(next())
         case 3 => //Subtract
           heap(next()) - heap(next())
-        case 4 => //Exp
+        case 4 => //Or
+          val left = heap(next())
+          val right = heap(next())
+          if (left == 0) right else left
+        case 5 => //And
+          val left = heap(next())
+          val right = heap(next())
+          if (right == 0) 0 else left
+        case 6 => //AndNot
+          val left = heap(next())
+          val right = heap(next())
+          if (right == 0) left else 0
+        case 7 => //Exp
           math.exp(heap(next()))
-        case 5 => //Log
+        case 8 => //Log
           math.log(heap(next()))
-        case 6 => //Sum
+        case 9 => //Abs
+          heap(next()).abs
+        case 10 => //Sum
           val size = next()
           var sum = 0.0
           var i = 0

--- a/src/compute/Gradient.scala
+++ b/src/compute/Gradient.scala
@@ -83,6 +83,21 @@ object Gradient {
             gradient.toReal * (Real.one / child.right)
           else
             gradient.toReal * -1 * child.left / (child.right * child.right)
+        case OrOp =>
+          if (isLeft)
+            gradient.toReal && child.left
+          else
+            gradient.toReal &&! child.left
+        case AndOp =>
+          if (isLeft)
+            gradient.toReal && child.right
+          else
+            Real.zero
+        case AndNotOp =>
+          if (isLeft)
+            gradient.toReal &&! child.right
+          else
+            Real.zero
       }
   }
 
@@ -90,6 +105,7 @@ object Gradient {
     def toReal = child.op match {
       case LogOp => gradient.toReal * (Real.one / child.original)
       case ExpOp => gradient.toReal * child
+      case AbsOp => gradient.toReal * child.original / (child || Real.one)
     }
   }
 }

--- a/src/compute/Real.scala
+++ b/src/compute/Real.scala
@@ -7,8 +7,13 @@ sealed trait Real {
   def -(other: Real): Real =
     Pruner.prune(new BinaryReal(this, other, SubtractOp))
   def /(other: Real): Real = Pruner.prune(new BinaryReal(this, other, DivideOp))
+  def ||(other: Real): Real = Pruner.prune(new BinaryReal(this, other, OrOp))
+  def &&(other: Real): Real = Pruner.prune(new BinaryReal(this, other, AndOp))
+  def &&!(other: Real): Real =
+    Pruner.prune(new BinaryReal(this, other, AndNotOp))
   def exp: Real = Pruner.prune(new UnaryReal(this, ExpOp))
   def log: Real = Pruner.prune(new UnaryReal(this, LogOp))
+  def abs: Real = Pruner.prune(new UnaryReal(this, AbsOp))
 }
 
 object Real {
@@ -83,6 +88,30 @@ case object DivideOp extends BinaryOp {
   def apply(left: Double, right: Double) = left / right
 }
 
+case object OrOp extends BinaryOp {
+  def apply(left: Double, right: Double) =
+    if (left == 0.0)
+      right
+    else
+      left
+}
+
+case object AndOp extends BinaryOp {
+  def apply(left: Double, right: Double) =
+    if (right == 0.0)
+      0.0
+    else
+      left
+}
+
+case object AndNotOp extends BinaryOp {
+  def apply(left: Double, right: Double) =
+    if (right == 0.0)
+      left
+    else
+      0.0
+}
+
 sealed trait UnaryOp {
   def apply(original: Double): Double
 }
@@ -93,4 +122,8 @@ case object ExpOp extends UnaryOp {
 
 case object LogOp extends UnaryOp {
   def apply(original: Double) = math.log(original)
+}
+
+case object AbsOp extends UnaryOp {
+  def apply(original: Double) = original.abs
 }


### PR DESCRIPTION
The motivation here was to get the `abs` unary operator, in order to later implement, eg, the `Laplace` distribution. The gradient of `abs` is undefined at zero, but the standard approach here (including in Stan, for instance) is to have the gradient at zero be zero. I chose to implement this using a new pseudo-logical `||` operator, where `(a || b)` is `b` when `a == 0` and `a` otherwise. We then need to consider what the gradient of `||` is, and implementing this required two more pseudo-logical operators, `&&` and `&&!`. Each of these 4 new operators can lead to zero gradients in various situations, which I have some apprehension about, but this seems to be common practice.

This builds but has not been tested; the intention is to follow it up with a `Laplace` PR that includes a working example.