### PR TITLE
Some exact gamma cases, etc

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Real.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Real.scala
@@ -67,6 +67,7 @@ object Real {
   private[compute] val BigTwo = BigDecimal(2.0)
   val zero: Real = Constant(BigZero)
   val one: Real = Constant(BigOne)
+  val two: Real = Constant(BigTwo)
   val infinity: Real = Infinity
   val negInfinity: Real = NegInfinity
 }

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Real.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Real.scala
@@ -152,7 +152,7 @@ final case class If private (test: NonConstant,
     extends NonConstant
 
 object If {
-  def apply(test: Real, whenNonZero: Real, whenZero: Real): Real =
+  def apply(test: Real, whenNonZero: => Real, whenZero: => Real): Real =
     test match {
       case Constant(Real.BigZero)               => whenZero
       case Constant(_) | Infinity | NegInfinity => whenNonZero

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/RealOps.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/RealOps.scala
@@ -30,7 +30,7 @@ private[compute] object RealOps {
                 "Cannot take the log of " + value.toDouble)
             else
               Real(Math.log(value.toDouble))
-          case AbsOp => Real(Math.abs(value.toDouble))
+          case AbsOp => Real(value.abs)
         }
       case nc: NonConstant =>
         val opt = (op, nc) match {

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/RealOps.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/RealOps.scala
@@ -6,12 +6,30 @@ private[compute] object RealOps {
 
   def unary(original: Real, op: UnaryOp): Real =
     original match {
-      case Infinity    => Infinity
-      case NegInfinity => NegInfinity
+      case Infinity => Infinity
+      case NegInfinity =>
+        op match {
+          case ExpOp => Real.zero
+          case LogOp =>
+            throw new ArithmeticException(
+              "Cannot take the log of a negative number")
+          case AbsOp => Infinity
+        }
+      case Constant(Real.BigZero) =>
+        op match {
+          case ExpOp => Real.one
+          case LogOp => NegInfinity
+          case AbsOp => Real.zero
+        }
       case Constant(value) =>
         op match {
           case ExpOp => Real(Math.exp(value.toDouble))
-          case LogOp => Real(Math.log(value.toDouble))
+          case LogOp =>
+            if (value.toDouble < 0)
+              throw new ArithmeticException(
+                "Cannot take the log of " + value.toDouble)
+            else
+              Real(Math.log(value.toDouble))
           case AbsOp => Real(Math.abs(value.toDouble))
         }
       case nc: NonConstant =>

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Distribution.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Distribution.scala
@@ -18,18 +18,17 @@ trait Distribution[T] extends Likelihood[T] { self =>
 }
 
 /**
-  * Combinatoric functions required for log density calculations. Note that they all return the log of the function described.
+  * Combinatoric functions useful in log density calculations.
+  * Note that they all return the log of the function described.
   */
 object Combinatorics {
-  def gamma(z: Real): Real = {
-    // This is Gergő Nemes' approximation to the log Gamma function, plus a trick taken from Boost's lgamma function:
-    // since the Nemes approximation isn't very accurate for small z, we instead calculate LogGamma(z + 1) - Log(z).
-    // See https://en.wikipedia.org/wiki/Stirling%27s_approximation and
-    // https://www.boost.org/doc/libs/1_50_0/libs/math/doc/sf_and_dist/html/math_toolkit/special/sf_gamma/lgamma.html.
-    val v = z + 1
-    val w = v + (Real.one / ((12 * v) - (Real.one / (10 * v))))
-    (Real(Math.PI * 2).log / 2) - (v.log / 2) + (v * (w.log - 1)) - z.log
-  }
+  def gamma(z: Real) =
+    if (z == Real.zero)
+      Real.infinity
+    else if (z == Real.one || z == Real.two)
+      Real.zero
+    else
+      approxGamma(z)
 
   def beta(a: Real, b: Real): Real =
     gamma(a) + gamma(b) - gamma(a + b)
@@ -38,4 +37,14 @@ object Combinatorics {
 
   def choose(n: Int, k: Int): Real =
     factorial(n) - factorial(k) - factorial(n - k)
+
+  private def approxGamma(z: Real): Real = {
+    // This is Gergő Nemes' approximation to the log Gamma function, plus a trick taken from Boost's lgamma function:
+    // since the Nemes approximation isn't very accurate for small z, we instead calculate LogGamma(z + 1) - Log(z).
+    // See https://en.wikipedia.org/wiki/Stirling%27s_approximation and
+    // https://www.boost.org/doc/libs/1_50_0/libs/math/doc/sf_and_dist/html/math_toolkit/special/sf_gamma/lgamma.html.
+    val v = z + 1
+    val w = v + (Real.one / ((12 * v) - (Real.one / (10 * v))))
+    (Real(Math.PI * 2).log / 2) - (v.log / 2) + (v * (w.log - 1)) - z.log
+  }
 }


### PR DESCRIPTION
cc @cqfd 

This is a bit of a grab bag of related numerical things.

* For gamma(0), gamma(1), and gamma(2), we return the exact values instead of the approximation. (Currently we just do this statically; we could also decide to make these checks dynamically, at a small performance cost).
* This allows us to use Beta(1,1) from Uniform without loss of performance or precision, which is satisfying. (We still special case the `generator` though).
* In the process if doing this, I noticed some other special cases we needed after the BigDecimal change; most notably, `Real.zero.log` would crash instead of returning `NegInfinity`. These are fixed.