### PR TITLE
Add effective sample size diagnostics

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/core/RandomVariable.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/RandomVariable.scala
@@ -54,29 +54,29 @@ class RandomVariable[+T](private val value: T,
       .map(_.head.apply())
       .toList
 
-  def checkConvergence[V](sampler: Sampler,
-                          warmupIterations: Int,
-                          iterations: Int,
-                          chains: Int)(
+  def sampleWithDiagnostics[V](sampler: Sampler,
+                               warmupIterations: Int,
+                               iterations: Int,
+                               chains: Int)(
       implicit rng: RNG,
-      sampleable: Sampleable[T, V]): (List[V], List[Double]) = {
+      sampleable: Sampleable[T, V]): (List[V], List[Diagnostics]) = {
     val fn = sampleable.prepare(value, density.variables)
     val samples = 1.to(chains).par.map { _ =>
       sampler
         .sample(density, warmupIterations)
         .take(iterations)
         .map { s =>
-          fn(s.parameters)
+          (s.parameters, fn(s.parameters))
         }
         .toList
     }
     val allSamples = samples.toList.flatMap { chain =>
       chain.map(_._2)
     }
-    val rHats = Sampler.gelmanRubin(samples.toList.map { chain =>
+    val diagnostics = Sampler.diagnostics(samples.toList.map { chain =>
       chain.map(_._1)
     })
-    (allSamples, rHats)
+    (allSamples, diagnostics)
   }
 
   def toStream[V](sampler: Sampler, warmupIterations: Int)(
@@ -85,7 +85,7 @@ class RandomVariable[+T](private val value: T,
     val fn = sampleable.prepare(value, density.variables)
     sampler.sample(density, warmupIterations).map { s =>
       { () =>
-        fn(s.parameters)._2
+        fn(s.parameters)
       }
     }
   }

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Sampleable.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Sampleable.scala
@@ -8,13 +8,13 @@ trait Sampleable[-S, +T] {
   def get(value: S)(implicit r: RNG, n: Numeric[Real]): T
 
   def prepare(value: S, variables: Seq[Variable])(
-      implicit r: RNG): Array[Double] => (Array[Double], T) = {
+      implicit r: RNG): Array[Double] => T = {
     val reqs = requirements(value).toList
     if (reqs.isEmpty) { array =>
       {
         implicit val evaluator: Evaluator =
           new Evaluator(variables.zip(array).toMap)
-        (Array.empty[Double], get(value))
+        get(value)
       }
     } else {
       val cf = Compiler.default.compile(variables, reqs)
@@ -26,7 +26,7 @@ trait Sampleable[-S, +T] {
               variables.zip(array).toMap ++
                 reqs.zip(reqValues).toMap
             )
-          (reqValues, get(value))
+          get(value)
         }
     }
   }

--- a/rainier-core/src/main/scala/com/stripe/rainier/sampler/Sampler.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/sampler/Sampler.scala
@@ -29,7 +29,7 @@ object Diagnostics {
       t.sum / n
     }
 
-    val meanMean = means.sum / n
+    val meanMean = means.sum / m
 
     val b = (n / (m - 1)) * means.map { m =>
       Math.pow(m - meanMean, 2)

--- a/rainier-core/src/main/scala/com/stripe/rainier/sampler/Sampler.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/sampler/Sampler.scala
@@ -1,6 +1,7 @@
 package com.stripe.rainier.sampler
 
 import com.stripe.rainier.compute._
+import scala.annotation.tailrec
 
 trait Sampler {
   def sample(density: Real, warmupIterations: Int)(
@@ -8,6 +9,77 @@ trait Sampler {
 }
 
 final case class Sample(accepted: Boolean, parameters: Array[Double])
+final case class Diagnostics(rHat: Double, effectiveSampleSize: Double)
+
+object Diagnostics {
+  def apply(traces: Seq[Array[Double]]): Diagnostics = {
+    val m = traces.size.toDouble
+    val n = traces.head.size.toDouble
+    val (rHat, v) = rHatAndV(traces, n, m)
+    val ac = autocorrelation(traces, n, m, v, 1, 0.0)
+    val ess = n * m / (1 + (2 * ac))
+    Diagnostics(rHat, ess)
+  }
+
+  def rHatAndV(traces: Seq[Array[Double]],
+               n: Double,
+               m: Double): (Double, Double) = {
+
+    val means = traces.map { t =>
+      t.sum / n
+    }
+
+    val meanMean = means.sum / n
+
+    val b = (n / (m - 1)) * means.map { m =>
+      Math.pow(m - meanMean, 2)
+    }.sum
+
+    val variances =
+      traces.zip(means).map {
+        case (t, m) =>
+          t.map { a =>
+            Math.pow(a - m, 2)
+          }.sum / (n - 1)
+      }
+
+    val w = variances.sum / m
+
+    val v =
+      (n - 1).toDouble / n * w +
+        b / n
+
+    val rHat = Math.sqrt(v / w)
+    (rHat, v)
+  }
+
+  @tailrec
+  def autocorrelation(traces: Seq[Array[Double]],
+                      n: Double,
+                      m: Double,
+                      v: Double,
+                      lag: Int,
+                      acc: Double): Double = {
+    val vt = traces.map { trace =>
+      variogram(trace, lag)
+    }.sum / m
+    val pt = 1.0 - (vt / (2.0 * v))
+    if (pt > 0.0 && lag < 100)
+      autocorrelation(traces, n, m, v, lag + 1, acc + pt)
+    else
+      acc
+  }
+
+  def variogram(trace: Array[Double], lag: Int): Double = {
+    var i = lag
+    var sum = 0.0
+    while (i < trace.size) {
+      sum += Math.pow(trace(i) - trace(i - lag), 2)
+      i += 1
+    }
+    sum / (trace.size - lag).toDouble
+  }
+}
 
 object Sampler {
   object Default {
@@ -16,33 +88,15 @@ object Sampler {
     val warmupIterations: Int = 10000
   }
 
-  def gelmanRubin(chains: List[List[Array[Double]]]): List[Double] = {
-    val nChains = chains.size
-    val nSamples = chains.head.size
+  def diagnostics(chains: List[List[Array[Double]]]): List[Diagnostics] = {
     val nParams = chains.head.head.size
     0.until(nParams).toList.map { i =>
       val traces = chains.map { c =>
         c.map { a =>
           a(i)
-        }
+        }.toArray
       }
-      val means = traces.map { t =>
-        t.sum / nSamples
-      }
-      val variances =
-        traces.zip(means).map {
-          case (t, m) =>
-            t.map { a =>
-              Math.pow(a - m, 2)
-            }.sum / (nSamples - 1)
-        }
-      val w = variances.sum / nChains
-      val meanMean = means.sum / nChains
-      val b = means.map { m =>
-        Math.pow(m - meanMean, 2)
-      }.sum / (nChains - 1)
-      val v = (1.0 - (1.0 / nSamples)) * w + b
-      Math.sqrt(v / w)
+      Diagnostics(traces)
     }
   }
 }


### PR DESCRIPTION
This adapts the previous `checkConvergence` into a `sampleWithDiagnostics` method which returns a `Diagnostics` object containing both `rHat` and `effectiveSampleSize` for each raw parameter. This is based on sections 30.3 and 30.4 in the Stan manual (including a correction to the final Neff equation in 30.4 that hasn't been published yet).