### PR TITLE
Fix ordering bug and performance issue in Translator

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Translator.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Translator.scala
@@ -175,7 +175,10 @@ private class Translator {
           opt.orElse { cache.get((k, opKey)) }
       }
       hit match {
-        case Some(sym) => VarRef(sym)
+        case Some(sym) =>
+          if (!irKeys.head.collect { case d: VarDef => d }.isEmpty)
+            sys.error("VarRef was used before its VarDef")
+          VarRef(sym)
         case None =>
           val sym = Sym.freshSym()
           cache += (refKeys.head, opKey) -> sym

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Translator.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Translator.scala
@@ -6,14 +6,21 @@ private class Translator {
   private val binary = new SymCache[BinaryOp]
   private val unary = new SymCache[UnaryOp]
   private val ifs = new SymCache[Unit]
+  private var reals = Map.empty[Real, IR]
 
-  def toIR(r: Real): IR = r match {
-    case v: Variable         => v.param
-    case Constant(value)     => Const(value)
-    case Unary(original, op) => unaryIR(toIR(original), op)
-    case i: If               => ifIR(toIR(i.whenNonZero), toIR(i.whenZero), toIR(i.test))
-    case l: Line             => lineIR(l)
-    case l: LogLine          => logLineIR(l)
+  def toIR(r: Real): IR = reals.get(r) match {
+    case Some(ir) => ref(ir)
+    case None =>
+      val ir = r match {
+        case v: Variable         => v.param
+        case Constant(value)     => Const(value)
+        case Unary(original, op) => unaryIR(toIR(original), op)
+        case i: If               => ifIR(toIR(i.whenNonZero), toIR(i.whenZero), toIR(i.test))
+        case l: Line             => lineIR(l)
+        case l: LogLine          => logLineIR(l)
+      }
+      reals += r -> ir
+      ir
   }
 
   private def unaryIR(original: IR, op: UnaryOp): IR =


### PR DESCRIPTION
This addresses two problems demonstrated by the example code in https://github.com/stripe/rainier/issues/108.

First: when constructing the tree of binary ops for an n-ary sequence of additions or multiplications, we were constructing nodes in a different order from the ultimate traversal - specifically, we were first constructing all of the leaves, then all of the second-last level, and so on up to the root; but traversal will be depth-first, and so (for example), the root's left child will be visited before any of the leaves but constructed after them. In some circumstances this could lead to a the first instance of a particular sub-expression being constructed and made into a variable definition (`VarDef` node), and then a second instance of that same sub-expression being constructed and turned into a reference to that same variable (`VarRef`)... but in fact, when generating code, the `VarRef` will get hit before the `VarDef`. Depending on the situation this could lead to a crash during code gen, or a crash during bytecode verification, or just a subtly incorrect result.

This PR makes a minor change to construct the IRs in the tree lazily by wrapping all of the construction logic in thunks; this results in the actual nodes being created in the same depth-first order as the traversal, which fixes this problem. It also adds a check which will error immediately during the IR construction process if it detects this problem occurring again (though it's not guaranteed to catch every instance of it).

Second, that same example code was extremely slow to compile. The thing that's notable about this model vs others is that because of the long chain auto-regressive chain, some parameters get referenced (transitively/indirectly) over and over and over again, and the Translator was having to rebuild the entire IR tree for these each time (to ultimately find that it was an expression that had been already seen, and so only emit a single VarRef). This PR speeds up that process by caching the Real => IR mapping and directly emitting the reference if we come across the identical Real for a second time. This dramatically speeds up the compilation of this model.

