### PR TITLE
Misc build file cleanup/fixes/simplification

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,5 +1,0 @@
-import sbt._
-
-object Dependencies {
-  lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.0.5"
-}

--- a/rainier-benchmark/build.sbt
+++ b/rainier-benchmark/build.sbt
@@ -1,3 +1,0 @@
-name := "rainier-benchmark"
-
-enablePlugins(JmhPlugin)

--- a/rainier-core/build.sbt
+++ b/rainier-core/build.sbt
@@ -1,7 +1,0 @@
-name := "rainier-core"
-
-libraryDependencies ++= Seq(
-  Dependencies.scalaTest % Test,
-)
-
-//Publish.settings

--- a/rainier-example/build.sbt
+++ b/rainier-example/build.sbt
@@ -1,1 +1,0 @@
-name := "rainier-example"


### PR DESCRIPTION
- configures the shaded asm to be published
- removes the tiny build files and moves the settings to the main one
- configures all dependencies in the same direct way
- orders all of the project configuration/settings in the same arbitrary order (that I picked)
- fixes build warnings about coerced assignments in the unpublished settings