### PR TITLE
Be more aggressive about distributing * across + 

### DIFF
--- a/rainier-benchmark/src/main/scala/com/stripe/rainier/bench/Benchmarks.scala
+++ b/rainier-benchmark/src/main/scala/com/stripe/rainier/bench/Benchmarks.scala
@@ -107,8 +107,8 @@ object Benchmarks {
   }
 }
 
-@Warmup(iterations = 3)
-@Measurement(iterations = 10)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 10, time = 1)
 @Fork(3)
 class Benchmarks {
   import Benchmarks._


### PR DESCRIPTION
This generalizes the previous FOIL distribution rules when multiplying two lines to fully expand out to `n*m` terms as long as `n*m` is below a set threshold. This is not the best greedy choice but empirically it's a good global heuristic; in particular, on our current benchmarks it triples the speed of `runFullNormal` without affecting any others.

The particular choice of threshold is fairly arbitrary and could be tuned later (and we probably want to find a good way to make it user-tunable).