### PR TITLE
bump num samples, get rid of max rhat retries

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/core/SBC.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/SBC.scala
@@ -76,7 +76,7 @@ final case class SBC[T](priorGenerators: Seq[Generator[Double]],
       sample(sampler, warmupIterations, syntheticSamples, thin)
     val ms = System.currentTimeMillis - t0
 
-    if (trials > 1 && (effectiveSampleSize < Samples || rHat > MaxRHat)) {
+    if (trials > 1 && effectiveSampleSize < Samples) {
       val newThin =
         Math
           .ceil(Samples.toDouble / effectiveSampleSize)
@@ -217,10 +217,9 @@ object SBC {
       (fn(l.head), l.head)
     }
 
-  val Samples = 128
+  val Samples = 1024
   val Chains = 4
   val RepsPerBin = 40
-  val MaxRHat = 1.1
   val Trials = 5
 
   case class Rep(rank: Int,


### PR DESCRIPTION
We weren't getting good convergence diagnostics at only 128 samples. Things seem much healthier at 1024, so I'm also getting rid of the (maybe cheating, not in the paper) thing I was doing before of retrying if the rHat was bad.