### PR TITLE
tweak DLM to be more numerically stable

### DIFF
--- a/rainier-example/src/main/scala/com/stripe/rainier/example/DLM.scala
+++ b/rainier-example/src/main/scala/com/stripe/rainier/example/DLM.scala
@@ -49,7 +49,8 @@ object DLM {
         static = tup._1
         states = tup._2
         os = states.head
-        ns <- Normal(static.mu + static.a * (os - static.mu), static.sig).param
+        ns <- Normal(((Real.one - static.a) * static.mu) + (static.a * os),
+                     static.sig).param
         _ <- Normal(ns, static.sigD).fit(obs(i))
       } yield (static, ns :: states)
 


### PR DESCRIPTION
The issues we happened to see on master with DLM at n=30 were, I'm pretty sure, just a coincidental symptom of an overall numerical instability of DLM's gradient; it was very sensitive to the particular ordering of terms (which were ultimately at the whim of the JVM). This slight adjustment seems to make it better.

I'm pretty certain we can automatically detect this kind of problem and flag it. I don't understand it well enough yet to know if there's a practical way for us to automatically avoid it entirely.