### PR TITLE
introduce compute.Context

### DIFF
--- a/rainier-benchmark/src/main/scala/com/stripe/rainier/bench/RealBenchmark.scala
+++ b/rainier-benchmark/src/main/scala/com/stripe/rainier/bench/RealBenchmark.scala
@@ -20,19 +20,18 @@ abstract class RealBenchmark {
   protected def expression: Real
 
   val expr = expression
-  val vars = expr.variables
-  val grad = gradient
-  val cf = compile
+  val context = Context(expr)
+  val vars = context.variables
+  val grad = context.gradient
+  val cf = context.compiler.compile(vars, expr)
   val gf = compileGradient
 
   @Benchmark
   def build = expression
   @Benchmark
-  def gradient = expr.gradient
+  def gradient = Context(expr).gradient
   @Benchmark
-  def compile = Compiler.default.compile(vars, expr)
-  @Benchmark
-  def compileGradient = Compiler.default.compile(vars, grad)
+  def compileGradient = Context(expr).compiler.compile(vars, grad)
   @Benchmark
   def run =
     cf(vars.map { _ =>

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Compiler.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Compiler.scala
@@ -8,13 +8,6 @@ trait Compiler {
       array(0)
     }
 
-  def compileGradient(inputs: Seq[Variable],
-                      output: Real): Array[Double] => (Double, Array[Double]) =
-    compile(inputs, output :: Gradient.derive(inputs, output).toList).andThen {
-      array =>
-        (array.head, array.tail)
-    }
-
   def compile(inputs: Seq[Variable],
               outputs: Seq[Real]): Array[Double] => Array[Double] = {
     val cf = compileUnsafe(inputs, outputs)
@@ -29,10 +22,6 @@ trait Compiler {
 
   def compileUnsafe(inputs: Seq[Variable],
                     outputs: Seq[Real]): ir.CompiledFunction
-}
-
-object Compiler {
-  var default: Compiler = IRCompiler(200, 100, false)
 }
 
 final case class InstrumentingCompiler(orig: Compiler, printEvery: Int)

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Context.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Context.scala
@@ -1,0 +1,7 @@
+package com.stripe.rainier.compute
+
+case class Context(density: Real) {
+  val compiler: Compiler = IRCompiler(200, 100, false)
+  val variables: List[Variable] = RealOps.variables(density).toList
+  lazy val gradient: List[Real] = Gradient.derive(variables, density).toList
+}

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Real.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Real.scala
@@ -34,9 +34,6 @@ sealed trait Real {
   def <(other: Real): Real = RealOps.isNegative(this - other)
   def >=(other: Real): Real = Real.one - (this < other)
   def <=(other: Real): Real = Real.one - (this > other)
-
-  lazy val variables: Seq[Variable] = RealOps.variables(this).toList
-  def gradient: Seq[Real] = Gradient.derive(variables, this)
 }
 
 object Real {
@@ -50,16 +47,13 @@ object Real {
 
   //print out Scala code that is equivalent to what the Compiler
   //would produce as JVM bytecode
-  def trace(reals: Seq[Real]): Unit = {
+  def trace(real: Real): Unit = {
+    val context = Context(real)
     val translator = new Translator
-    val irs = reals.map { r =>
-      translator.toIR(r)
-    }
-    val params = reals.flatMap(_.variables.toSet).toList.map(_.param)
+    val irs = List(translator.toIR(real))
+    val params = context.variables.map(_.param)
     ir.Tracer.trace(params, irs)
   }
-
-  def trace(real: Real): Unit = trace(List(real))
 
   private[compute] val BigZero = BigDecimal(0.0)
   private[compute] val BigOne = BigDecimal(1.0)

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/SBC.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/SBC.scala
@@ -10,7 +10,6 @@ final case class SBC[T](priorGenerators: Seq[Generator[Double]],
 
   import SBC._
 
-  require(priorParams.forall(_.variables.size == 1))
   val priorGenerator = Generator.traverse(priorGenerators)
   val emptyEvaluator = new Evaluator(Map.empty)
 

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Sampleable.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Sampleable.scala
@@ -10,26 +10,26 @@ trait Sampleable[-S, +T] {
   def requirements(value: S): Set[Real]
   def get(value: S)(implicit r: RNG, n: Numeric[Real]): T
 
-  def prepare(value: S, variables: Seq[Variable])(
+  def prepare(value: S, context: Context)(
       implicit r: RNG): Array[Double] => T = {
     val reqs = requirements(value).toList
     if (reqs.isEmpty) { array =>
       {
         implicit val evaluator: Evaluator =
           new Evaluator(
-            variables
+            context.variables
               .zip(array)
               .toMap)
         get(value)
       }
     } else {
-      val cf = Compiler.default.compile(variables, reqs)
+      val cf = context.compiler.compile(context.variables, reqs)
       array =>
         {
           val reqValues = cf(array)
           implicit val evaluator: Evaluator =
             new Evaluator(
-              variables
+              context.variables
                 .zip(array)
                 .toMap ++
                 reqs.zip(reqValues).toMap

--- a/rainier-core/src/main/scala/com/stripe/rainier/sampler/HMC.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/sampler/HMC.scala
@@ -4,11 +4,11 @@ import com.stripe.rainier.compute._
 import scala.collection.mutable.ListBuffer
 
 final case class HMC(nSteps: Int) extends Sampler {
-  def sample(density: Real,
+  def sample(context: Context,
              warmupIterations: Int,
              iterations: Int,
              keepEvery: Int)(implicit rng: RNG): List[Array[Double]] = {
-    val lf = LeapFrog(density.variables.toList, density)
+    val lf = LeapFrog(context)
     val params = lf.initialize
     val stepSize =
       DualAvg.findStepSize(lf, params, 0.65, nSteps, warmupIterations)

--- a/rainier-core/src/main/scala/com/stripe/rainier/sampler/Sampler.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/sampler/Sampler.scala
@@ -4,7 +4,7 @@ import com.stripe.rainier.compute._
 import scala.annotation.tailrec
 
 trait Sampler {
-  def sample(density: Real,
+  def sample(context: Context,
              warmupIterations: Int,
              iterations: Int,
              keepEvery: Int)(implicit rng: RNG): List[Array[Double]]
@@ -109,4 +109,17 @@ object Sampler {
       Diagnostics(traces)
     }
   }
+
+  def sample(context: Context,
+             sampler: Sampler,
+             warmupIterations: Int,
+             iterations: Int,
+             keepEvery: Int)(implicit rng: RNG): List[Array[Double]] =
+    if (context.variables.isEmpty)
+      1.to(iterations / keepEvery).toList.map { _ =>
+        Array.empty[Double]
+      } else
+      sampler
+        .sample(context, warmupIterations, iterations, keepEvery)
+
 }

--- a/rainier-core/src/main/scala/com/stripe/rainier/sampler/Walkers.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/sampler/Walkers.scala
@@ -4,11 +4,11 @@ import com.stripe.rainier.compute._
 import scala.collection.mutable.ListBuffer
 
 final case class Walkers(walkers: Int) extends Sampler {
-  def sample(density: Real,
+  def sample(context: Context,
              warmupIterations: Int,
              iterations: Int,
              keepEvery: Int)(implicit rng: RNG): List[Array[Double]] = {
-    val initial = WalkersChain(density, density.variables, walkers)
+    val initial = WalkersChain(context, walkers)
     val warmedUp =
       1.to(warmupIterations)
         .foldLeft(initial) {

--- a/rainier-core/src/main/scala/com/stripe/rainier/sampler/WalkersChain.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/sampler/WalkersChain.scala
@@ -44,13 +44,13 @@ final private case class WalkersChain(cf: Array[Double] => Double,
 }
 
 private object WalkersChain {
-  def apply(density: Real, variables: Seq[Variable], nWalkers: Int)(
+  def apply(context: Context, nWalkers: Int)(
       implicit rng: RNG): WalkersChain = {
-    val cf = Compiler.default.compile(variables, density)
+    val cf = context.compiler.compile(context.variables, context.density)
     val walkers = 1
       .to(nWalkers)
       .map { _ =>
-        1.to(variables.size)
+        1.to(context.variables.size)
           .map { _ =>
             rng.standardNormal
           }

--- a/rainier-core/src/test/scala/com/stripe/rainier/compute/RealTest.scala
+++ b/rainier-core/src/test/scala/com/stripe/rainier/compute/RealTest.scala
@@ -8,7 +8,7 @@ class RealTest extends FunSuite {
     test(description) {
       val x = new Variable
       val result = fn(x)
-      val c = Compiler.default.compile(List(x), result)
+      val c = Context(result).compiler.compile(List(x), result)
       List(1.0, 0.0, -1.0, 2.0, -2.0, 0.5, -0.5).foreach { n =>
         val constant = Try { fn(Constant(n)) } match {
           case Success(Infinity)                 => 1.0 / 0.0

--- a/rainier-core/src/test/scala/com/stripe/rainier/core/RandomVariableTest.scala
+++ b/rainier-core/src/test/scala/com/stripe/rainier/core/RandomVariableTest.scala
@@ -19,7 +19,7 @@ class RandomVariableTest extends FunSuite {
 
   def sampleOnce[S, T](x: RandomVariable[S], paramValue: Double)(
       implicit s: Sampleable[S, T]): (T, Double) = {
-    val variables = x.density.variables
+    val variables = Context(x.density).variables
     implicit val num: Evaluator =
       new Evaluator(variables.map { v =>
         v -> paramValue


### PR DESCRIPTION
This is a small refactoring setting things up for some more consequential changes.

This introduces a `Context` object which wraps a `density` (or, more generally, some "output" `Real`), and provides a single bottleneck for performing static analysis on it - currently that means obtaining the `variables` and `gradient` for that real, and a `compiler` to compile it or related functions with.

For now this just delegates to the same implementations as before and doesn't provide any actual value. However, in the future I intend to use this as a place to more efficiently manage the various caches and lookup tables used in the analysis and compilation process.