### PR TITLE
lock down the public interface to Real

### DIFF
--- a/rainier-benchmark/src/main/scala/rainier/bench/Benchmarks.scala
+++ b/rainier-benchmark/src/main/scala/rainier/bench/Benchmarks.scala
@@ -11,7 +11,7 @@ object Benchmarks {
 
     def setup = {
       val expr = expression
-      val vars = Real.variables(expr).toList
+      val vars = expr.variables
       val cf = ArrayCompiler.compile(vars, expr)
       val a = asm.ASMCompiler.compile(vars, expr)
       (cf, a, vars)

--- a/rainier-core/src/main/scala/rainier/compute/Gradient.scala
+++ b/rainier-core/src/main/scala/rainier/compute/Gradient.scala
@@ -2,7 +2,7 @@ package rainier.compute
 
 import scala.collection.mutable.HashMap
 
-object Gradient {
+private object Gradient {
   def derive(variables: Seq[Variable], output: Real): Seq[Real] = {
     val diffs = HashMap.empty[Real, CompoundDiff]
     def diff(real: Real): CompoundDiff = {
@@ -78,17 +78,17 @@ object Gradient {
             gradient.toReal * -1 * child.left / (child.right * child.right)
         case OrOp =>
           if (isLeft)
-            gradient.toReal && child.left
+            BinaryReal(gradient.toReal, child.left, AndOp)
           else
-            gradient.toReal &&! child.left
+            BinaryReal(gradient.toReal, child.left, AndNot)
         case AndOp =>
           if (isLeft)
-            gradient.toReal && child.right
+            BinaryReal(gradient.toReal, child.right, AndOp)
           else
             Real.zero
         case AndNotOp =>
           if (isLeft)
-            gradient.toReal &&! child.right
+            BinaryReal(gradient.toReal, child.right, AndNot)
           else
             Real.zero
       }
@@ -98,7 +98,7 @@ object Gradient {
     def toReal = child.op match {
       case LogOp => gradient.toReal * (Real.one / child.original)
       case ExpOp => gradient.toReal * child
-      case AbsOp => gradient.toReal * child.original / (child || Real.one)
+      case AbsOp => gradient.toReal * child.original / BinaryReal(child, Real.one, OrOp)
     }
   }
 }

--- a/rainier-core/src/main/scala/rainier/compute/Pruner.scala
+++ b/rainier-core/src/main/scala/rainier/compute/Pruner.scala
@@ -1,6 +1,6 @@
 package rainier.compute
 
-object Pruner {
+private object Pruner {
   def prune(real: Real): Real = real match {
     case u: UnaryReal =>
       u.original match {

--- a/rainier-core/src/main/scala/rainier/compute/Table.scala
+++ b/rainier-core/src/main/scala/rainier/compute/Table.scala
@@ -2,7 +2,7 @@ package rainier.compute
 
 import scala.collection.mutable.WeakHashMap
 
-object Table {
+private object Table {
   val binary = WeakHashMap.empty[(Real, Real, BinaryOp), BinaryReal]
   val unary = WeakHashMap.empty[(Real, UnaryOp), UnaryReal]
 

--- a/rainier-core/src/main/scala/rainier/report/Report.scala
+++ b/rainier-core/src/main/scala/rainier/report/Report.scala
@@ -101,7 +101,7 @@ object Report {
     println("")
     println(name)
 
-    println(fmtKey("Variables") + Real.variables(model.density).size)
+    println(fmtKey("Variables") + model.density.variables.size)
 
     config.foreach {
       case (k, v) =>

--- a/rainier-core/src/main/scala/rainier/sampler/Emcee.scala
+++ b/rainier-core/src/main/scala/rainier/sampler/Emcee.scala
@@ -11,12 +11,11 @@ case class Emcee(iterations: Int, burnIn: Int, walkers: Int) extends Sampler {
                      ))
 
   def sample(density: Real)(implicit rng: RNG): Iterator[Sample] = {
-    val variables = Real.variables(density).toList
-    EmceeChain(density, variables, walkers).toStream
+    EmceeChain(density, density.variables, walkers).toStream
       .drop(burnIn * walkers)
       .take(iterations * walkers)
       .map { c =>
-        val map = variables.zip(c.variables).toMap
+        val map = density.variables.zip(c.variables).toMap
         Sample(c.walker, c.accepted, new Evaluator(map))
       }
       .iterator

--- a/rainier-core/src/main/scala/rainier/sampler/Hamiltonian.scala
+++ b/rainier-core/src/main/scala/rainier/sampler/Hamiltonian.scala
@@ -26,15 +26,14 @@ case class Hamiltonian(iterations: Int,
                      ))
 
   def sample(density: Real)(implicit rng: RNG): Iterator[Sample] = {
-    val variables = Real.variables(density).toList
-    val tuned = take(HamiltonianChain(variables, density),
+    val tuned = take(HamiltonianChain(density.variables, density),
                      burnIn + 1,
                      initialStepSize,
                      sampleMethod).last
     val stepSize = findReasonableStepSize(tuned, initialStepSize)
     0.until(chains).iterator.flatMap { i =>
       take(tuned, iterations, initialStepSize, sampleMethod).map { c =>
-        val eval = new Evaluator(variables.zip(c.hParams.qs).toMap)
+        val eval = new Evaluator(density.variables.zip(c.hParams.qs).toMap)
         Sample(i, c.accepted, eval)
       }.iterator
     }

--- a/rainier-core/src/main/scala/rainier/sampler/MAP.scala
+++ b/rainier-core/src/main/scala/rainier/sampler/MAP.scala
@@ -20,9 +20,8 @@ object MAP {
   def optimize(density: Real,
                iterations: Int,
                stepSize: Double): Map[Variable, Double] = {
-    val variables = Real.variables(density).toList
-    val cf = Compiler.default.compileGradient(variables, density)
-    val initialValues = variables.map { v =>
+    val cf = Compiler.default.compileGradient(density.variables, density)
+    val initialValues = density.variables.map { v =>
       0.0
     }.toArray
     val finalValues = 1.to(iterations).foldLeft(initialValues) {
@@ -33,6 +32,6 @@ object MAP {
             v + (stepSize * g)
         }
     }
-    variables.zip(finalValues).toMap
+    density.variables.zip(finalValues).toMap
   }
 }


### PR DESCRIPTION
This makes the public interface to `rainier.compute` as narrow as possible, to avoid anyone accidentally relying on internal implementation details of `Real`.