### PR TITLE
refactor Compiler to make alternative implementations easier

### DIFF
--- a/rainier-core/src/main/scala/rainier/sampler/Emcee.scala
+++ b/rainier-core/src/main/scala/rainier/sampler/Emcee.scala
@@ -10,12 +10,15 @@ case class Emcee(iterations: Int, burnIn: Int, walkers: Int) extends Sampler {
                        "Burn In" -> burnIn.toDouble
                      ))
 
-  def sample(density: Real)(implicit rng: RNG): Iterator[Sample] =
-    EmceeChain(density, walkers).toStream
+  def sample(density: Real)(implicit rng: RNG): Iterator[Sample] = {
+    val variables = Real.variables(density).toList
+    EmceeChain(density, variables, walkers).toStream
       .drop(burnIn * walkers)
       .take(iterations * walkers)
       .map { c =>
-        Sample(c.walker, c.accepted, new Evaluator(c.variables))
+        val map = variables.zip(c.variables).toMap
+        Sample(c.walker, c.accepted, new Evaluator(map))
       }
       .iterator
+  }
 }

--- a/rainier-core/src/main/scala/rainier/sampler/Hamiltonian.scala
+++ b/rainier-core/src/main/scala/rainier/sampler/Hamiltonian.scala
@@ -26,14 +26,15 @@ case class Hamiltonian(iterations: Int,
                      ))
 
   def sample(density: Real)(implicit rng: RNG): Iterator[Sample] = {
-    val tuned = take(HamiltonianChain(density),
+    val variables = Real.variables(density).toList
+    val tuned = take(HamiltonianChain(variables, density),
                      burnIn + 1,
                      initialStepSize,
                      sampleMethod).last
     val stepSize = findReasonableStepSize(tuned, initialStepSize)
     0.until(chains).iterator.flatMap { i =>
       take(tuned, iterations, initialStepSize, sampleMethod).map { c =>
-        val eval = new Evaluator(c.variables.zip(c.hParams.qs).toMap)
+        val eval = new Evaluator(variables.zip(c.hParams.qs).toMap)
         Sample(i, c.accepted, eval)
       }.iterator
     }

--- a/rainier-core/src/main/scala/rainier/sampler/HamiltonianChain.scala
+++ b/rainier-core/src/main/scala/rainier/sampler/HamiltonianChain.scala
@@ -2,12 +2,10 @@ package rainier.sampler
 
 import rainier.compute._
 
-case class HamiltonianChain(accepted: Boolean,
-                            hParams: HParams,
-                            negativeDensity: Real,
-                            variables: Seq[Variable],
-                            gradient: Seq[Real],
-                            cf: Compiler.CompiledFunction)(implicit rng: RNG) {
+case class HamiltonianChain(
+    accepted: Boolean,
+    hParams: HParams,
+    cf: Array[Double] => (Double, Array[Double]))(implicit rng: RNG) {
 
   // Take a single leapfrog step without re-initializing momenta
   // for use in tuning the step size
@@ -48,47 +46,38 @@ case class HamiltonianChain(accepted: Boolean,
     )
   }
 
-  private def integrator =
-    LeapFrogIntegrator(negativeDensity, variables, gradient, cf)
+  private def integrator = LeapFrogIntegrator(cf)
 }
 
 object HamiltonianChain {
 
-  def apply(density: Real)(implicit rng: RNG): HamiltonianChain = {
-    val variables = Real.variables(density).toList
+  def apply(variables: Seq[Variable], density: Real)(
+      implicit rng: RNG): HamiltonianChain = {
     val negativeDensity = density * -1
-    val gradient = Gradient.derive(variables, negativeDensity).toList
-    val cf = Compiler(negativeDensity :: gradient)
-    val hParams = initialize(negativeDensity, variables, gradient, cf)
-    HamiltonianChain(true, hParams, negativeDensity, variables, gradient, cf)
+    val cf = Compiler.default.compileGradient(variables, negativeDensity)
+    val hParams = initialize(variables.size, cf)
+    HamiltonianChain(true, hParams, cf)
   }
 
-  def initialize(negativeDensity: Real,
-                 variables: Seq[Variable],
-                 gradient: Seq[Real],
-                 cf: Compiler.CompiledFunction)(implicit rng: RNG): HParams = {
-    val qs = variables.map { v =>
-      rng.standardNormal
-    }
-    val inputs =
-      variables
-        .zip(qs)
-        .toMap
+  def initialize(nVars: Int, cf: Array[Double] => (Double, Array[Double]))(
+      implicit rng: RNG): HParams = {
+    val qs = 1
+      .to(nVars)
+      .map { v =>
+        rng.standardNormal
+      }
+      .toArray
 
-    val outputs = cf(inputs)
+    val (potential, gradPotential) = cf(qs)
 
-    val gradPotential = gradient.map { g =>
-      outputs(g)
-    }
-    val potential = outputs(negativeDensity)
     HParams(qs, gradPotential, potential)
   }
 }
 
 case class HParams(
-    qs: Seq[Double],
-    ps: Seq[Double],
-    gradPotential: Seq[Double],
+    qs: Array[Double],
+    ps: Array[Double],
+    gradPotential: Array[Double],
     potential: Double
 ) {
 
@@ -108,11 +97,12 @@ case class HParams(
 
 object HParams {
 
-  def apply(qs: Seq[Double], gradPotential: Seq[Double], potential: Double)(
+  def apply(qs: Array[Double], gradPotential: Array[Double], potential: Double)(
       implicit rng: RNG): HParams = {
-    val ps = (1 to qs.size).map { _ =>
+    val ps = qs.map { _ =>
       rng.standardNormal
     }
+
     HParams(qs, ps, gradPotential, potential)
   }
 }

--- a/rainier-core/src/main/scala/rainier/sampler/HamiltonianIntegrator.scala
+++ b/rainier-core/src/main/scala/rainier/sampler/HamiltonianIntegrator.scala
@@ -12,10 +12,7 @@ trait HamiltonianIntegrator {
   def step(hParams: HParams, stepSize: Double): HParams
 }
 
-case class LeapFrogIntegrator(negativeDensity: Real,
-                              variables: Seq[Variable],
-                              gradient: Seq[Real],
-                              cf: Compiler.CompiledFunction)
+case class LeapFrogIntegrator(cf: Array[Double] => (Double, Array[Double]))
     extends HamiltonianIntegrator {
 
   private def halfStepPs(hParams: HParams, stepSize: Double): HParams = {
@@ -31,19 +28,12 @@ case class LeapFrogIntegrator(negativeDensity: Real,
       .zip(hParams.ps)
       .map { case (q, p) => q + (stepSize * p) }
 
-    val inputs =
-      variables
-        .zip(newQs)
-        .toMap
-
-    val outputs = cf(inputs)
+    val (potential, gradPotential) = cf(newQs)
 
     hParams.copy(
       qs = newQs,
-      gradPotential = gradient.map { g =>
-        outputs(g)
-      },
-      potential = outputs(negativeDensity)
+      gradPotential = gradPotential,
+      potential = potential
     )
   }
 

--- a/rainier-core/src/main/scala/rainier/sampler/MAP.scala
+++ b/rainier-core/src/main/scala/rainier/sampler/MAP.scala
@@ -21,18 +21,16 @@ object MAP {
                iterations: Int,
                stepSize: Double): Map[Variable, Double] = {
     val variables = Real.variables(density).toList
-    val gradients = Gradient.derive(variables, density).toList
-    val cf = Compiler(density :: gradients)
+    val cf = Compiler.default.compileGradient(variables, density)
     val initialValues = variables.map { v =>
       0.0
-    }
+    }.toArray
     val finalValues = 1.to(iterations).foldLeft(initialValues) {
       case (values, _) =>
-        val inputs = variables.zip(values).toMap
-        val outputs = cf(inputs)
+        val (_, gradients) = cf(values)
         values.zip(gradients).map {
           case (v, g) =>
-            v + (stepSize * outputs(g))
+            v + (stepSize * g)
         }
     }
     variables.zip(finalValues).toMap

--- a/rainier-example/src/main/scala/rainier/example/FitHLL.scala
+++ b/rainier-example/src/main/scala/rainier/example/FitHLL.scala
@@ -47,14 +47,3 @@ object FitHLL {
     compare(1000)
   }
 }
-
-object TraceHLL {
-  def main(args: Array[String]) {
-    val m = FitHLL.compare(1000)
-    val d = m.density
-    val v = Real.variables(d).toList.head
-    val g = Gradient.derive(List(v), d).head
-    val c = Compiler(List(d, g))
-    c.trace
-  }
-}

--- a/rainier-example/src/main/scala/rainier/example/FitNormal.scala
+++ b/rainier-example/src/main/scala/rainier/example/FitNormal.scala
@@ -26,22 +26,3 @@ object FitNormal {
     println(DensityPlot().plot2D(model(1000).sample()).mkString("\n"))
   }
 }
-
-object TraceNormal {
-  def main(args: Array[String]) {
-    val m = FitNormal.model(1000)
-    val d = m.density
-    val v = Real.variables(d).toList.head
-    val g = Gradient.derive(List(v), d).head
-    val c = Compiler(List(d, g))
-    c.trace
-
-    implicit val rng = RNG.default
-    val t1 = System.currentTimeMillis
-    val samples =
-      m.sample(Hamiltonian(1000, 100, 100, 100, SampleHMC, 1, 0.01))
-    val t2 = System.currentTimeMillis
-    println("ms: " + (t2 - t1))
-    println("mean: " + (samples.map(_._1).sum / samples.size))
-  }
-}


### PR DESCRIPTION
This extracts a `Compiler` trait to allow for multiple implementations later, as well as simplifying the interface to just require it to produce `Array[Double] => Array[Double]`. This incidentally provides a performance boost because it removes the necessity to constantly build and interrogate `Map[Variable,Double]`.