### PR TITLE
defer multiplying out sums until they are summed

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/LineOps.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/LineOps.scala
@@ -17,29 +17,26 @@ private[compute] object LineOps {
     Line(line.ax, line.b + v)
 
   /*
-  Return Some(real) if an optimization is possible here,
-  otherwise None will fall back to the default multiplication behavior.
-
-  If the resulting number of terms is below a set threshold, expand out the multiplication
-  of sums. Although this may result in a larger number of multiplication ops locally,
-  it's also more likely to allow cancellations or simplifications later on, so as a heuristic
-  it's worth doing up to a point.
+  Multiply two lines, using the distribution rule, to produce a new Line.
    */
-  def multiply(left: Line, right: Line): Option[Real] =
-    if (left.ax.size * right.ax.size >= 10)
-      None
-    else {
-      val allLeft = (Real.one, left.b) :: left.ax.toList
-      val allRight = (Real.one, right.b) :: right.ax.toList
-      val terms = allLeft.flatMap {
-        case (x, a) =>
-          allRight.map {
-            case (y, c) =>
-              (x * y) * (a * c)
-          }
-      }
-      Some(Real.sum(terms))
+  def multiply(left: Line, right: Line): Line = {
+    val allLeft = (Real.one, left.b) :: left.ax.toList
+    val allRight = (Real.one, right.b) :: right.ax.toList
+    val terms = allLeft.flatMap {
+      case (x, a) =>
+        allRight.map {
+          case (y, c) =>
+            (x * y, a * c)
+        }
     }
+    val (newAx, newB) = terms.foldLeft((Map.empty[NonConstant, Double], 0.0)) {
+      case ((nAx, nB), (x: NonConstant, a)) =>
+        (merge(nAx, Map(x -> a)), nB)
+      case ((nAx, nB), (Constant(x), a)) =>
+        (nAx, nB + x * a)
+    }
+    Line(newAx, newB)
+  }
 
   /*
   Return Some(real) if an optimization is possible here,
@@ -116,7 +113,7 @@ private[compute] object LineOps {
           acc + (k -> newV)
     }
   }
- 
+
   object Line1 {
     def unapply(line: Line): Option[(Double, NonConstant, Double)] = {
       if (line.ax.size == 1)

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/LogLineOps.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/LogLineOps.scala
@@ -9,7 +9,7 @@ private[compute] object LogLineOps {
     if (merged.isEmpty)
       Real.one
     else
-      LogLine(LineOps.merge(left.ax, right.ax))
+      LogLine(merged)
   }
 
   def pow(line: LogLine, v: Double): LogLine =
@@ -23,6 +23,58 @@ private[compute] object LogLineOps {
   seem definitely worth doing.
    */
   def log(@unused line: LogLine): Option[Real] = None
+
+  /*
+  If possible, return a representation of ax as a list of terms to be summed. Within limits, it's helpful here
+  to distribute the multiplications across any internal sums, because that may well surface some terms
+  that are in common with whatever we're about to sum this with.
+   */
+  val DistributeToMaxTerms = 20
+  def distribute(line: LogLine): Option[Line] = {
+
+    def nTerms(l: Line): Int =
+      if (l.b == 0.0)
+        l.ax.size
+      else
+        l.ax.size + 1
+    def nTerms2(l: Line): Int = {
+      val n = nTerms(l)
+      (n * (n + 1)) / 2
+    }
+
+    val initial = (List.empty[(NonConstant, Double)], Option.empty[Line])
+    val (factors, terms) = line.ax.foldLeft(initial) {
+      case ((f, None), (l: Line, 1.0)) if (nTerms(l) < DistributeToMaxTerms) =>
+        (f, Some(l))
+      case ((f, Some(t)), (l: Line, 1.0))
+          if ((nTerms(t) * nTerms(l)) < DistributeToMaxTerms) =>
+        (f, Some(LineOps.multiply(t, l)))
+      case ((f, None), (l: Line, 2.0)) if (nTerms2(l) < DistributeToMaxTerms) =>
+        (f, Some(LineOps.multiply(l, l)))
+      case ((f, Some(t)), (l: Line, 2.0))
+          if (nTerms(t) * nTerms2(l) < DistributeToMaxTerms) =>
+        (f, Some(LineOps.multiply(t, LineOps.multiply(l, l))))
+      case ((f, opt), xa) =>
+        (xa :: f, opt)
+    }
+
+    terms.map { l =>
+      if (factors.isEmpty)
+        l
+      else {
+        val ll = LogLine(factors.toMap)
+        val (newAx, newB) =
+          l.ax.foldLeft((Map[NonConstant, Double](ll -> l.b), 0.0)) {
+            case ((nAx, nB), (x, a)) =>
+              multiply(ll, LogLine(x)) match {
+                case Constant(v)     => (nAx, nB + v * a)
+                case nc: NonConstant => (nAx + (nc -> a), nB)
+              }
+          }
+        Line(newAx, newB)
+      }
+    }
+  }
 
   /*
   Factor a scalar constant exponent k out of ax and return it along with

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/LogLineOps.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/LogLineOps.scala
@@ -28,6 +28,17 @@ private[compute] object LogLineOps {
   If possible, return a representation of ax as a list of terms to be summed. Within limits, it's helpful here
   to distribute the multiplications across any internal sums, because that may well surface some terms
   that are in common with whatever we're about to sum this with.
+
+  That is, what we are doing here is:
+
+    * assume we have some expression s = y_0^k_0 * y_1^k_1 * ..., where k_n is constant
+    * assume that the y_n terms in s are of themselves of the form a_n_0 * x_n_0 + a_n_1 * x_n_1 + ...
+      where a_n_m is constant
+    * assume we are now trying to construct s + t for some unknown t
+    * we want to restructure s to end up as something like ((a_0_0 * a_1_0 * ...) * (x_0_0 * x_1_0 * ...)) + ...),
+      up to some maximum number of additive terms
+    * we want to do this because we hope that the non-constant (x_0_0...) parts of these terms may be in
+      common with something in t (or some later thing we will add s+t to), and we can combine the constants
    */
   val DistributeToMaxTerms = 20
   def distribute(line: LogLine): Option[Line] = {

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Real.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Real.scala
@@ -100,7 +100,11 @@ private object Line {
   def apply(nc: NonConstant): Line =
     nc match {
       case l: Line => l
-      case _       => Line(Map(nc -> 1.0), 0.0)
+      case l: LogLine =>
+        LogLineOps
+          .distribute(l)
+          .getOrElse(Line(Map(l -> 1.0), 0.0))
+      case _ => Line(Map(nc -> 1.0), 0.0)
     }
 }
 

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/RealOps.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/RealOps.scala
@@ -45,10 +45,6 @@ private[compute] object RealOps {
       case (Constant(x), Constant(y))     => Constant(x * y)
       case (Constant(x), nc: NonConstant) => LineOps.scale(Line(nc), x)
       case (nc: NonConstant, Constant(x)) => LineOps.scale(Line(nc), x)
-      case (l1: Line, l2: Line) =>
-        LineOps.multiply(l1, l2).getOrElse {
-          LogLineOps.multiply(LogLine(l1), LogLine(l2))
-        }
       case (nc1: NonConstant, nc2: NonConstant) =>
         LogLineOps.multiply(LogLine(nc1), LogLine(nc2))
     }


### PR DESCRIPTION
We've previously had an optimization where, given a multiplication of the form `(ax + b)(cy + d)` (where everything but `x` and `y` are constants) we would expand it out to `(acxy + bcy + adx + bd)`, in the hopes that we might later on sum this result with something else that had `x` and `xy` terms and the constants would combine. Very recently, we generalized this to multiplications of sums with more than two terms (within limits), which helped specifically with the "full normal" benchmark (fitting a normal that has uniform priors for mean and sd).

This PR stems from the observation that the only real reason to expand out these multiplications is when we are immediately going to sum the results with something else; otherwise we should keep it in product form; either we'll do something non-linear with the product and foreclose usefully multiplying it out (in which case we're glad we didn't do that for nothing), or we'll keep accumulating more terms into the product, which doesn't stop us from multiplying the whole thing out later; or we will, indeed, try to sum something with it, in which case we can take advantage of the distribution rule with more hope that it will be useful, and with an entire multi-term product at once.

That is, what we are doing here is:
* assume we have some expression `s = y_0^k_0 * y_1^k_1 * ...`, where `k_n` is constant
* assume that the `y_n` terms in `s` are of themselves of the form `a_n_0 * x_n_0 + a_n_1 * x_n_1 + ...` where `a_n_m` is constant
* assume we are now trying to construct `s + t` for some unknown `t`
* we want to restructure `s` to end up as something like `((a_0_0 * a_1_0 * ...) * (x_0_0 * x_1_0 * ...)) + ...)`, up to some maximum number of additive terms
* we want to do this because we hope that the non-constant `(x_0_0...)` parts of these terms may be in common with something in `t` (or some later thing we will add `s+t` to), and we can combine the constants

