### PR TITLE
don't cache param in Injection

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Injection.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Injection.scala
@@ -31,7 +31,7 @@ trait Injection { self =>
         n.toDouble(forwards(dist.generator.get(r, n)))
       }
 
-    val param: RandomVariable[Real] = dist.param.map(forwards)
+    def param: RandomVariable[Real] = dist.param.map(forwards)
   }
 }
 


### PR DESCRIPTION
quick fix for overzealous caching