### PR TITLE
use actual / on BigDecimal for constant divisions

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Real.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Real.scala
@@ -20,7 +20,7 @@ sealed trait Real {
   def *(other: Real): Real = RealOps.multiply(this, other)
 
   def -(other: Real): Real = this + (other * -1)
-  def /(other: Real): Real = this * other.pow(-1)
+  def /(other: Real): Real = RealOps.divide(this, other)
 
   def pow(exponent: Real): Real = RealOps.pow(this, exponent)
 

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/RealOps.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/RealOps.scala
@@ -90,6 +90,12 @@ private[compute] object RealOps {
         LogLineOps.multiply(LogLine(nc1), LogLine(nc2))
     }
 
+  def divide(left: Real, right: Real): Real =
+    (left, right) match {
+      case (Constant(x), Constant(y)) => Real(x / y)
+      case _                          => left * right.pow(-1)
+    }
+
   def pow(original: Real, exponent: Real): Real =
     exponent match {
       case Infinity       => Infinity

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/RealOps.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/RealOps.scala
@@ -92,6 +92,10 @@ private[compute] object RealOps {
 
   def divide(left: Real, right: Real): Real =
     (left, right) match {
+      case (Constant(Real.BigZero), Constant(Real.BigZero)) =>
+        throw new ArithmeticException(
+          "Cannot divide zero by zero")
+      case (_, Constant(Real.BigZero)) => left * Infinity
       case (Constant(x), Constant(y)) => Real(x / y)
       case _                          => left * right.pow(-1)
     }
@@ -120,6 +124,8 @@ private[compute] object RealOps {
           NegInfinity
         else
           Infinity
+      case (Constant(Real.BigZero), _) if exponent < 0 =>
+        Infinity
       case (Constant(v), _) => Real(pow(v, exponent))
       case (l: Line, _) =>
         LineOps.pow(l, exponent).getOrElse {

--- a/rainier-tests/src/test/scala/com/stripe/rainier/compute/RealTest.scala
+++ b/rainier-tests/src/test/scala/com/stripe/rainier/compute/RealTest.scala
@@ -92,4 +92,8 @@ class RealTest extends FunSuite {
   run("pow") { x =>
     x.pow(x)
   }
+
+  run("<") { x =>
+    Real(5.499999999999998) < x
+  }
 }


### PR DESCRIPTION
This adds a test for #159 as well as a simple fix.