### PR TITLE
Optimizer trait

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Context.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Context.scala
@@ -2,7 +2,8 @@ package com.stripe.rainier.compute
 
 case class Context(density: Real, placeholders: Seq[Variable]) {
   val compiler: Compiler = IRCompiler(200, 100, false)
-  val variables: List[Variable] = RealOps.variables(density).toList
+  val variables: List[Variable] =
+    RealOps.variables(density).toList.filterNot(placeholders.toSet)
   lazy val gradient: List[Real] = Gradient.derive(variables, density).toList
 }
 

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Context.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Context.scala
@@ -1,7 +1,11 @@
 package com.stripe.rainier.compute
 
-case class Context(density: Real) {
+case class Context(density: Real, placeholders: Seq[Variable]) {
   val compiler: Compiler = IRCompiler(200, 100, false)
   val variables: List[Variable] = RealOps.variables(density).toList
   lazy val gradient: List[Real] = Gradient.derive(variables, density).toList
+}
+
+object Context {
+  def apply(density: Real): Context = Context(density, Nil)
 }

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Categorical.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Categorical.scala
@@ -161,3 +161,15 @@ final case class BetaBinomial(a: Real, b: Real, k: Int)
       Binomial(p, k).generator
     }
 }
+
+object BetaBinomial {
+  def logDensity(a: Real, b: Real, k: Real, n: Real): Real = {
+    val choose =
+      Combinatorics.gamma(k + 1) -
+        Combinatorics.gamma(n + 1) -
+        Combinatorics.gamma(k - n + 1)
+    choose +
+      Combinatorics.beta(a + n, k - n + b) -
+      Combinatorics.beta(a, b)
+  }
+}

--- a/rainier-core/src/main/scala/com/stripe/rainier/sampler/Optimizer.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/sampler/Optimizer.scala
@@ -1,0 +1,9 @@
+package com.stripe.rainier.sampler
+
+import com.stripe.rainier.compute._
+
+trait Optimizer {
+  def optimize(context: Context,
+               batches: Array[Array[Double]],
+               iterations: Int): Array[Double]
+}

--- a/rainier-core/src/main/scala/com/stripe/rainier/sampler/Optimizer.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/sampler/Optimizer.scala
@@ -1,9 +1,9 @@
 package com.stripe.rainier.sampler
 
-import com.stripe.rainier.compute._
+import com.stripe.rainier.compute.Context
 
 trait Optimizer {
   def optimize(context: Context,
                batches: Array[Array[Double]],
-               iterations: Int): Array[Double]
+               iterations: Int)(implicit rng: RNG): Array[Double]
 }

--- a/rainier-core/src/main/scala/com/stripe/rainier/sampler/SGD.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/sampler/SGD.scala
@@ -1,0 +1,34 @@
+package com.stripe.rainier.sampler
+
+import com.stripe.rainier.compute.Context
+
+final case class SGD(stepSize: Double) extends Optimizer {
+  def optimize(context: Context,
+               batches: Array[Array[Double]],
+               iterations: Int)(implicit rng: RNG): Array[Double] = {
+    val state = new SGDState(context)
+
+    val batchBuf = new Array[Double](batches.size)
+    val nBatches = batches.head.size
+    var i = 0
+    while (i < iterations) {
+      var batch = 0
+      var err = 0.0
+      while (batch < nBatches) {
+        var col = 0
+        while (col < batchBuf.size) {
+          batchBuf(col) = batches(col)(batch)
+          col += 1
+        }
+        err += state.step(stepSize, batchBuf)
+        batch += 1
+      }
+
+      println(s"Epoch $i: ${err / nBatches}")
+
+      i += 1
+    }
+
+    state.parameters
+  }
+}

--- a/rainier-core/src/main/scala/com/stripe/rainier/sampler/SGDState.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/sampler/SGDState.scala
@@ -1,0 +1,35 @@
+package com.stripe.rainier.sampler
+
+import com.stripe.rainier.compute.Context
+
+private[sampler] class SGDState(context: Context)(implicit rng: RNG) {
+  val cf = context.compiler
+    .compileUnsafe(context.variables ++ context.placeholders,
+                   context.density :: context.gradient)
+  var inputBuf = new Array[Double](cf.numInputs)
+  val outputBuf = new Array[Double](cf.numOutputs)
+  val globalsBuf = new Array[Double](cf.numGlobals)
+
+  0.until(context.variables.size).foreach { i =>
+    inputBuf(i) = rng.standardNormal
+  }
+
+  def step(stepSize: Double, batch: Array[Double]): Double = {
+    val nVars = context.variables.size
+    var i = 0
+    while (i < batch.size) {
+      inputBuf(nVars + i) = batch(i)
+      i += 1
+    }
+    cf(inputBuf, globalsBuf, outputBuf)
+    i = 1
+    while (i < outputBuf.size) {
+      inputBuf(i - 1) += (outputBuf(i) * stepSize)
+      i += 1
+    }
+    outputBuf(0)
+  }
+
+  def parameters: Array[Double] =
+    inputBuf.take(context.variables.size)
+}

--- a/rainier-example/src/main/scala/com/stripe/rainier/example/SGD.scala
+++ b/rainier-example/src/main/scala/com/stripe/rainier/example/SGD.scala
@@ -4,17 +4,23 @@ import com.stripe.rainier.compute._
 import com.stripe.rainier.core._
 import com.stripe.rainier.sampler
 import com.stripe.rainier.repl._
-import scala.io.Source
 
 object SGD {
+  def hmcModel(data: List[(Int, Int)]): RandomVariable[(Real, Real)] =
+    for {
+      u <- Uniform(0, 1).param
+      v <- Exponential(0.1).param
+      _ <- Beta(u * v, (1 - u) * v).binomial.fit(data)
+    } yield (u, v)
+
   def model(data: List[(Int, Int)]): RandomVariable[(Real, Real)] =
     for {
-      a <- LogNormal(0, 1).param
-      b <- LogNormal(0, 1).param
+      u <- Uniform(0, 1).param
+      v <- Exponential(0.1).param
       _ <- fit(data, 100) { (k, n) =>
-        BetaBinomial.logDensity(a, b, k, n)
+        BetaBinomial.logDensity(u * v, (1 - u) * v, k, n)
       }
-    } yield (a, b)
+    } yield (u, v)
 
   //super hacky and manual
   def fit(data: List[(Int, Int)], batchSize: Int)(
@@ -45,19 +51,24 @@ object SGD {
   }
 
   def main(args: Array[String]): Unit = {
+    val trueU = 0.3
+    val trueV = 8
+
     val data: List[(Int, Int)] =
-      Source
-        .fromFile(args(0))
-        .getLines
-        .map { line =>
-          val parts = line.split("\t")
-          (parts(0).toInt, parts(1).toInt)
+      RandomVariable(Exponential(0.01).generator.map(_.toInt).flatMap { k =>
+        BetaBinomial(trueU * trueV, (1.0 - trueU) * trueV, k).generator.map {
+          n =>
+            (k, n)
         }
-        .toList
+      }).sample(100000)
 
     val m = model(data)
 
-    val (a, b) = m.optimize(sampler.SGD(0.001), 5)
-    println(s"Beta($a,$b)")
+    val (u, v) = m.optimize(sampler.SGD(0.00001), 20)
+    println((u, v))
+
+    val m2 = hmcModel(data.take(1000))
+    val samples = m2.sample(sampler.HMC(200), 1000, 1000)
+    plot2D(samples)
   }
 }

--- a/rainier-example/src/main/scala/com/stripe/rainier/example/SGD.scala
+++ b/rainier-example/src/main/scala/com/stripe/rainier/example/SGD.scala
@@ -11,10 +11,38 @@ object SGD {
     for {
       a <- LogNormal(0, 1).param
       b <- LogNormal(0, 1).param
-    //  _ <- data.fit(Predictor.from { k: Real =>
-        BetaBinomial(a, b, k)
-      })
+      _ <- fit(data, 100) { (k, n) =>
+        BetaBinomial.logDensity(a, b, k, n)
+      }
     } yield (a, b)
+
+  //super hacky and manual
+  def fit(data: List[(Int, Int)], batchSize: Int)(
+      fn: (Real, Real) => Real): RandomVariable[Unit] = {
+    val batchVariables = 1.to(batchSize).map { _ =>
+      (new Variable, new Variable)
+    }
+    val density = Real.sum(batchVariables.map(fn.tupled))
+    val buffers = 1.to(batchSize).map { _ =>
+      (new scala.collection.mutable.ArrayBuffer[Double],
+       new scala.collection.mutable.ArrayBuffer[Double])
+    }
+    data.grouped(batchSize).foreach { batch =>
+      if (batch.size == batchSize) {
+        batch.zip(buffers).foreach {
+          case ((k, n), (kBuf, nBuf)) =>
+            kBuf += k.toDouble
+            nBuf += n.toDouble
+        }
+      }
+    }
+    val columns =
+      batchVariables.zip(buffers).flatMap {
+        case ((kVar, nVar), (kBuf, nBuf)) =>
+          List((kVar, kBuf.toArray), (nVar, nBuf.toArray))
+      }
+    RandomVariable((), density, columns.toMap)
+  }
 
   def main(args: Array[String]): Unit = {
     val data: List[(Int, Int)] =

--- a/rainier-example/src/main/scala/com/stripe/rainier/example/SGD.scala
+++ b/rainier-example/src/main/scala/com/stripe/rainier/example/SGD.scala
@@ -1,0 +1,35 @@
+package com.stripe.rainier.example
+
+import com.stripe.rainier.compute._
+import com.stripe.rainier.core._
+import com.stripe.rainier.sampler
+import com.stripe.rainier.repl._
+import scala.io.Source
+
+object SGD {
+  def model(data: List[(Int, Int)]): RandomVariable[(Real, Real)] =
+    for {
+      a <- LogNormal(0, 1).param
+      b <- LogNormal(0, 1).param
+    //  _ <- data.fit(Predictor.from { k: Real =>
+        BetaBinomial(a, b, k)
+      })
+    } yield (a, b)
+
+  def main(args: Array[String]): Unit = {
+    val data: List[(Int, Int)] =
+      Source
+        .fromFile(args(0))
+        .getLines
+        .map { line =>
+          val parts = line.split("\t")
+          (parts(0).toInt, parts(1).toInt)
+        }
+        .toList
+
+    val m = model(data)
+
+    val (a, b) = m.optimize(sampler.SGD(0.001), 5)
+    println(s"Beta($a,$b)")
+  }
+}


### PR DESCRIPTION
This lays the low-level groundwork for mini-batch-based optimization rather than full sampling, including a very simple SGD example. Primarily, this includes:

- tracking "placeholder" variables (vs parameter variables) in `RandomVariable` along with columnar data for each one.
- ensuring that we don't bother with gradients on placeholder vars
- an `optimize` method on `RandomVariable` and an `Optimize` trait with a simple `SGD` implementation that can use those placeholder variables and columns of data to do mini-batch optimization

However, there is not yet any high-level API comparable to `Distribution.fit` for producing RVs that have placeholders, or density functions that make use of those placeholders. This is manually hacked together inside the `example.SGD` which is currently the only thing that exercises this code.