### PR TITLE
Fix quadratic behavior in `variables` and `gradient`

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Gradient.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Gradient.scala
@@ -104,7 +104,15 @@ private object Gradient {
       extends Diff {
     def toReal: Real = {
       val exponent = child.ax(term)
-      gradient.toReal * child * exponent / term
+      val otherTerms =
+        if (child.ax.size == 1)
+          Real.one
+        else
+          LogLine(child.ax - term)
+      gradient.toReal *
+        exponent *
+        term.pow(exponent - 1) *
+        otherTerms
     }
   }
 }

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Gradient.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Gradient.scala
@@ -67,9 +67,10 @@ private object Gradient {
       parts = part :: parts
     }
 
-    def toReal: Real = parts match {
+    lazy val toReal: Real = parts match {
       case head :: Nil => head.toReal
-      case _           => Real.sum(parts.map(_.toReal))
+      case _ =>
+        Real.sum(parts.map(_.toReal))
     }
   }
 
@@ -103,15 +104,7 @@ private object Gradient {
       extends Diff {
     def toReal: Real = {
       val exponent = child.ax(term)
-      val otherTerms =
-        if (child.ax.size == 1)
-          Real.one
-        else
-          LogLine(child.ax - term)
-      gradient.toReal *
-        exponent *
-        term.pow(exponent - 1) *
-        otherTerms
+      gradient.toReal * child * exponent / term
     }
   }
 }

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/LogLineOps.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/LogLineOps.scala
@@ -40,7 +40,7 @@ private[compute] object LogLineOps {
    * we want to do this because we hope that the non-constant (x_0_0...) parts of these terms may be in
       common with something in t (or some later thing we will add s+t to), and we can combine the constants
    */
-  val DistributeToMaxTerms = 0
+  val DistributeToMaxTerms = 20
   def distribute(line: LogLine): Option[Line] = {
 
     def nTerms(l: Line): Int =

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/LogLineOps.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/LogLineOps.scala
@@ -40,7 +40,7 @@ private[compute] object LogLineOps {
    * we want to do this because we hope that the non-constant (x_0_0...) parts of these terms may be in
       common with something in t (or some later thing we will add s+t to), and we can combine the constants
    */
-  val DistributeToMaxTerms = 20
+  val DistributeToMaxTerms = 0
   def distribute(line: LogLine): Option[Line] = {
 
     def nTerms(l: Line): Int =


### PR DESCRIPTION
This adds a couple of easy fixes for formerly quadratic behavior that was a problem in compute graphs that referenced the same value a lot of times (like the `DLM` model).

* `Real.variables` keeps track of whether we've visited a node before and bails if we have, rather than happily re-walking that part of the graph umpteen times
* `CompoundDiff` uses a `lazy val` for `toReal` instead of a `def`, so that it still defers computation until the appropriate time but doesn't recompute umpteen times