### PR TITLE
Simulation-based calibration

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/core/RandomVariable.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/RandomVariable.scala
@@ -6,7 +6,7 @@ import com.stripe.rainier.sampler._
 /**
   * The main probability monad used in Rainier for constructing probabilistic programs which can be sampled
   */
-class RandomVariable[+T](private val value: T,
+class RandomVariable[+T](val value: T,
                          private val densities: Set[RandomVariable.BoxedReal]) {
 
   def flatMap[U](fn: T => RandomVariable[U]): RandomVariable[U] = {

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/SBC.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/SBC.scala
@@ -1,0 +1,102 @@
+package com.stripe.rainier.core
+
+import com.stripe.rainier.sampler._
+import com.stripe.rainier.compute._
+
+final case class SBC[T](priorGenerators: Seq[Generator[Double]],
+                        priorParams: Seq[Real],
+                        posterior: RandomVariable[(Distribution[T], Real)]) {
+  import SBC._
+
+  require(priorParams.forall(_.variables.size == 1))
+  val priorGenerator = Generator.traverse(priorGenerators)
+  val emptyEvaluator = new Evaluator(Map.empty)
+
+  def simulate(sampler: Sampler,
+               warmupIterations: Int,
+               syntheticSamples: Int,
+               logBins: Int)(implicit rng: RNG): Either[Double, Stream[Int]] = {
+    val initialThin = 2
+    val (_, maxRHat, minEffectiveSampleSize) =
+      sample(sampler, warmupIterations, syntheticSamples, initialThin)
+    if (maxRHat > MaxRHat)
+      Left(maxRHat)
+    else {
+      val thin =
+        if (minEffectiveSampleSize < Samples)
+          Math
+            .ceil(initialThin.toDouble * Samples / minEffectiveSampleSize)
+            .toInt
+        else
+          initialThin
+
+      Right(
+        rankStream(sampler, warmupIterations, syntheticSamples, thin, logBins))
+    }
+  }
+
+  private def rankStream(sampler: Sampler,
+                         warmupIterations: Int,
+                         syntheticSamples: Int,
+                         thin: Int,
+                         logBins: Int)(implicit rng: RNG): Stream[Int] =
+    rank(sampler, warmupIterations, syntheticSamples, thin, logBins) #::
+      rankStream(sampler, warmupIterations, syntheticSamples, thin, logBins)
+
+  private def rank(sampler: Sampler,
+                   warmupIterations: Int,
+                   syntheticSamples: Int,
+                   thin: Int,
+                   logBins: Int)(implicit rng: RNG): Int =
+    sample(sampler, warmupIterations, syntheticSamples, thin)._1 /
+      (Samples / (1 << logBins))
+
+  private def sample(sampler: Sampler,
+                     warmupIterations: Int,
+                     syntheticSamples: Int,
+                     thin: Int)(implicit rng: RNG): (Int, Double, Double) = {
+    val trueValues = priorGenerator.get(rng, emptyEvaluator)
+    implicit val trueEval = new Evaluator(priorParams.zip(trueValues).toMap)
+    val trueOutput = posterior.map(_._2).get
+
+    val syntheticValues =
+      posterior.map(_._1.generator.repeat(syntheticSamples)).get
+    val model = posterior.flatMap {
+      case (d, r) =>
+        d.fit(syntheticValues).map { _ =>
+          r
+        }
+    }
+    val (samples, diag) = model.sampleWithDiagnostics(sampler,
+                                                      Chains,
+                                                      warmupIterations,
+                                                      (Samples / Chains) * thin,
+                                                      thin)
+
+    val maxRHat = diag.map(_.rHat).max
+    val minEffectiveSampleSize = diag.map(_.effectiveSampleSize).min
+    val rawRank = samples.count { n =>
+      n < trueOutput
+    }
+    (rawRank, maxRHat, minEffectiveSampleSize)
+  }
+}
+
+object SBC {
+  def apply[T](priors: Seq[Continuous])(
+      fn: Seq[Real] => (Distribution[T], Real)): SBC[T] = {
+    val priorParams = priors.map(_.param)
+    val priorGenerators = priors.map(_.generator)
+    val posterior = RandomVariable.traverse(priorParams).map(fn)
+    SBC(priorGenerators, priorParams.map(_.value), posterior)
+  }
+
+  def apply[T](prior: Continuous)(fn: Real => Distribution[T]): SBC[T] =
+    apply(List(prior)) { l =>
+      (fn(l.head), l.head)
+    }
+
+  val Samples = 123
+  val Chains = 4
+  val MaxRHat = 1.1
+}

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/SBC.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/SBC.scala
@@ -72,11 +72,11 @@ final case class SBC[T](priorGenerators: Seq[Generator[Double]],
       val reps = bins * RepsPerBin
 
       println(
-        s"\nRunning simulation-based calibration. rHat: $rHat, thinning factor: $thin")
-
+        s"\nRunning simulation-based calibration.\nrHat: $rHat, thinning factor: $thin")
+      println("99% of bins should end up between the [ and ] quantile markers")
       val lower = binomialQuantile(0.005, reps, 1.0 / bins)
       val upper = binomialQuantile(0.995, reps, 1.0 / bins)
-      println("\n" * (bins + 1))
+      println("\n" * (bins + 2))
       1.to(reps).foreach { i =>
         val list = stream.take(i).toList
         val timeTaken = System.currentTimeMillis - t0
@@ -160,6 +160,13 @@ final case class SBC[T](priorGenerators: Seq[Generator[Double]],
 }
 
 object SBC {
+  /*
+  fn is a function that takes a Seq[Real]
+  specifying the values of all the parameters (one for each Continuous in the prior)
+  and returns a (Distribution[T], Real) which is a pair of values:
+  1) a distribution describing the likelihood of the observed data, given the parameter values,
+  2) the parameter value or summary stat we're calibrating on
+   */
   def apply[T](priors: Seq[Continuous])(
       fn: Seq[Real] => (Distribution[T], Real)): SBC[T] = {
     val priorParams = priors.map(_.param)

--- a/rainier-example/src/main/scala/com/stripe/rainier/example/SBCNormal.scala
+++ b/rainier-example/src/main/scala/com/stripe/rainier/example/SBCNormal.scala
@@ -1,0 +1,15 @@
+package com.stripe.rainier.example
+
+import com.stripe.rainier.core._
+import com.stripe.rainier.sampler._
+import com.stripe.rainier.repl._
+
+object SBCNormal {
+  def main(args: Array[String]): Unit = {
+    val _ =
+      SBC(Uniform(0, 1)) { x =>
+        Normal(x, 1)
+      }.prepare(HMC(5), 1000, 1000)
+        .animate(3)
+  }
+}

--- a/rainier-example/src/main/scala/com/stripe/rainier/example/SBCNormal.scala
+++ b/rainier-example/src/main/scala/com/stripe/rainier/example/SBCNormal.scala
@@ -8,7 +8,6 @@ object SBCNormal {
   def main(args: Array[String]): Unit = {
     SBC(Uniform(0, 1)) { x =>
       Normal(x, 1)
-    }.prepare(HMC(5), 1000, 1000)
-      .animate(3)
+    }.animate(HMC(1), 10000, 1000)
   }
 }

--- a/rainier-example/src/main/scala/com/stripe/rainier/example/SBCNormal.scala
+++ b/rainier-example/src/main/scala/com/stripe/rainier/example/SBCNormal.scala
@@ -6,10 +6,9 @@ import com.stripe.rainier.repl._
 
 object SBCNormal {
   def main(args: Array[String]): Unit = {
-    val _ =
-      SBC(Uniform(0, 1)) { x =>
-        Normal(x, 1)
-      }.prepare(HMC(5), 1000, 1000)
-        .animate(3)
+    SBC(Uniform(0, 1)) { x =>
+      Normal(x, 1)
+    }.prepare(HMC(5), 1000, 1000)
+      .animate(3)
   }
 }


### PR DESCRIPTION
This implements Simulation-based calibration as described in https://arxiv.org/abs/1804.06788 and http://andrewgelman.com/2018/04/18/better-check-yo-self-wreck-yo-self/ . The API works like this:

* you construct a `SBC`instance using one of the two `apply` methods on the `SBC` companion object. The univariate form is `SBC(priorDist){x => buildNoiseDist(x)}` where `priorDist` is a `Continuous` distribution, `x` is assumed to be drawn from `priorDist`, and `buildNoiseDist` returns any `Distribution` parameterized by `x`, which will be used first to generate synthetic data and then as a likelihood function for that data.
* you start with the `prepare` method on `SBC` which will return a `SBC.Run` instance after running a single 4-chain diagnostic trace on the model; this lets you inspect the rHat for convergence before proceeding, and inspect how much SBC needs to thin your trace to get a sufficiently large effective sample size for running the calibration
* you can then call `simulate` (for programmatic use) or, better, `animate` (for interactive use) to run the actual calibration, which will run a large number of traces and check the results for uniformity per the referenced paper. Both of these methods take a `logBins` parameter, which must be between 1 and 7, and will produce histograms with 2^logBins bins. The `animate` version will animate the histograms growing in your terminal (which can take quite a long time, so this acts as a kind of progress bar), as well as giving you other diagnostic info like the rHat, and drawing confidence bounds on the histogram bars so you can see  whether the non-uniformity is within reasonable limits.

To see this in action, try the `SBCNormal` example.

The next step would be to use this from the test cases, but I plan to do that as a separate PR.
