### PR TITLE
`fit` returns a `Likelihood` rather than a `Generator`

### DIFF
--- a/docs/tour.md
+++ b/docs/tour.md
@@ -18,7 +18,7 @@ val model = for {
     slope <- LogNormal(0,1).param
     intercept <- LogNormal(0,1).param
     regression <- Predictor.from{x: Int => Poisson(x*slope + intercept)}.fit(data)
-} yield regression
+} yield regression.predict(21)
 ```
 
 ## Distribution
@@ -33,7 +33,7 @@ You construct a distribution from its parameters, usually with the `apply` metho
 
 ```scala
 scala> val normal: Distribution[Double] = Normal(0,1)
-normal: com.stripe.rainier.core.Distribution[Double] = com.stripe.rainier.core.Injection$$anon$1@4614111e
+normal: com.stripe.rainier.core.Distribution[Double] = com.stripe.rainier.core.Injection$$anon$1@4ce0cc1a
 ```
 
 In Rainier, `Distribution` objects play three different roles. `Continuous` distributions (like `Normal`), implement `param`, and all distributions implement `fit` and `generator`. Each of these methods is central to one of the three stages of building a model in Rainier: defining your parameters and their priors; fitting the parameters to some observed data; and using the fit parameters to generate samples of some posterior distribution of interest. We'll start by exploring each of these in turn.
@@ -48,43 +48,44 @@ Let's use that same `Normal(0,1)` distribution as a prior for a new parameter:
 
 ```scala
 scala> val x = Normal(0,1).param
-x: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@1a58b301
+x: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@232e5b21
 ```
 
 You can see that the type of `x` is `RandomVariable[Real]`. `RandomVariable` pairs a type of value (in this case, a real number) with some knowledge of the relative probability density of different values of that type. We can use this knowledge to produce a sample of these possible values:
 
 ```scala
 scala> x.sample()
-res0: List[Double] = List(1.4588454307198901, -2.5730831879427876, -0.4808792678236574, 0.6171810555204899, 0.9911856030659025, 0.49010869346774927, -0.1275174851319194, -1.1570029113783307, 2.567882787980774, 0.7042148688654633, 0.8961795739814149, 1.7140934735234024, 1.4286918145656493, 1.167325113299711, -1.2680380901324013, 0.1185760073008304, -0.5761731171533748, -0.023398200958025667, -0.7736410743640572, -0.051929817993721095, 0.8205730397330855, 0.24939418376421954, 0.375050464368331, -0.8070961465042661, 1.6494381215230258, -0.3987542642620787, -0.18118403821339424, -0.6558375727474967, 0.5400922535820991, 0.29909220185452756, 0.3475411276684546, 1.4884873398730054, -1.0829977544379426, -0.39922343834780744, 0.3081184499327483, -0.6475707727038842, -0....
+Initializing RNG with seed 1528607621103
+res0: List[Double] = List(0.2668925806558562, 0.2668925806558562, 0.2668925806558562, 0.2668925806558562, 0.2668925806558562, 0.2668925806558562, 0.2668925806558562, 0.08308255891110272, -0.7507410928137115, -0.7507410928137115, -0.7509669096148541, 2.0631314152983418, 1.3249273912534498, 0.03555138311217787, 0.03555138311217787, -0.6955898234740514, -0.0837806333999056, -0.9274366321774818, -0.9274366321774818, 0.8318328769519683, 0.25325404344233426, 0.28406288209268826, 0.28406288209268826, 0.28406288209268826, 0.28406288209268826, 0.6742861222712562, -0.3570215030919299, -0.5400233157792773, -0.5400233157792773, 1.5672412873474744, 1.73802462004861, -0.16635438290570548, -0.16635438290570548, -0.16635438290570548, -0.16635438290570548, 0.7579880774045454, -...
 ```
 
 Each element of the list above represents a single sample from the distribution over `x`. It's easier to understand these if we plot them as a histogram:
 
 ```scala
 scala> plot1D(x.sample())
-     350 |                                                                                
-         |                                   ·   ·∘                                       
-         |                                   ○∘∘ ○○  ∘                                    
-         |                                 ··○○○○○○· ○                                    
-         |                             ··  ○○○○○○○○○ ○∘∘                                  
-     260 |                            ·○○ ·○○○○○○○○○○○○○ ·                                
-         |                            ○○○∘○○○○○○○○○○○○○○∘○∘                               
-         |                          ∘ ○○○○○○○○○○○○○○○○○○○○○                               
-         |                         ○○∘○○○○○○○○○○○○○○○○○○○○○                               
-         |                        ·○○○○○○○○○○○○○○○○○○○○○○○○○                              
-     170 |                        ○○○○○○○○○○○○○○○○○○○○○○○○○○∘                             
-         |                       ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○                            
-         |                       ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                          
-         |                     ○ ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                          
-         |                    ∘○∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘                         
-      80 |                   ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                         
-         |                ○·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○ ○·                     
-         |               ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                     
-         |             ∘∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○ ·                
-         |          ∘··○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○·               
-       0 |· ··  ∘··○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○·∘○· ··∘·· ·
+     500 |                                                                                
+         |                                         ∘                                      
+         |                                         ○                                      
+         |                                         ○                                      
+         |                                         ○ ∘○ ○                                 
+     370 |                                         ○ ○○ ○∘                                
+         |                                        ○○○○○·○○                                
+         |                                      ○○○○○○○○○○  ○                             
+         |                                  ·  ○○○○○○○○○○○ ∘○·                            
+         |                                 ·○ ·○○○○○○○○○○○○○○○                            
+     250 |                                 ○○○○○○○○○○○○○○○○○○○∘∘                          
+         |                                 ○○○○○○○○○○○○○○○○○○○○○∘                         
+         |                               ·○○○○○○○○○○○○○○○○○○○○○○○                         
+         |                               ○○○○○○○○○○○○○○○○○○○○○○○○∘                        
+         |                              ∘○○○○○○○○○○○○○○○○○○○○○○○○○                        
+     120 |                            ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○                     
+         |                           ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·                   
+         |                          ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·                  
+         |                        ∘·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘·                
+         |                     ··○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·              
+       0 |·       · ····∘··∘○∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘∘∘······· ··
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-       -3.27    -2.48    -1.70    -0.92    -0.14     0.64     1.42     2.21     2.99  
+        -4.5     -3.6     -2.7     -1.7     -0.8     0.1      1.1      2.0      2.9   
 ```
 
 Since the only information we have about `x` so far is its `Normal` prior, this distribution unsurprisingly looks  normal. Later we'll see how to update our beliefs about `x` based on observational data.
@@ -92,103 +93,103 @@ Since the only information we have about `x` so far is its `Normal` prior, this 
 For now, though, let's explore what we can do just with priors. `RandomVariable` has more than just `sample`: you can use the familiar collection methods like `map`, `flatMap`, and `zip` to transform and combine the parameters you create. For example, we can create a log-normal distribution just by mapping over `e^x`:
 
 ```scala
-scala> val ex = x.map(_.exp)
-ex: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@7ca46d5c
+scala> val e_x = x.map(_.exp)
+e_x: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@325063a0
 
-scala> plot1D(ex.sample())
-    2400 |                                                                                
+scala> plot1D(e_x.sample())
+    2300 |                                                                                
          | ·                                                                              
          | ○                                                                              
          | ○                                                                              
-         |·○                                                                              
-    1800 |○○                                                                              
+         | ○                                                                              
+    1700 | ○                                                                              
          |○○                                                                              
          |○○                                                                              
-         |○○·                                                                             
+         |○○∘                                                                             
          |○○○                                                                             
-    1200 |○○○                                                                             
+    1100 |○○○                                                                             
          |○○○                                                                             
          |○○○∘                                                                            
-         |○○○○                                                                            
-         |○○○○                                                                            
-     600 |○○○○○                                                                           
-         |○○○○○·                                                                          
+         |○○○○·                                                                           
+         |○○○○○                                                                           
+     500 |○○○○○                                                                           
+         |○○○○○∘                                                                          
          |○○○○○○·                                                                         
-         |○○○○○○○∘                                                                        
-         |○○○○○○○○○··                                                                     
-       0 |○○○○○○○○○○○∘∘∘∘∘············· ··· ···  · ·     ·····  ··           ·           ·
+         |○○○○○○○∘·                                                                       
+         |○○○○○○○○○∘··                                                                    
+       0 |○○○○○○○○○○○○○∘∘∘······················ ···· ·· ·· ·    · ·· · ·       ·   ·    ·
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        0.0      3.7      7.5      11.2     14.9     18.6     22.3     26.0     29.7  
+        0.0      3.5      7.0      10.6     14.1     17.6     21.1     24.6     28.1  
 ```
 
 Or we can create another `Normal` parameter and zip the two together to produce a 2D gaussian. Since there's nothing relating these two parameters to each other, you can see in the plot that they're completely independent.
 
 ```scala
 scala> val y = Normal(0,1).param
-y: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@7a2ee603
+y: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@7dba9d23
 
 scala> val xy = x.zip(y)
-xy: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@5bbb88fd
+xy: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@5efebe61
 
 scala> plot2D(xy.sample())
-     3.7 |                                                                                
-         |                             ··                                                 
-         |     ·                        · ·       · ·   ·                                 
-         |                             · ···   ·   ·· ·   · ·  ··      ·                  
-         |         ·             ··   ·      ·· ·· ··· ·  ·· ·····    · · ·       ··      
-     2.0 |              · · · · ··· ·· ······ · ··· · ···· ····    ·· ··     · ··         
-         |               ···  ······· ·············· ··········· ······  ·· ··            
-         |            ··  ·································· ········· · ·· ·      ·      
-         | ·     · ····················································· ··· · ·          
-         |     ·······················∘··∘∘∘··∘∘∘···∘·········∘·········· ····     · ·   ·
-     0.4 |       · ···············∘∘·∘∘∘○∘∘∘∘∘∘∘∘∘∘·····∘················  ·····  ·    ·  
-         |       ···············∘∘···∘○∘∘∘∘○∘∘∘∘∘·∘∘∘∘∘····∘··∘············· ·· ··      · 
-         |   ·   ···············∘···∘··∘∘∘∘·∘∘∘∘○∘∘∘∘∘∘∘∘∘∘·∘·················  ·         
-         |  · ·· ················∘·∘··∘·∘·∘∘∘∘∘∘∘∘∘○∘∘···∘················· ·· ·          
-         |      ···· ···············∘·∘∘∘·∘∘∘∘·∘∘∘··∘∘∘··················· ··             
-    -1.2 |   · ···· ················∘····∘∘∘·∘∘····················· · ···· ·         ·   
-         |·     · · · ············································ ······· ·      ·       
-         |       ·· ··· ······ ·································· ·   ·  · ·              
-         |      ·· ····   ············· · ··············  ··· ·· ··· ··                   
-         |             ·  ··  ··   ·· ·  ······· ··· · ···· ··· · ·· · ·    ·             
-    -2.8 |         ·  · ·   ·  · ·     ·  ···      ·   ·         ·                        
+     3.9 |                                                                                
+         |                                        ·                                       
+         |                                         ·  ·      ··      ·                    
+         |                    ·       ·   ·  ·   · ·  ·     ··    ··                      
+         |                · · · ·· ·· ·· ·· ······· ····· ·  · · ···                      
+     2.0 |       ·     ·     ·· ···· ·· ··· ·················· ··  ·                      
+         |               · · ······································      ··  ·            
+         |    ·  ··  ··  · · ······································ ··· ·  ·      ·       
+         |         ························∘····∘·∘····∘················· ····  ·   ·    ·
+         |     ·   ·  ················∘·∘··∘∘∘∘·∘∘∘∘··∘·∘················· · · ·· ··      
+     0.1 |   ·  ··· ·· ············∘····∘∘∘∘∘·∘∘∘∘∘∘∘∘∘∘··∘·∘·············· ···  ·        
+         |      ·   ··················∘·∘∘∘∘∘·∘∘○○∘∘∘∘∘∘∘∘···∘················· ··        
+         |      · · ·  ···············∘∘∘··∘∘∘∘∘∘∘∘∘∘·∘∘∘∘∘················· ···          
+         |·     ·  ····················∘·∘·∘·∘∘·∘·∘∘∘∘∘·····∘················  ·     ·    
+         |    · · ·   ···· ···························∘················· ·        ·       
+    -1.7 |    ·        ·  ·· ········································ ·······             
+         |           · ··   ·· ····································· · ··                 
+         |      ·         · ·· ····  ······· ·············· · ··    ·     ·   ·           
+         |                    ·  ·····   ··· ······· ·· ·   · ·      ·                    
+         |                          ·      ·  ·    ··                                     
+    -3.6 |                               ·     ·         ·     ·                          
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-       -3.00    -2.28    -1.55    -0.83    -0.10     0.62     1.35     2.07     2.80  
+       -3.64    -2.80    -1.96    -1.12    -0.28     0.56     1.40     2.24     3.08  
 ```
 
 Finally, we can use `flatMap` to create two parameters that *are* related to each other. In particular, we'll create a new parameter `z` that we believe to be very close to `x`: its prior is a `Normal` centered on `x` with a very small standard deviation. We'll then make a 2D plot of `(x,z)` to see the relationship.
 
 ```scala
 scala> val z = x.flatMap{a => Normal(a, 0.1).param}
-z: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@52443333
+z: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@40fb6c3c
 
 scala> val xz = x.zip(z)
-xz: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@20403bcd
+xz: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@2d8e1a86
 
 scala> plot2D(xz.sample())
-     4.3 |                                                                                
+     3.7 |                                                                                
          |                                                                               ·
-         |                                                                         ·      
-         |                                                                      ··        
-         |                                                                ·······         
-     2.3 |                                                           ·······              
-         |                                                       ········                 
-         |                                                   ········                     
-         |                                              ····∘∘···                         
-         |                                           ··∘∘∘∘···                            
-     0.3 |                                       ··∘○○∘···                                
-         |                                   ··∘○○○∘··                                    
-         |                              ···∘∘○○∘···                                       
-         |                           ··∘∘○∘···                                            
-         |                       ···∘∘∘···                                                
-    -1.7 |                   ·········                                                    
-         |               ·········                                                        
-         |            ·······                                                             
-         |         ·····                                                                  
-         |     ·  ···                                                                     
-    -3.6 |···                                                                             
+         |                                                                         · ··   
+         |                                                                  ········      
+         |                                                               ·······          
+     2.0 |                                                          ········ ·            
+         |                                                      ·········                 
+         |                                                  ·········                     
+         |                                              ····∘∘····                        
+         |                                          ···∘∘∘∘···                            
+     0.2 |                                     ···∘∘∘∘∘····                               
+         |                                 ····∘∘∘∘···                                    
+         |                             ····∘○○∘···                                        
+         |                          ···∘∘∘∘···                                            
+         |                     ····∘∘∘·····                                               
+    -1.5 |                  ··········                                                    
+         |              ·········                                                         
+         |          ··········                                                            
+         |       ·········                                                                
+         |    ····· ·                                                                     
+    -3.3 |·  ···                                                                          
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-       -3.77    -2.87    -1.98    -1.09    -0.19     0.70     1.59     2.49     3.38  
+       -3.30    -2.52    -1.74    -0.97    -0.19     0.59     1.37     2.14     2.92  
 ```
 
 You can see that although we still sample from the full range of `x` values, for any given sample, `x` and `z` are quite close to each other.
@@ -210,10 +211,10 @@ We can model the number of sales we get on each day as a poisson distribution pa
 
 ```scala
 scala> val poisson9: RandomVariable[_] = Poisson(9).fit(sales)
-poisson9: com.stripe.rainier.core.RandomVariable[_] = com.stripe.rainier.core.RandomVariable@55211f61
+poisson9: com.stripe.rainier.core.RandomVariable[_] = com.stripe.rainier.core.RandomVariable@57227bda
 
 scala> val poisson10: RandomVariable[_] = Poisson(10).fit(sales)
-poisson10: com.stripe.rainier.core.RandomVariable[_] = com.stripe.rainier.core.RandomVariable@50c62667
+poisson10: com.stripe.rainier.core.RandomVariable[_] = com.stripe.rainier.core.RandomVariable@4cbce5c8
 ```
 
 Although it's almost never necessary, we can reach into any `RandomVariable` and get its current probability `density`:
@@ -230,75 +231,103 @@ scala> val lr = (poisson9.density - poisson10.density).exp
 lr: com.stripe.rainier.compute.Real = Constant(3.0035986601488043)
 ```
 
-We can see here that our data is about 3x as likely to have come from a `Poisson(9)` as it is to have come from a `Poisson(10)`. We could keep doing this with a large number of values to build up a sense of the rate distribution, but it would be tedious, and we'd be ignoring any prior we had on the rate. Instead, the right way to do this in Rainier is to make the rate a parameter, and let the library do the hard work of exploring the space. Specifically, we can use `flatMap` to chain the creation of the parameter with the creation and fit of the `Poisson` distribution. Since we want our rate to be a positive number, and expect it to be more likely to be on the small side than the large side, the log-normal parameter we created earlier as `ex` seems like a reasonable choice.
+We can see here that our data is about 3x as likely to have come from a `Poisson(9)` as it is to have come from a `Poisson(10)`. We could keep doing this with a large number of values to build up a sense of the rate distribution, but it would be tedious, and we'd be ignoring any prior we had on the rate. Instead, the right way to do this in Rainier is to make the rate a parameter, and let the library do the hard work of exploring the space. Specifically, we can use `flatMap` to chain the creation of the parameter with the creation and fit of the `Poisson` distribution. Since we want our rate to be a positive number, and expect it to be more likely to be on the small side than the large side, the log-normal parameter we created earlier as `e_x` seems like a reasonable choice.
 
 ```scala
-scala> val poisson: RandomVariable[_] = ex.flatMap{r => Poisson(r).fit(sales)}
-poisson: com.stripe.rainier.core.RandomVariable[_] = com.stripe.rainier.core.RandomVariable@3787aa5d
+scala> val poisson: RandomVariable[_] = e_x.flatMap{r => Poisson(r).fit(sales)}
+poisson: com.stripe.rainier.core.RandomVariable[_] = com.stripe.rainier.core.RandomVariable@2e53a756
 ```
 
 By the way: before, when we looked at `poisson9.density`, the model had no parameters and so we got a constant value back. Now, since the model's density is a function of the parameter value, we get something more opaque back. This is why inspecting `density` is not normally useful.
 
 ```scala
 scala> poisson.density
-res6: com.stripe.rainier.compute.Real = com.stripe.rainier.compute.Line@4df7a3a0
+res6: com.stripe.rainier.compute.Real = com.stripe.rainier.compute.Line@d415bc0
 ```
 
-Instead, we can sample the quantity we're actually interested in. Let's recreate this model from the start, with the slightly friendlier `for` syntax:
+Instead, we can sample the quantity we're actually interested in. To start with, let's try to sample the rate parameter of the Poisson, conditioned by our observed data. Here's almost the same thing we had above, recreated with the slightly friendlier `for` syntax, and yielding the `r` parameter at the end:
 
 ```scala
 scala> val rate = for {
-     |     x <- Normal(0,1).param
-     |     ex = x.exp
-     |     _ <- Poisson(ex).fit(sales)
-     | } yield ex
-rate: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@5f16a1e4
+     |     r <- e_x
+     |     poisson <- Poisson(r).fit(sales)
+     | } yield r
+rate: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@77065612
 ```
 
-Here we're creating our log-normal prior, using it as the rate on a Poisson distribution, fitting that distribution to the data, and then outputting the rate. Let's plot it!
+This is our first "full" model: we have a parameter with a log-normal prior, bundled into the `RandomVariable` named `e_x`; we use that parameter to initialize a `Poisson` noise distribution which we fit to our observations; and at the end, we output the same parameter (referenced by `r`) as the quantity we're interested in sampling from the posterior.
+
+Let's plot the results!
 
 ```scala
 scala> plot1D(rate.sample())
-     370 |                                                                                
-         |                           ∘                                                    
-         |                          ○○· ∘  ∘                                              
-         |                          ○○○·○○ ○ ·∘                                           
-         |                     ∘· ∘ ○○○○○○○○·○○                                           
-     270 |                    ∘○○∘○○○○○○○○○○○○○                                           
-         |                    ○○○○○○○○○○○○○○○○○∘                                          
-         |                  · ○○○○○○○○○○○○○○○○○○∘                                         
-         |                  ○∘○○○○○○○○○○○○○○○○○○○○                                        
-         |                  ○○○○○○○○○○○○○○○○○○○○○○·○                                      
-     180 |                 ○○○○○○○○○○○○○○○○○○○○○○○○○·                                     
-         |                ∘○○○○○○○○○○○○○○○○○○○○○○○○○○∘∘                                   
-         |            ·  ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                                   
-         |            ○ ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                                   
-         |            ○∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘∘∘                                
-      90 |            ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·∘                              
-         |        · ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                             
-         |        ○·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘··                          
-         |        ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘·                        
-         |     ∘··○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                      
-       0 |···∘∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○○∘∘·∘∘∘ ···        ·
+     420 |                                                                                
+         |                            ∘    ∘                                              
+         |                            ○·   ○                                              
+         |                            ○○  ·○                                              
+         |                         ○ ∘○○∘·○○                                              
+     310 |                         ○·○○○○○○○○∘                                            
+         |                      ∘  ○○○○○○○○○○○·                                           
+         |                      ○○○○○○○○○○○○○○○○·                                         
+         |                    ∘∘○○○○○○○○○○○○○○○○○                                         
+         |                    ○○○○○○○○○○○○○○○○○○○ ∘                                       
+     210 |                   ○○○○○○○○○○○○○○○○○○○○○○∘                                      
+         |                ∘ ·○○○○○○○○○○○○○○○○○○○○○○○                                      
+         |                ○○○○○○○○○○○○○○○○○○○○○○○○○○ ·○                                   
+         |                ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·                                  
+         |                ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·                                 
+     100 |              ○·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                                 
+         |              ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○ ∘ ∘ ∘                           
+         |           ∘ ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○ ○                           
+         |         ∘∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·                         
+         |    ∘  · ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·∘  ·                    
+       0 |· ○∘○·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○○○∘··∘∘··· ∘        ·
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        4.88     5.72     6.56     7.40     8.23     9.07     9.91    10.75    11.58  
+        4.68     5.55     6.42     7.28     8.15     9.02     9.88    10.75    11.61  
 ```
+
+Looks like our daily rate is probably somewhere between 6 and 9, which corresponds well to the steep 3x dropoff we saw before between 9 and 10.
+
+## A mathematical digression
+
+Please feel free to skip this section if it's not helping you.
+
+One thing that sometimes confuses people at this stage is, what is the line with `fit` actually doing? It seems to return a `poisson` object that we just ignore. (That object, by the way, is just the `Poisson(r)` distribution object that we used to do the `fit`.) And yet the line is clearly doing something, because sampling from `rate` gives quite different results from just sampling directly from `e_x`.
+
+They key is to remember that a `RandomVariable` has two parts: a `value` and a `density`. Mathematically, you should think of these as two different *functions* of the same latent parameter space `Q`. That is, you should think of `value` as being some deterministic function `f = F(q)`, and `density` as being the (unnormalized) probability function `P(Q=q)`.
+
+ When we `map` or `flatMap` a `RandomVariable` (whether explicitly or inside a `for` construct), the object we see and work with (like, the `r` above) is the `value` object. And we can see in the definition of `rate` that it's just passing that value object through to the end; it should end up with the same `value` function as the prior, `e_x`. And indeed, it does:
+
+```scala
+scala> e_x.value == rate.value
+res8: Boolean = true
+```
+
+So, for the same input in the latent parameter space, `e_x` and `rate` will produce the same output.
+
+However, when we `flatMap`, behind the scenes we're also working with the `density` object. Specifically, when we start with one `RandomVariable` (like `e_x`), and use `flatMap` to flatten another `RandomVariable` into it (like the result of `fit`), the resulting `RandomVariable` (like `rate`) will have a `density` that *combines* the densities of the other two `RandomVariable`s. Put another way, `flatMap` is the bayesian update operation: you're putting in a prior, coming up with a likelihood, and getting back the posterior. That's what the `fit` line is doing: constructing a likelihood function that we can incorporate into our posterior density. And if we look at the densities, we'll see that they are indeed different:
+
+```scala
+scala> e_x.density == rate.density
+res9: Boolean = false
+```
+
+So although `F(q)` has not changed, `P(Q=q)` *has* changed; which means that `P(F(q)=f)` has also changed, and it's that change which we're observing when we see that sampling values of `F` produces different results in the two cases.
 
 ## `generator` and `Generator`
 
-The rate parameter is nice to have, but what we originally said is that we wanted to predict how many sales to expect tomorrow. For that we need to plug the rate back into a Poisson distribution, but in this case, instead of fitting data *to* that distribution, we want to generate data *from* that distribution. You might think that we could do this with `param`, that is, with something like this:
+Sampling from the rate parameter is nice, but what we originally said is that we wanted to predict how many sales to expect tomorrow. As we just discussed in the digression, we got a `poisson` value back from `fit` but didn't do anything with it. This value is just the distribution we used for the `fit`, that is, `Poisson(r)`. Now, instead of fitting data *to* that distribution, we want to generate data *from* that distribution. One idea might be to do that with `param`, that is, with something like this:
 
 ```scala
 //This code won't compile
 for {
-    x <- Normal(0,1).param
-    ex = x.exp
-    _ <- Poisson(ex).fit(sales)
-    prediction <- Poisson(ex).param
+    r <- e_x
+    poisson <- Poisson(r).fit(sales)
+    prediction <- poisson.param
 } yield prediction
 ```
 
-This has a couple of problems. First, it seems conceptually wrong to think of a prediction as a parameter: there is no true value of "how many sales will we have tomorrow" for us to infer, and we have no observational data that can influence our belief about its value; once we've derived the rate parameter, the prediction is purely generative. Second, as a practical matter, Rainier only supports continuous parameters, and here we need to generate discrete values, so `Poisson(ex).param` won't, in fact, compile.
+This has a couple of problems. First, it seems conceptually wrong to think of a prediction as a parameter: there is no true value of "how many sales will we have tomorrow" for us to infer, and we have no observational data that can influence our belief about its value; once we've derived the rate parameter, the prediction is purely generative. Second, as a practical matter, Rainier only supports continuous parameters, and here we need to generate discrete values, so `poisson.param` won't, in fact, compile.
 
 Luckily, all distributions, continious or discrete, implement `generator`, which gives us what we need: a way to randomly generate new values from a distribution as part of the sampling process. Every `Distribution[T]` can give us a `Generator[T]`, and if we sample from a `RandomVariable[Generator[T]]`, we will get values of type `T`. (You can think of `Real` as being a special case that acts in this sense like a `Generator[Double]`).
 
@@ -306,59 +335,45 @@ Here's one way we could implement what we're looking for:
 
 ```scala
 scala> val prediction = for {
-     |     x <- Normal(0,1).param
-     |     ex = x.exp
-     |     _ <- Poisson(ex).fit(sales)    
-     | } yield Poisson(ex).generator
-prediction: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@5c33e33b
+     |     r <- e_x
+     |     poisson <- Poisson(r).fit(sales)
+     | } yield poisson.generator
+prediction: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@620ce32e
 ```
 
-This is almost the same model as `rate` above, but instead of taking the real-valued `ex` rate parameter as the output, we're producing poisson-distributed integers. The samples look like this:
+This is almost the same model as `rate` above, but instead of taking the real-valued `r` rate parameter as the output, we're producing poisson-distributed integers. The samples look like this:
 
 ```scala
 scala> prediction.sample()
-res8: List[Int] = List(9, 9, 11, 7, 6, 3, 9, 18, 7, 6, 9, 8, 3, 7, 5, 4, 14, 8, 9, 3, 8, 10, 5, 6, 8, 5, 4, 6, 3, 6, 12, 13, 7, 12, 7, 10, 7, 9, 7, 6, 10, 10, 6, 9, 8, 8, 7, 9, 6, 10, 7, 3, 6, 12, 10, 5, 10, 4, 6, 6, 9, 14, 3, 8, 8, 6, 5, 9, 9, 6, 7, 5, 2, 7, 5, 5, 5, 5, 4, 6, 8, 10, 8, 10, 11, 6, 6, 11, 5, 12, 2, 8, 12, 8, 12, 5, 8, 12, 3, 12, 12, 7, 7, 7, 4, 7, 9, 10, 15, 7, 8, 10, 4, 7, 4, 9, 9, 6, 5, 10, 8, 10, 7, 10, 10, 6, 7, 10, 7, 9, 10, 3, 7, 9, 10, 13, 6, 5, 6, 7, 9, 7, 3, 6, 3, 13, 15, 2, 10, 14, 7, 6, 9, 8, 6, 9, 6, 12, 7, 10, 1, 9, 7, 5, 10, 5, 6, 7, 4, 4, 8, 8, 5, 11, 3, 12, 8, 8, 7, 6, 13, 9, 8, 7, 6, 5, 5, 9, 8, 7, 3, 7, 8, 8, 6, 9, 6, 10, 12, 7, 6, 8, 6, 10, 4, 7, 7, 10, 8, 5, 8, 9, 10, 16, 14, 10, 8, 11, 5, 5, 12, 11, 3, 10, 6, 10, 3, 9, 3, 11...
+res10: List[Int] = List(8, 8, 3, 14, 13, 9, 2, 6, 4, 7, 11, 4, 7, 9, 8, 8, 17, 11, 10, 11, 14, 14, 5, 4, 7, 9, 4, 9, 7, 3, 7, 5, 10, 8, 13, 5, 7, 12, 16, 10, 9, 6, 11, 12, 4, 9, 10, 6, 13, 10, 8, 6, 7, 4, 9, 9, 6, 6, 9, 8, 8, 5, 7, 5, 9, 10, 5, 10, 10, 4, 10, 7, 10, 7, 4, 8, 7, 8, 5, 7, 13, 5, 6, 8, 7, 7, 8, 6, 3, 16, 5, 8, 7, 8, 6, 8, 8, 5, 9, 11, 11, 9, 7, 6, 9, 3, 7, 10, 10, 5, 5, 8, 5, 10, 4, 8, 5, 12, 3, 3, 9, 4, 5, 5, 8, 10, 8, 9, 13, 3, 10, 9, 4, 6, 7, 9, 11, 7, 9, 10, 12, 10, 4, 12, 12, 16, 4, 9, 14, 6, 7, 12, 14, 10, 5, 5, 3, 8, 6, 8, 5, 4, 6, 9, 4, 7, 9, 5, 8, 7, 9, 10, 9, 7, 6, 6, 10, 13, 8, 7, 7, 6, 8, 3, 3, 11, 10, 6, 7, 5, 6, 5, 13, 10, 7, 9, 12, 6, 8, 6, 11, 10, 15, 10, 5, 6, 6, 2, 9, 6, 7, 12, 7, 6, 3, 4, 6, 8, 6, 11, 8, 8, 9, 9, 10, 8, 9, 10, 4...
 ```
-
-It's very common to want to generate new data that mimics the data you fit against. We've been carefully ignoring the type of `RandomVariable` that `fit` returns, but in fact, it contains a `Generator` to do just that. That gives us another way to implement the same thing. (While we're at it, let's make use of the `LogNormal` distribution instead of rolling our own.)
-
-```scala
-scala> val prediction2 = for {
-     |     ex <- LogNormal(0,1).param
-     |     poisson <- Poisson(ex).fit(sales)    
-     | } yield poisson.map(_.head)
-prediction2: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@40d17a57
-```  
-
-There's a bit of a twist here: because we `fit` against a list of 7 data points, the generator returned from there will try to produce output of the same shape, with each sample having a sequence of 7 ints. Luckily, `Generator` has the usual `map` and `flatMap` methods, so we can fix that by grabbing just the first value with `head`.
-
-Let's plot it this time:
+Or, if we plot them, like this:
 
 ```scala
-scala> plot1D(prediction2.sample())
-    1360 |                                                                                
-         |                           ·   ○                                                
-         |                       ∘   ○   ○                                                
-         |                       ○   ○   ○                                                
-         |                       ○   ○   ○   ·                                            
-    1020 |                   ∘   ○   ○   ○   ○                                            
-         |                   ○   ○   ○   ○   ○                                            
-         |                   ○   ○   ○   ○   ○   ·                                        
-         |                   ○   ○   ○   ○   ○   ○                                        
-         |                   ○   ○   ○   ○   ○   ○                                        
-     680 |                   ○   ○   ○   ○   ○   ○                                        
-         |               ○   ○   ○   ○   ○   ○   ○   ○                                    
-         |               ○   ○   ○   ○   ○   ○   ○   ○                                    
-         |               ○   ○   ○   ○   ○   ○   ○   ○                                    
-         |               ○   ○   ○   ○   ○   ○   ○   ○                                    
-     340 |           ∘   ○   ○   ○   ○   ○   ○   ○   ○   ○                                
-         |           ○   ○   ○   ○   ○   ○   ○   ○   ○   ○   ·                            
-         |           ○   ○   ○   ○   ○   ○   ○   ○   ○   ○   ○                            
-         |       ∘   ○   ○   ○   ○   ○   ○   ○   ○   ○   ○   ○   ∘                        
-         |       ○   ○   ○   ○   ○   ○   ○   ○   ○   ○   ○   ○   ○   ·                    
-       0 |·  ∘   ○   ○   ○   ○   ○   ○   ○   ○   ○   ○   ○   ○   ○   ○   ○   ·   ·   ·   ·
+scala> plot1D(prediction.sample())
+    1410 |                                                                                
+         |                        ○                                                       
+         |                        ○  ·                                                    
+         |                    ·   ○  ○                                                    
+         |                    ○   ○  ○                                                    
+    1050 |                 ·  ○   ○  ○   ○                                                
+         |                 ○  ○   ○  ○   ○                                                
+         |                 ○  ○   ○  ○   ○                                                
+         |                 ○  ○   ○  ○   ○  ·                                             
+         |                 ○  ○   ○  ○   ○  ○                                             
+     700 |             ·   ○  ○   ○  ○   ○  ○                                             
+         |             ○   ○  ○   ○  ○   ○  ○   ·                                         
+         |             ○   ○  ○   ○  ○   ○  ○   ○                                         
+         |             ○   ○  ○   ○  ○   ○  ○   ○                                         
+         |             ○   ○  ○   ○  ○   ○  ○   ○  ·                                      
+     350 |          ∘  ○   ○  ○   ○  ○   ○  ○   ○  ○                                      
+         |          ○  ○   ○  ○   ○  ○   ○  ○   ○  ○   ·                                  
+         |          ○  ○   ○  ○   ○  ○   ○  ○   ○  ○   ○                                  
+         |      ∘   ○  ○   ○  ○   ○  ○   ○  ○   ○  ○   ○  ·                               
+         |      ○   ○  ○   ○  ○   ○  ○   ○  ○   ○  ○   ○  ○  ·                            
+       0 |·  ∘  ○   ○  ○   ○  ○   ○  ○   ○  ○   ○  ○   ○  ○  ○   ∘  ·   ·  ·   ·  ·   ·  ·
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        0.0      2.3      4.5      6.8      9.0      11.3     13.6     15.8     18.1  
+        0.0      2.6      5.2      7.8      10.4     13.0     15.6     18.2     20.8  
 ```
 
 ## `Likelihood` and `Predictor`
@@ -399,129 +414,98 @@ scala> plot2D(data)
         0.0      2.3      4.5      6.8      9.0      11.3     13.6     15.8     18.1  
 ```
 
-How should we model this? We'll need to know what the rate was on day 0 (the intercept), as well as how fast the rate increases each day (the slope). We know they're both positive and not too large, so let's keep using LogNormal priors.
+How should we model this? We'll need to know what the rate was on day 0 (the intercept), as well as how fast the rate increases each day (the slope). We know they're both positive and not too large, so let's keep using log-normal priors. (This time we can just use the builtin `LogNormal` instead of deriving it ourselves).
 
 ```scala
 scala> val prior = for {
      |     slope <- LogNormal(0,1).param
      |     intercept <- LogNormal(0,1).param
      |     } yield (slope, intercept)
-prior: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@4154a3d7
+prior: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@5a99dd10
 ```
 
 Now, for any given day `i`, we want to check the number of sales against `Poisson(intercept + slope*i)`. We could write some kind of recursive flatMap to build and fit each of these different distribution objects in turn, but this is a common enough pattern that Rainier already has something built in for it: `Predictor`. `Predictor` is not a `Distribution`, but instead wraps a function from `X => Distribution[Y]` for some `(X,Y)`; you can use this any time you have a dependent variable of type `Y` that you're modeling with some independent variables jointly represented as `X`. 
 
-Like `Distribution`, `Predictor` implements `fit` (in fact, they both extend the `Likelihood` trait which provides that method). So we can create and use it like this:
+Like `Distribution`, `Predictor` implements `fit` (in fact, they both extend the `Likelihood` trait which provides that method). So we can extend the previous model to create and use a `Predictor` like this:
 
 ```scala
-scala> val regr = prior.flatMap {case (slope, intercept) =>
-     |   Predictor.from{i: Int => Poisson(intercept + slope*i)}.fit(data) 
-     | }
-regr: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Seq[(Int, Int)]]] = com.stripe.rainier.core.RandomVariable@75675b7
+scala> val regr = for {
+     |     (slope, intercept) <- prior
+     |     predictor <- Predictor.from{i: Int =>
+     |                     Poisson(intercept + slope*i)
+     |                 }.fit(data) 
+     | } yield (slope, intercept)
+regr: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@5cd8e466
 ```
-
-As before, the return value from `fit` will be a `Generator` that tries to recreate the input data. In this case, it will keep the `X` the same but generate a new `Y` for each data point. If we flatten all of the samples out, we can plot them and compare to the observed data to get a sense of whether our model is any good.
-
-```scala
-scala> plot2D(regr.sample().flatten)
-     110 |                                                                                
-         |                                                                               ·
-         |                                                                           ·   ·
-         |                                                                   ·   ·   ·   ·
-         |                                                               ·   ·   ·   ·   ·
-      82 |                                                           ·   ·   ·   ·   ·   ·
-         |                                                       ·   ·   ·   ·   ·   ·   ·
-         |                                           ·   ·   ·   ·   ·   ·   ·   ·   ·   ·
-         |                                       ·   ·   ·   ·   ·   ·   ·   ·   ∘   ∘   ∘
-         |                           ·           ·   ·   ·   ·   ·   ·   ·   ∘   ∘   ·   ·
-      55 |   ·               ·   ·   ·   ·   ·   ·   ·   ·   ·   ∘   ∘   ∘   ∘   ·   ·   ·
-         |·  ·   ·   ·   ·   ·   ·   ·   ·   ·   ·   ·   ·   ∘   ∘   ∘   ·   ·   ·   ·   ·
-         |·  ·   ·   ·   ·   ·   ·   ·   ·   ·   ·   ∘   ∘   ∘   ∘   ·   ·   ·   ·   ·   ·
-         |·  ·   ·   ·   ·   ·   ·   ·   ·   ∘   ∘   ∘   ∘   ·   ·   ·   ·   ·   ·   ·   ·
-         |·  ·   ·   ·   ·   ·   ·   ∘   ∘   ∘   ∘   ·   ·   ·   ·   ·   ·   ·   ·   ·   ·
-      27 |·  ·   ·   ·   ·   ·   ∘   ∘   ∘   ·   ·   ·   ·   ·   ·   ·   ·   ·   ·   ·   ·
-         |·  ·   ·   ·   ∘   ○   ∘   ∘   ·   ·   ·   ·   ·   ·   ·   ·   ·   ·   ·   ·   ·
-         |·  ·   ∘   ∘   ∘   ∘   ·   ·   ·   ·   ·   ·   ·   ·   ·   ·   ·                
-         |·  ○   ○   ∘   ·   ·   ·   ·   ·   ·                                            
-         |○  ∘   ·   ·   ·   ·                                                            
-       0 |∘  ·   ·   ·   ·                                                                
-         |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        0.0      2.3      4.5      6.8      9.0      11.3     13.6     15.8     18.1  
-```
-
-Although there's a lot of uncertainty, you can see the dense line down the middle matches fairly closely to the observed data, so our model isn't totally off-base. We can also learn something by plotting the slope vs the intercept. (Rather than redefining everything as we did in the previous section, we'll use `zip` to sneak the parameters back in to the fully-specified model.)
+As before, we're starting out by just sampling the parameters. By plotting them, we can see that the model's confidence in the intercept, in particular, is pretty low: although it's most likely to be somewhere around 8, it could be anywhere from 3 to 13 or even higher. Second, as you'd hope, the two parameters are anti-correlated: a smaller intercept would imply a higher slope, and vice versa.
 
 ```scala
-scala> val regr2 = regr.zip(prior).map(_._2)
-regr2: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@408b35b1
-
-scala> plot2D(regr2.sample())
-      44 |                                                                                
+scala> plot2D(regr.sample())
+    15.1 |                                                                                
          |·                                                                               
-         |···                                                                             
-         |···                                                                             
-         |··· ··                                                                          
-      33 |· ···                                                                           
-         |  ···· ·           ·                                                            
-         |     ·  ·                                                                       
-         |      ·              ·                                                          
-         |          ·                                                                     
-      23 |         · ·                                                                    
-         |          ·    ·                                                                
-         |               ·                                                                
-         |                  ··       ·                                                    
-         |                   · ·                                                          
-      13 |                       ·          ·     ·  ·· ··                                
-         |                            ·     ·· ·   ·············                          
-         |                                   ·    · ···············  ·  ·                ·
-         |                                        ·  ·······∘○○○○∘····· ·                 
-         |                                                ·····∘∘∘∘∘∘·····                
-       3 |                                                    ··············              
+         |    ·             ·  ·                                                          
+         |·   ·    ·····       ·  ·                                                       
+         |   ·  ········· ······ · ··     ·                                               
+    12.1 |  ·   · ··· ··················· · · ·                                           
+         |         · ······················ · ····    ·                                   
+         |   ·     ···· ··························· ·                                     
+         |          ··· ······························                                    
+         |          · · ···········∘∘··∘∘∘∘∘∘············· ·   ·                          
+     9.2 |            · ··········∘∘·∘∘∘∘∘○∘∘∘∘·∘·········· ·    ·                        
+         |                 ··········∘∘∘∘○∘○∘○∘∘○∘∘∘∘···········  ··                      
+         |                   ·········∘∘·∘○∘∘○∘○∘○○○∘∘∘∘·········· ·· · ·                 
+         |                ··  ··········∘∘∘∘∘○∘∘○∘○○∘○∘∘∘∘··········· ··  ·               
+         |                      ···········∘·∘○∘○∘○○○∘∘○○·∘············· ·· ·     ·       
+     6.2 |                           ··········∘·∘∘∘·∘∘∘∘∘∘∘··············  ··            
+         |                         ··    ··········∘∘·∘··∘∘∘∘············· ·  ·  ·        
+         |                                 · · ··························· · ··    ·      
+         |                                       ······························           
+         |                                       ·    ··· ···· ·· ······ · ·       ·      
+     3.3 |                                            ·        ·  ·  · ·   ·· ·· ·       ·
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        0.00     0.53     1.06     1.59     2.12     2.65     3.18     3.72     4.25  
+        2.42     2.60     2.78     2.96     3.14     3.32     3.49     3.67     3.85  
 ```
 
-There are two things to see here. First, the tails are very wide: although there's the greatest density with a small slope and intercept, the model can't rule out that one of them is quite large. Second, as you'd hope, the two parameters are anti-correlated: a large slope necessarily implies a small intercept, and vice-versa.
-
-Alternatively, as before, we could try to predict what will happen tomorrow. Let's recreate the whole model again this time for maximum clarity, and ask the predictor to generate a value for day 21 (having given it days 0 through 20).
+Alternatively, as in the earlier example, we could try to predict what will happen tomorrow. This is similar to calling `poisson.generator` before, but this time, we use the `predict` method on `Predictor`, which takes the covariate (the day, in this case), and returns a `Generator` for the dependent variable (the number of sales). Putting it all together, it looks like this:
 
 ```scala
-scala> val regr3 = for {
+scala> val regr2 = for {
      |     slope <- LogNormal(0,1).param
      |     intercept <- LogNormal(0,1).param
-     |     predictor = Predictor.from{i: Int => Poisson(intercept + slope*i)}
-     |     _ <- predictor.fit(data)
+     |     predictor <- Predictor.from{i: Int => 
+     |                     Poisson(intercept + slope*i)
+     |                 }.fit(data)
      | } yield predictor.predict(21)
-regr3: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@5210553a
+regr2: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@59ce705b
 ```
 
-Plotting this is a bit ugly because of binning artifacts, but it's interesting to see the secondary mode down around 38, which represents the small chance that there was a very high intercept but basically no slope, and all the variation in the original data was just noise.
+Plotting this gives us a prediction which incorporates both the natural noise of a poisson distribution and our uncertainty about its underlying parameterization.
 
 ```scala
-scala> plot1D(regr3.sample())
-     840 |                                                                                
-         |                                             ∘                                  
-         |                                             ○                                  
-         |                                        ∘    ○                                  
-         |                                        ○    ○                                  
-     630 |                                        ○    ○                                  
-         |                                        ○    ○     ·                            
-         |                                        ○    ○     ○                            
-         |                                        ○    ○     ○                            
-         |                                        ○    ○     ○                            
-     420 |                                        ○ ·· ○     ○                            
-         |                                        ○·○○·○∘    ○                            
-         |                                  ○     ○○○○○○○∘∘  ○                            
-         |                                  ○   ·∘○○○○○○○○○∘ ○                            
-         |                                  ○ · ○○○○○○○○○○○○○○                            
-     210 |                                  ○ ○○○○○○○○○○○○○○○○·    ∘                      
-         |                                  ○∘○○○○○○○○○○○○○○○○○∘∘ ·○                      
-         |                                · ○○○○○○○○○○○○○○○○○○○○○∘○○                      
-         |                              ··○○○○○○○○○○○○○○○○○○○○○○○○○○                      
-         |           ·     ·          ∘∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘∘··∘                 
-       0 |·······∘·∘∘○∘∘∘∘∘○∘∘∘∘∘··∘∘∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘∘·······  ·    ·
+scala> plot1D(regr2.sample())
+     470 |                                                                                
+         |                                     ∘                                          
+         |                                ∘○∘∘∘○                                          
+         |                               ·○○○○○○                                          
+         |                            ∘∘ ○○○○○○○○                                         
+     350 |                            ○○ ○○○○○○○○○ ○                                      
+         |                           ∘○○ ○○○○○○○○○ ○                                      
+         |                           ○○○ ○○○○○○○○○ ○○ ·                                   
+         |                          ○○○○ ○○○○○○○○○ ○○·○                                   
+         |                         ·○○○○ ○○○○○○○○○ ○○○○                                   
+     230 |                        ·○○○○○ ○○○○○○○○○ ○○○○∘·                                 
+         |                      ∘ ○○○○○○ ○○○○○○○○○ ○○○○○○·                                
+         |                      ○○○○○○○○ ○○○○○○○○○ ○○○○○○○                                
+         |                     ∘○○○○○○○○ ○○○○○○○○○ ○○○○○○○                                
+         |                   · ○○○○○○○○○ ○○○○○○○○○ ○○○○○○○·∘                              
+     110 |                   ○ ○○○○○○○○○ ○○○○○○○○○ ○○○○○○○○○ ∘                            
+         |                  ·○ ○○○○○○○○○ ○○○○○○○○○ ○○○○○○○○○ ○·                           
+         |                ∘∘○○ ○○○○○○○○○ ○○○○○○○○○ ○○○○○○○○○ ○○∘·                         
+         |             ·∘∘○○○○ ○○○○○○○○○ ○○○○○○○○○ ○○○○○○○○○ ○○○○∘                        
+         |            ∘○○○○○○○ ○○○○○○○○○ ○○○○○○○○○ ○○○○○○○○○ ○○○○○∘○·· ·                  
+       0 |·········○ ○○○○○○○○○ ○○○○○○○○○ ○○○○○○○○○ ○○○○○○○○○ ○○○○○○○○○ ○∘∘······ ·· ·    ·
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-         22       32       43       53       64       74       85       96      106   
+        43.0     51.1     59.2     67.3     75.4     83.6     91.7     99.8    107.9  
 ```
 
 Finally, let's close with a small and somewhat contrived example of a hierarchical model, where we have two separate regressions that share a parameter. For the sake of the example, let's assume that we have a second sales dataset, much like the first, where we know they had the same rate at the start of the observations, but may have grown at different rates - so their intercepts will be equal but their slopes will not. Here's the data:
@@ -534,45 +518,45 @@ data2: List[(Int, Int)] = List((0,9), (1,2), (2,3), (3,17), (4,21), (5,12), (6,2
 It's straightforward to set up two separate slopes, two separate predictor, but the same interecept. We'll still just sample the first slope so we can compare to the previous model.
 
 ```scala
-scala> val regr4 = for {
+scala> val regr3 = for {
      |     slope1 <- LogNormal(0,1).param
      |     slope2 <- LogNormal(0,1).param
      |     intercept <- LogNormal(0,1).param
-     |     _ <- Predictor.from{i: Int => Poisson(intercept + slope1*i)}.fit(data)
-     |     _ <- Predictor.from{i: Int => Poisson(intercept + slope2*i)}.fit(data2)
+     |     pred1 <- Predictor.from{i: Int => Poisson(intercept + slope1*i)}.fit(data)
+     |     pred2 <- Predictor.from{i: Int => Poisson(intercept + slope2*i)}.fit(data2)
      | } yield (slope1, intercept)
-regr4: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@51e2ddf1
+regr3: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@12980f7a
 ```
 
-Plotting slope vs intercept now, we can see that, even though these are two separate regressions, we get tighter bounds than before by letting the new data influence the shared parameter:
+Plotting slope vs intercept now, we can see that, even though these are two separate regressions, we get tighter bounds than before by letting the new data influence the shared parameter. It makes sense that we'd get more confidence on the intercept, since we have two different time series to learn from now; but because of the anti-correlation, that also leads to somewhat more confidence than before on the `slope1` parameter as well.
 
 ```scala
-scala> plot2D(regr4.sample())
-      26 |                                                                                
-         |·                                                                               
-         |··                                                                              
-         | ··                       ·                                                     
-         |   ·                       ·                                                    
-      20 |                                                                                
-         |                                                                                
-         |                                                                                
-         |                                                                                
-         |                                                                                
-      14 |                                                                                
-         |                                                                                
-         |                                                                                
-         |                                                                                
-         |                                                                                
-       9 |                                                   · ················           
-         |                                                    ····················        
-         |                                                     ·······∘∘∘∘∘∘∘∘·······  ·  
-         |                                                        ······∘∘∘○○○∘∘∘········ 
-         |                                                       ·· ··········∘∘··········
-       3 |                                                                ··············· 
+scala> plot2D(regr3.sample())
+    10.8 |                                                                                
+         |         ·       ·                                                              
+         | ·   ·   · ··    ·   ·                                                          
+         |  · ··    ····   · ·  · ·                                                       
+         |   ·   ············· ··· ····                                                   
+     8.9 |     ····· ······················  ·   ·                                        
+         |·  ··   ······························   · ·  ··                                
+         |·  · · ······························· ··· ·  ·····                             
+         |   ··· ················∘∘∘∘····················   ·               ·             
+         |·  · ·  ·············∘·∘∘·∘∘·∘∘∘·∘···················   ··                      
+     7.0 |       ··············∘·∘·∘∘∘∘○∘∘∘∘∘∘∘∘··∘·∘···············  ·    ·              
+         | ·   · · ··  ·········∘∘∘∘∘∘∘○∘∘○○∘○∘○∘∘∘∘·∘··············   ··                 
+         |       ·   ···· ·····∘··∘·∘∘∘○∘∘∘○∘○○∘○∘·∘∘∘∘·∘············ ···· ·  ·           
+         |             ··············∘·∘∘∘∘∘∘○○○∘○∘∘∘∘∘∘∘∘∘·∘············· ·     ·        
+         |            ···· ·············∘·∘∘∘∘○∘○∘∘∘∘○∘∘·∘·∘∘··············· ···          
+     5.1 |               ·  ·  · ···············∘∘∘·○·∘·∘∘···∘············· ···  ·        
+         |                   ·  · ·· · ·································· ····· ···       
+         |                         · ·  ···························· ······ · ··          
+         |                               ·  ·   ·  ········ ····· ·········· · · ·     · ·
+         |                                        ·  ···  · ··    ·      ·    ·      ··   
+     3.2 |                                        ·     · ·  ·         ··   ·             
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        0.71     1.06     1.41     1.77     2.12     2.47     2.83     3.18     3.53  
+        2.79     2.92     3.05     3.19     3.32     3.46     3.59     3.72     3.86  
 ```
 
 ## Learning More
 
-This tour has focused on the high-level API. If you want to understand more about what's going on under the hood, you might enjoy reading the [implementation notes](impl.md). If you want to learn more about Bayesian modeling in general, [Cam Davidson Pilon's book](http://camdavidsonpilon.github.io/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers/) is an excellent resource - the examples are in Python, but porting them to Rainier is a good learning exercise. Over time, we hope to add more Rainier-specific documentation and community resources; for now, feel free to file a [GitHub issue](https://github.com/stripe/rainier/issues) with any questions or problems.
+This tour has focused on the high-level API. If you want to understand more about what's going on under the hood, you might enjoy reading about [Real](real.md) or checking out some [implementation notes](impl.md). If you want to learn more about Bayesian modeling in general, [Cam Davidson Pilon's book](http://camdavidsonpilon.github.io/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers/) is an excellent resource - the examples are in Python, but porting them to Rainier is a good learning exercise. Over time, we hope to add more Rainier-specific documentation and community resources; for now, feel free to file a [GitHub issue](https://github.com/stripe/rainier/issues) with any questions or problems.

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Distribution.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Distribution.scala
@@ -11,10 +11,10 @@ trait Distribution[T] extends Likelihood[T] { self =>
 
   def generator: Generator[T]
 
-  def fit(t: T): RandomVariable[Generator[T]] =
-    RandomVariable(generator, logDensity(t))
-  override def fit(list: Seq[T]): RandomVariable[Generator[Seq[T]]] =
-    RandomVariable(generator.repeat(list.size), logDensities(list))
+  def fit(t: T): RandomVariable[Distribution[T]] =
+    RandomVariable(this, logDensity(t))
+  def fit(list: Seq[T]): RandomVariable[Distribution[T]] =
+    RandomVariable(this, logDensities(list))
 }
 
 /**

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Likelihood.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Likelihood.scala
@@ -4,11 +4,6 @@ package com.stripe.rainier.core
   * Likelihood trait, declaring the `fit` method for conditioning
   */
 trait Likelihood[T] {
-  def fit(t: T): RandomVariable[Generator[T]]
-  def fit(seq: Seq[T]): RandomVariable[Generator[Seq[T]]] = {
-    val rvs: Seq[RandomVariable[Generator[T]]] = seq.map(fit)
-    RandomVariable.traverse(rvs).map { gens: Seq[Generator[T]] =>
-      Generator.traverse(gens)
-    }
-  }
+  def fit(t: T): RandomVariable[Likelihood[T]]
+  def fit(seq: Seq[T]): RandomVariable[Likelihood[T]]
 }

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Predictor.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Predictor.scala
@@ -7,14 +7,13 @@ abstract class Predictor[X, Y, Z](implicit ev: Z <:< Distribution[Y])
     extends Likelihood[(X, Y)] {
   def apply(x: X): Z
 
-  def fit(pair: (X, Y)): RandomVariable[Generator[(X, Y)]] = {
-    val (x, y) = pair
-    ev(apply(x)).fit(y).map { g =>
-      g.map { yy =>
-        (x, yy)
-      }
-    }
-  }
+  def fit(pair: (X, Y)): RandomVariable[Predictor[X,Y,Z]] =
+    RandomVariable(this, ev(apply(pair._1)).logDensity(pair._2))
+
+  def fit(seq: (X, Y)): RandomVariable[Predictor[X,Y,Z]] =
+    RandomVariable(this, Real.sum(seq.map{case (x,y) => ev(apply(x)).logDensity(y)))
+
+  def predict(x: X): Generator[Y] = ev(apply(x)).generator
 
   def predict(seq: Seq[X]): Generator[Seq[(X, Y)]] =
     Generator.traverse(seq.map { x =>
@@ -22,8 +21,6 @@ abstract class Predictor[X, Y, Z](implicit ev: Z <:< Distribution[Y])
         (x, y)
       }
     })
-
-  def predict(x: X): Generator[Y] = ev(apply(x)).generator
 }
 
 /**

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Predictor.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Predictor.scala
@@ -1,5 +1,7 @@
 package com.stripe.rainier.core
 
+import com.stripe.rainier.compute._
+
 /**
   * Predictor class, for fitting data with covariates
   */
@@ -7,11 +9,13 @@ abstract class Predictor[X, Y, Z](implicit ev: Z <:< Distribution[Y])
     extends Likelihood[(X, Y)] {
   def apply(x: X): Z
 
-  def fit(pair: (X, Y)): RandomVariable[Predictor[X,Y,Z]] =
+  def fit(pair: (X, Y)): RandomVariable[Predictor[X, Y, Z]] =
     RandomVariable(this, ev(apply(pair._1)).logDensity(pair._2))
 
-  def fit(seq: (X, Y)): RandomVariable[Predictor[X,Y,Z]] =
-    RandomVariable(this, Real.sum(seq.map{case (x,y) => ev(apply(x)).logDensity(y)))
+  def fit(seq: Seq[(X, Y)]): RandomVariable[Predictor[X, Y, Z]] =
+    RandomVariable(this, Real.sum(seq.map {
+      case (x, y) => ev(apply(x)).logDensity(y)
+    }))
 
   def predict(x: X): Generator[Y] = ev(apply(x)).generator
 

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/RandomVariable.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/RandomVariable.scala
@@ -88,6 +88,13 @@ class RandomVariable[+T](val value: T,
 
   val density: Real =
     Real.sum(densities.toList.map(_.toReal))
+
+  //this is really just here to allow destructuring in for{}
+  def withFilter(fn: T => Boolean): RandomVariable[T] =
+    if (fn(value))
+      this
+    else
+      RandomVariable(value, Real.zero.log)
 }
 
 /**

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/RandomVariable.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/RandomVariable.scala
@@ -42,9 +42,20 @@ class RandomVariable[+T](val value: T,
     sampleable.get(value)(rng, num)
 
   def sample[V]()(implicit rng: RNG, sampleable: Sampleable[T, V]): List[V] =
-    sample(Sampler.Default.sampler,
-           Sampler.Default.warmupIterations,
-           Sampler.Default.iterations)
+    sample(Sampler.Default.iterations)
+
+  def sample[V](iterations: Int)(implicit rng: RNG,
+                                 sampleable: Sampleable[T, V]): List[V] =
+    if (density.variables.isEmpty) {
+      val fn = sampleable.prepare(value, density.variables)
+      1.to(iterations).toList.map { _ =>
+        fn(Array.empty[Double])
+      }
+    } else {
+      sample(Sampler.Default.sampler,
+             Sampler.Default.warmupIterations,
+             iterations)
+    }
 
   def sample[V](sampler: Sampler,
                 warmupIterations: Int,

--- a/rainier-core/src/main/scala/com/stripe/rainier/sampler/Sampler.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/sampler/Sampler.scala
@@ -93,9 +93,9 @@ object Diagnostics {
 
 object Sampler {
   object Default {
-    val sampler: Walkers = Walkers(100)
+    val sampler: Sampler = HMC(5)
     val iterations: Int = 10000
-    val warmupIterations: Int = 10000
+    val warmupIterations: Int = 100000
   }
 
   def diagnostics(chains: List[List[Array[Double]]]): List[Diagnostics] = {


### PR DESCRIPTION
This is theoretically a breaking change, though I suspect very little if any code in the wild will be affected.

Previously, `fit` returned a `RandomVariable[Generator[T]]`, with the idea being that it would be a generator of synthetic data from the posterior that was equivalent, as closely as possible, to the observations passed into `fit`.

I originally made this choice because it seemed like the only useful thing that could be *generically* returned from `fit`; my reasoning was that all you could do with a generic `Likelihood[T]` was call `fit` on it again, which you have no reason to do, whereas even if that generator wasn't always useful (or even usually useful) it was better than nothing.

There were two problems with this reasoning:
* if you have large number of observations, it turns out it can be extremely expensive to create the `Generator`, which is really lame if you're just going to throw it away (which you almost certainly are going to do in that specific case)
* Scala's type system is smarter than I gave it credit for, and if `Distribution[T]` and `Predictor[T]` provide narrower return types in their implementation of `fit`, then those will be respected at the call site. This means that it *is* useful to return `RandomVariable(this, likelihood)` from `fit`, because you have can have a less-generic type attached to `this`, and can do useful things with it (like call `generator` in the `Distribution` case or call `predict` in the `Predictor` case).

This change includes a significant update to `tour.md` to explain the new API. As part of doing this, I decided to switch the default `Sampler` from `Walkers` to `HMC`, since I was getting better plots in the tour output by doing that.