### PR TITLE
Add the Beta distribution.

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala
@@ -147,7 +147,7 @@ object Exponential {
 object Beta {
   def apply(a: Real, b: Real): Continuous = new Continuous {
     def realLogDensity(real: Real): Real =
-      If(real < 0, Real.negInfinity, If(real > 1, Real.negInfinity, betaDensity(real)))
+      Uniform.standard.realLogDensity(real) + betaDensity(real)
 
     def param: RandomVariable[Real] =
       Uniform.standard.param.flatMap { u =>

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala
@@ -161,7 +161,7 @@ object Beta {
       RandomVariable(logistic, density)
     }
 
-    def generator: Generator[Double] =
+    val generator: Generator[Double] =
       Gamma(a, 1).generator.zip(Gamma(b, 1).generator).map {
         case (z1, z2) =>
           z1 / (z1 + z2)

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala
@@ -161,11 +161,11 @@ object Beta {
       RandomVariable(logistic, density)
     }
 
-    def generator: Generator[Double] = Generator.require(Set(a, b)) { (r, n) =>
-      val z1 = Gamma(a, 1).generator.get(r, n)
-      val z2 = Gamma(b, 1).generator.get(r, n)
-      z1 / (z1 + z2)
-    }
+    def generator: Generator[Double] =
+      Gamma(a, 1).generator.zip(Gamma(b, 1).generator).map {
+        case (z1, z2) =>
+          z1 / (z1 + z2)
+      }
   }
 }
 

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala
@@ -148,10 +148,10 @@ object Beta {
   def apply(a: Real, b: Real): Continuous = new Continuous {
     def realLogDensity(p: Real): Real =
       If(p < 0,
-        Real.zero.log,
-        If(p > 1,
-          Real.zero.log,
-          (a - 1) * p.log + (b - 1) * (1 - p).log - Combinatrics.beta(a, b)))
+         Real.zero.log,
+         If(p > 1,
+            Real.zero.log,
+            (a - 1) * p.log + (b - 1) * (1 - p).log - Combinatrics.beta(a, b)))
 
     def param: RandomVariable[Real] = {
       val x = new Variable

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala
@@ -148,9 +148,9 @@ object Beta {
   def apply(a: Real, b: Real): Continuous = new Continuous {
     def realLogDensity(p: Real): Real =
       If(p < 0,
-         Real.zero.log,
+         Real.negInfinity,
          If(p > 1,
-            Real.zero.log,
+            Real.negInfinity,
             (a - 1) * p.log + (b - 1) * (1 - p).log - Combinatrics.beta(a, b)))
 
     def param: RandomVariable[Real] = {

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala
@@ -146,26 +146,22 @@ object Exponential {
   */
 object Beta {
   def apply(a: Real, b: Real): Continuous = new Continuous {
-    def realLogDensity(p: Real): Real =
-      If(p < 0,
-         Real.negInfinity,
-         If(p > 1,
-            Real.negInfinity,
-            (a - 1) * p.log + (b - 1) * (1 - p).log - Combinatrics.beta(a, b)))
+    def realLogDensity(real: Real): Real =
+      If(real < 0, Real.negInfinity, If(real > 1, Real.negInfinity, betaDensity(real)))
 
-    def param: RandomVariable[Real] = {
-      val x = new Variable
-      val logistic = Real.one / (Real.one + (x * -1).exp)
-      val logisticJacobian = logistic * (1 - logistic)
-      val density = realLogDensity(logistic) + logisticJacobian.log
-      RandomVariable(logistic, density)
-    }
+    def param: RandomVariable[Real] =
+      Uniform.standard.param.flatMap { u =>
+        RandomVariable(u, betaDensity(u))
+      }
 
     val generator: Generator[Double] =
       Gamma(a, 1).generator.zip(Gamma(b, 1).generator).map {
         case (z1, z2) =>
           z1 / (z1 + z2)
       }
+
+    private def betaDensity(u: Real): Real =
+      (a - 1) * u.log + (b - 1) * (1 - u).log - Combinatrics.beta(a, b)
   }
 }
 

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Distribution.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Distribution.scala
@@ -22,8 +22,9 @@ trait Distribution[T] extends Likelihood[T] { self =>
   */
 object Combinatrics {
   def gamma(z: Real): Real = {
-    val w = (z + 1) + (Real.one / ((12 * (z + 1)) - (Real.one / (10 * (z + 1)))))
-    (Real(Math.PI * 2).log / 2) - ((z + 1).log / 2) + ((z + 1) * (w.log - 1)) - z.log
+    val v = z + 1
+    val w = v + (Real.one / ((12 * v) - (Real.one / (10 * v))))
+    (Real(Math.PI * 2).log / 2) - (v.log / 2) + (v * (w.log - 1)) - z.log
   }
 
   def beta(a: Real, b: Real): Real =

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Distribution.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Distribution.scala
@@ -22,8 +22,8 @@ trait Distribution[T] extends Likelihood[T] { self =>
   */
 object Combinatrics {
   def gamma(z: Real): Real = {
-    val w = z + (Real.one / ((12 * z) - (Real.one / (10 * z))))
-    (Real(Math.PI * 2).log / 2) - (z.log / 2) + (z * (w.log - 1))
+    val w = (z + 1) + (Real.one / ((12 * (z + 1)) - (Real.one / (10 * (z + 1)))))
+    (Real(Math.PI * 2).log / 2) - ((z + 1).log / 2) + ((z + 1) * (w.log - 1)) - z.log
   }
 
   def beta(a: Real, b: Real): Real =

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Distribution.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Distribution.scala
@@ -22,6 +22,10 @@ trait Distribution[T] extends Likelihood[T] { self =>
   */
 object Combinatrics {
   def gamma(z: Real): Real = {
+    // This is Gergő Nemes' approximation to the log Gamma function, plus a trick taken from Boost's lgamma function:
+    // since the Nemes approximation isn't very accurate for small z, we instead calculate LogGamma(z + 1) - Log(z).
+    // See https://en.wikipedia.org/wiki/Stirling%27s_approximation and
+    // https://www.boost.org/doc/libs/1_50_0/libs/math/doc/sf_and_dist/html/math_toolkit/special/sf_gamma/lgamma.html.
     val v = z + 1
     val w = v + (Real.one / ((12 * v) - (Real.one / (10 * v))))
     (Real(Math.PI * 2).log / 2) - (v.log / 2) + (v * (w.log - 1)) - z.log

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Generator.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Generator.scala
@@ -21,6 +21,12 @@ trait Generator[T] { self =>
     def get(implicit r: RNG, n: Numeric[Real]): U = fn(self.get).get
   }
 
+  def zip[U](other: Generator[U]): Generator[(T, U)] =
+    for {
+      t <- this
+      u <- other
+    } yield (t, u)
+
   def repeat(k: Int): Generator[Seq[T]] = new Generator[Seq[T]] {
     val requirements: Set[Real] = self.requirements
     def get(implicit r: RNG, n: Numeric[Real]): Seq[T] = 0.until(k).map { i =>

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Generator.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Generator.scala
@@ -21,11 +21,10 @@ trait Generator[T] { self =>
     def get(implicit r: RNG, n: Numeric[Real]): U = fn(self.get).get
   }
 
-  def zip[U](other: Generator[U]): Generator[(T, U)] =
-    for {
-      t <- this
-      u <- other
-    } yield (t, u)
+  def zip[U](other: Generator[U]): Generator[(T, U)] = new Generator[(T, U)] {
+    val requirements: Set[Real] = self.requirements ++ other.requirements
+    def get(implicit r: RNG, n: Numeric[Real]): (T, U) = (self.get, other.get)
+  }
 
   def repeat(k: Int): Generator[Seq[T]] = new Generator[Seq[T]] {
     val requirements: Set[Real] = self.requirements


### PR DESCRIPTION
Here's the Beta distribution!

I've also added a tweak to `Combinatrics.gamma` suggested by Boost's lgamma function: https://www.boost.org/doc/libs/1_50_0/libs/math/doc/sf_and_dist/html/math_toolkit/special/sf_gamma/lgamma.html. Our existing approximation to the log gamma function isn't very accurate when z is small, but amusingly, there's an easy fix: just do lgamma(z + 1) - log(z)!