### PR TITLE
Fix FitPriors

### DIFF
--- a/src/main/scala/rainier/models/FitPriors.scala
+++ b/src/main/scala/rainier/models/FitPriors.scala
@@ -53,7 +53,7 @@ object FitPriors {
         "Uniform(Normal)" -> unifNormal
       )
 
-//    Report.printReport(prior, Emcee(10000, 1000, 100))
+    Report.printReport(prior, Emcee(1000, 100, 100))
     Report.printReport(prior, Hamiltonian(1000, 10, 10, 10))
   }
 }


### PR DESCRIPTION
Use fewer iterations of Emcee so that Report isn't trying to process an absurd number of samples.