### PR TITLE
add tracing to Compiler and use it in FitHLL

### DIFF
--- a/src/main/scala/rainier/models/FitHLL.scala
+++ b/src/main/scala/rainier/models/FitHLL.scala
@@ -14,7 +14,7 @@ object FitHLL {
       hll.logDensity(lambda, sketch)
     }
 
-  def compare(scale: Int) = {
+  def compare(scale: Int): RandomVariable[Real] = {
     println("Generating a set with max size " + scale)
     val data = 1.to(scale).map { i =>
       rand.nextInt
@@ -27,17 +27,34 @@ object FitHLL {
     println("Confidence interval: " + lower.toInt + ", " + upper.toInt)
 
     println("Inferring size")
-    val samples = model(sketch).sample()
+    val m = model(sketch)
+    val t1 = System.currentTimeMillis
+    val samples =
+      m.sample(Hamiltonian(10000, 1000, 100, 100, SampleHMC, 1, 0.01))
+    val t2 = System.currentTimeMillis
     val mean = samples.sum / samples.size
     println("Inferred size: " + mean.toInt)
     val sorted = samples.sorted
     val lower2 = sorted((samples.size * 0.05).toInt)
     val upper2 = sorted((samples.size * 0.95).toInt)
     println("Credible interval: " + lower2.toInt + ", " + upper2.toInt)
+    println("ms: " + (t2 - t1))
     println("")
+    m
   }
 
   def main(args: Array[String]) {
     compare(1000)
+  }
+}
+
+object TraceHLL {
+  def main(args: Array[String]) {
+    val m = FitHLL.compare(1000)
+    val d = m.density
+    val v = Real.variables(d).toList.head
+    val g = Gradient.derive(List(v), d).head
+    val c = Compiler(List(d, g))
+    c.trace
   }
 }


### PR DESCRIPTION
This lays some groundwork to do some Compiler optimization. It:

* adds a human readable `trace` to `CompiledFunction` so you can inspect the generated instructions
* adds a `TraceHLL` entrypoint that just runs `FitHLL` but then dumps the instructions for the density & gradient
* uses HMC with a large number of iterations in `FitHLL` so that it takes long enough to be an interesting benchmark, and reports on the time spent; this gives a rough quantitative idea of whether any compiler optimizations are doing anything useful, vs the trace which gives qualitative info

Note that simple textual transformations on the trace output should allow you to produce Java or C versions of the calculations to use as a baseline /cc @gkk-stripe 

