### PR TITLE
Limit `pow` to integer exponents

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Evaluator.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Evaluator.scala
@@ -14,7 +14,9 @@ class Evaluator(var cache: Map[Real, Double]) extends Numeric[Real] {
   private def eval(real: Real): Double = real match {
     case l: Line => l.ax.map { case (r, d) => toDouble(r) * d }.sum + l.b
     case l: LogLine =>
-      l.ax.map { case (r, d) => Math.pow(toDouble(r), d) }.reduce(_ * _)
+      l.ax
+        .map { case (r, d) => Math.pow(toDouble(r), d.toDouble) }
+        .reduce(_ * _)
     case Unary(original, op) =>
       eval(RealOps.unary(Constant(toDouble(original)), op))
     case Constant(value) => value

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/LineOps.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/LineOps.scala
@@ -62,10 +62,10 @@ private[compute] object LineOps {
   a.pow(k) * x.pow(k). Since we can precompute a.pow(k), this just moves
   a multiply around, and there's a chance that a.pow(k) will simplify further.
    */
-  def pow(line: Line, exponent: Double): Option[Real] =
+  def pow(line: Line, exponent: Int): Option[Real] =
     line match {
       case Line1(a, x, 0) =>
-        Some(x.pow(exponent) * Math.pow(a, exponent))
+        Some(x.pow(exponent) * Math.pow(a, exponent.toDouble))
       case _ => None
     }
 
@@ -90,8 +90,8 @@ private[compute] object LineOps {
       (line, 1.0)
   }
 
-  def merge(left: Map[NonConstant, Double],
-            right: Map[NonConstant, Double]): Map[NonConstant, Double] = {
+  def merge[N](left: Map[NonConstant, N], right: Map[NonConstant, N])(
+      implicit n: Numeric[N]): Map[NonConstant, N] = {
     val (big, small) =
       if (left.size > right.size)
         (left, right)
@@ -103,11 +103,11 @@ private[compute] object LineOps {
         val newV = big
           .get(k)
           .map { bigV =>
-            bigV + v
+            n.plus(bigV, v)
           }
           .getOrElse(v)
 
-        if (newV == 0.0)
+        if (newV == n.zero)
           acc - k
         else
           acc + (k -> newV)

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Real.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Real.scala
@@ -22,8 +22,8 @@ sealed trait Real {
   def -(other: Real): Real = this + (other * -1)
   def /(other: Real): Real = this * other.pow(-1)
 
-  def pow[N](exponent: N)(implicit num: Numeric[N]): Real =
-    RealOps.pow(this, num.toDouble(exponent))
+  def pow(exponent: Int): Real =
+    RealOps.pow(this, exponent)
 
   def exp: Real = RealOps.unary(this, ir.ExpOp)
   def log: Real = RealOps.unary(this, ir.LogOp)
@@ -119,7 +119,7 @@ Luckily, this aligns well with the demands of numerical stability: if you have t
 together, you are better off adding their logs.
  */
 private final case class LogLine(
-    ax: Map[NonConstant, Double]
+    ax: Map[NonConstant, Int]
 ) extends NonConstant {
   require(ax.size > 0)
 }
@@ -128,7 +128,7 @@ private object LogLine {
   def apply(nc: NonConstant): LogLine =
     nc match {
       case l: LogLine => l
-      case _          => LogLine(Map(nc -> 1.0))
+      case _          => LogLine(Map(nc -> 1))
     }
 }
 

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/RealOps.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/RealOps.scala
@@ -49,11 +49,11 @@ private[compute] object RealOps {
         LogLineOps.multiply(LogLine(nc1), LogLine(nc2))
     }
 
-  def pow(original: Real, exponent: Double): Real =
+  def pow(original: Real, exponent: Int): Real =
     (original, exponent) match {
-      case (Constant(v), _) => Constant(Math.pow(v, exponent))
-      case (_, 0.0)         => Real.one
-      case (_, 1.0)         => original
+      case (Constant(v), _) => Constant(Math.pow(v, exponent.toDouble))
+      case (_, 0)           => Real.one
+      case (_, 1)           => original
       case (l: Line, _) =>
         LineOps.pow(l, exponent).getOrElse {
           LogLineOps.pow(LogLine(l), exponent)

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Translator.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Translator.scala
@@ -48,7 +48,10 @@ private class Translator {
 
   private def logLineIR(line: LogLine): IR = {
     val (y, k) = LogLineOps.factor(line)
-    factoredLine(y.ax, 1.0, k, powRing)
+    factoredLine(y.ax.map { case (x, a) => (x, a.toDouble) },
+                 1.0,
+                 k.toDouble,
+                 powRing)
   }
 
   /**
@@ -124,7 +127,10 @@ private class Translator {
           binaryIR(toIR(x), toIR(x), ring.plus)
       case (l: LogLine, a) => //this can only happen for a Line's terms
         () =>
-          factoredLine(l.ax, a, 1.0, powRing)
+          factoredLine(l.ax.map { case (y, b) => (y, b.toDouble) },
+                       a,
+                       1.0,
+                       powRing)
       case (x, a) =>
         () =>
           binaryIR(toIR(x), Const(a), ring.times)

--- a/rainier-core/src/test/scala/com/stripe/rainier/compute/RealTest.scala
+++ b/rainier-core/src/test/scala/com/stripe/rainier/compute/RealTest.scala
@@ -80,4 +80,13 @@ class RealTest extends FunSuite {
       (x * x)) * x) +
       (x * x * x))
   }
+
+  val exponents = scala.util.Random.shuffle(-40.to(40))
+  run("exponent sums") { x =>
+    //don't try this for x=0, because (0/0 * 0) will optimize to 0 in the constant case
+    If(x, exponents.foldLeft(x) {
+      case (a, e) =>
+        (a + x.pow(e)) * x
+    }, x)
+  }
 }

--- a/rainier-core/src/test/scala/com/stripe/rainier/compute/RealTest.scala
+++ b/rainier-core/src/test/scala/com/stripe/rainier/compute/RealTest.scala
@@ -11,7 +11,7 @@ class RealTest extends FunSuite {
       val result = fn(x)
       val result2 = fn(x2)
       val c = Compiler.default.compile(List(x), result)
-      List(1.0, 0.0, -1.0, 2.0, -2.0, 0.5, -0.5).foreach { n =>
+      List(1.0, /*0.0,*/ -1.0, 2.0, -2.0, 0.5, -0.5).foreach { n =>
         val constant = fn(Constant(n))
         assert(constant.isInstanceOf[Constant], s"[c, n=$n]")
         val eval = new Evaluator(Map(x -> n, x2 -> n))
@@ -75,11 +75,17 @@ class RealTest extends FunSuite {
     Poisson(x.abs + 1).logDensities(0.to(10).toList)
   }
 
+  val exponents = scala.util.Random.shuffle(-40.to(40))
   run("exponent sums") { x =>
-    val exponents = (-40).to(40)
     exponents.foldLeft(x) {
       case (a, e) =>
         (a + x.pow(e)) * x
     }
+  }
+
+  run("4x^3") { x =>
+    (((((x + x) * x) +
+      (x * x)) * x) +
+      (x * x * x))
   }
 }

--- a/rainier-core/src/test/scala/com/stripe/rainier/compute/RealTest.scala
+++ b/rainier-core/src/test/scala/com/stripe/rainier/compute/RealTest.scala
@@ -11,7 +11,7 @@ class RealTest extends FunSuite {
       val result = fn(x)
       val result2 = fn(x2)
       val c = Compiler.default.compile(List(x), result)
-      List(1.0, /*0.0,*/ -1.0, 2.0, -2.0, 0.5, -0.5).foreach { n =>
+      List(1.0, 0.0, -1.0, 2.0, -2.0, 0.5, -0.5).foreach { n =>
         val constant = fn(Constant(n))
         assert(constant.isInstanceOf[Constant], s"[c, n=$n]")
         val eval = new Evaluator(Map(x -> n, x2 -> n))
@@ -73,14 +73,6 @@ class RealTest extends FunSuite {
   }
   run("poisson") { x =>
     Poisson(x.abs + 1).logDensities(0.to(10).toList)
-  }
-
-  val exponents = scala.util.Random.shuffle(-40.to(40))
-  run("exponent sums") { x =>
-    exponents.foldLeft(x) {
-      case (a, e) =>
-        (a + x.pow(e)) * x
-    }
   }
 
   run("4x^3") { x =>


### PR DESCRIPTION
This makes one tiny fix and one fairly major change/fix to the compute graph.

The tiny one is that in rare cases we were letting through some 0 coefficients in `Line` during `distribute`, which then wreak havoc later on. We now make sure to use `merge` to avoid this.

The major one is that we now represent exponents in a `LogLine` as integers. This avoids problems with floating point precision as we aggregate or factor out exponent terms - you really don't want (as I was able to trigger) to end up with `x^0.99999999` instead of `x`, especially if `x` can be negative. It does mean that we can't take square roots, which I suspect we will one day want to do, but it would be easy to add a unary `SqrtOp` whenever we need it.