### PR TITLE
Make Poisson generate non-negative numbers

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Discrete.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Discrete.scala
@@ -15,12 +15,14 @@ final case class Poisson(lambda: Real) extends Distribution[Int] {
   val generator: Generator[Int] =
     Generator.require(Set(lambda)) { (r, n) =>
       val l = math.exp(-n.toDouble(lambda))
-      var k = 0
-      var p = 1.0
-      while (p > l) {
-        k += 1
-        p *= r.standardUniform
+      if (l >= 1.0) { 0 } else {
+        var k = 0
+        var p = 1.0
+        while (p > l) {
+          k += 1
+          p *= r.standardUniform
+        }
+        k - 1
       }
-      k - 1
     }
 }


### PR DESCRIPTION
Previously, a `Poisson(0.0).generator` would return `-1`s. Now it returns `0`s.