### PR TITLE
ZeroToOne instead of Or/And/AndNot

### DIFF
--- a/rainier-core/src/main/scala/rainier/compute/Gradient.scala
+++ b/rainier-core/src/main/scala/rainier/compute/Gradient.scala
@@ -76,21 +76,6 @@ private object Gradient {
             gradient.toReal * (Real.one / child.right)
           else
             gradient.toReal * -1 * child.left / (child.right * child.right)
-        case OrOp =>
-          if (isLeft)
-            BinaryReal(gradient.toReal, child.left, AndOp)
-          else
-            BinaryReal(gradient.toReal, child.left, AndNotOp)
-        case AndOp =>
-          if (isLeft)
-            BinaryReal(gradient.toReal, child.right, AndOp)
-          else
-            Real.zero
-        case AndNotOp =>
-          if (isLeft)
-            BinaryReal(gradient.toReal, child.right, AndNotOp)
-          else
-            Real.zero
       }
   }
 
@@ -99,7 +84,9 @@ private object Gradient {
       case LogOp => gradient.toReal * (Real.one / child.original)
       case ExpOp => gradient.toReal * child
       case AbsOp =>
-        gradient.toReal * child.original / BinaryReal(child, Real.one, OrOp)
+        gradient.toReal * child.original / UnaryReal(child, ZeroToOne)
+      case ZeroToOne =>
+        gradient.toReal * (child.original / UnaryReal(child.original, ZeroToOne))
     }
   }
 }

--- a/rainier-core/src/main/scala/rainier/compute/Real.scala
+++ b/rainier-core/src/main/scala/rainier/compute/Real.scala
@@ -125,30 +125,6 @@ private case object DivideOp extends BinaryOp {
   def apply(left: Double, right: Double) = left / right
 }
 
-private case object OrOp extends BinaryOp {
-  def apply(left: Double, right: Double) =
-    if (left == 0.0)
-      right
-    else
-      left
-}
-
-private case object AndOp extends BinaryOp {
-  def apply(left: Double, right: Double) =
-    if (right == 0.0)
-      0.0
-    else
-      left
-}
-
-private case object AndNotOp extends BinaryOp {
-  def apply(left: Double, right: Double) =
-    if (right == 0.0)
-      left
-    else
-      0.0
-}
-
 private sealed trait UnaryOp {
   def apply(original: Double): Double
 }
@@ -163,4 +139,12 @@ private case object LogOp extends UnaryOp {
 
 private case object AbsOp extends UnaryOp {
   def apply(original: Double) = original.abs
+}
+
+private case object ZeroToOne extends UnaryOp {
+  def apply(original: Double) =
+    if(original == 0.0)
+      1.0
+    else
+      original
 }


### PR DESCRIPTION
It looks like we can simplify all of the or/and/andnot usage down into a single function where:

```
f(x) = 1; x = 0
f(x) = x; x != 0
```

What's especially nice about this is that (for our purposes anyway) `f'(x) = x / f(x)`, which means that it's "closed" under differentiation in the sense of not introducing any new functions.

This will be much simpler to support in the new compiler (probably just by introducing a static function that implements it, which presumably the JIT will then inline).

