### PR TITLE
WIP: Mixture distributions

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala
@@ -28,7 +28,6 @@ trait Continuous extends Distribution[Double] {
     val paramSupport = support.transform(x)
 
     val logDensity = support.logJacobian(x) + realLogDensity(paramSupport)
-    // TODO: I removed `If isDefined` from here to speed up logDensity calls; check where it's necessary
 
     RandomVariable(paramSupport, logDensity)
   }

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala
@@ -27,11 +27,8 @@ trait Continuous extends Distribution[Double] {
 
     val paramSupport = support.transform(x)
 
-    val logDensity = If(
-      support.isDefinedAt(x),
-      support.logJacobian(x) + realLogDensity(paramSupport),
-      Real.negInfinity
-    )
+    val logDensity = support.logJacobian(x) + realLogDensity(paramSupport)
+    // TODO: I removed `If isDefined` from here to speed up logDensity calls; check where it's necessary
 
     RandomVariable(paramSupport, logDensity)
   }

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala
@@ -241,4 +241,14 @@ object ContinuousMixture {
       otherDistributions + supportDistribution,
       supportDistribution._1.support
     )
+
+  def apply(supportDistribution: Continuous,
+            otherDistributions: Map[Continuous, Real]): ContinuousMixture = {
+    val remainingWeight: Real = 1.0 - otherDistributions.values.sum
+    new ContinuousMixture(
+      otherDistributions + (supportDistribution -> remainingWeight),
+      supportDistribution.support
+    )
+  }
+
 }

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Injection.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Injection.scala
@@ -34,8 +34,10 @@ trait Injection { self =>
 
     new Continuous {
       def realLogDensity(real: Real): Real =
-        dist.realLogDensity(backwards(real)) +
-          logBackwardsJacobian(real)
+        If(newSupport.isDefinedAt(real),
+           dist.realLogDensity(backwards(real)) +
+             logBackwardsJacobian(real),
+           Real.zero.log)
 
       val generator: Generator[Double] =
         Generator.require(self.requirements) { (r, n) =>

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Injection.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Injection.scala
@@ -33,18 +33,21 @@ trait Injection { self =>
     }
 
     new Continuous {
+      val support: Support = newSupport
+
       def realLogDensity(real: Real): Real =
-        If(newSupport.isDefinedAt(real),
+        /*If(support.isDefinedAt(real),
            dist.realLogDensity(backwards(real)) +
              logBackwardsJacobian(real),
-           Real.zero.log)
+           Real.zero.log)*/
+        dist.realLogDensity(backwards(real)) +
+          logBackwardsJacobian(real)
 
       val generator: Generator[Double] =
         Generator.require(self.requirements) { (r, n) =>
           n.toDouble(forwards(dist.generator.get(r, n)))
         }
 
-      val support: Support = newSupport
     }
   }
 }

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Support.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Support.scala
@@ -36,13 +36,7 @@ object OpenUnitSupport extends Support {
   def logJacobian(v: Variable): Real =
     transform(v).log + (1 - transform(v)).log
 
-  // (x > 0) <=> ((x + |x|) != 0) && (x != 0) <=> (x + |x|) * x != 0
-  def greaterThan0(x: Real): Real = (x + x.abs) * x
-
-  // x is in (0, 1) <=> (x > 0) && (1 - x > 0)
-  def in01(x: Real): Real = greaterThan0(x) * greaterThan0(1 - x)
-
-  def isDefinedAt(x: Real): Real = in01(x)
+  def isDefinedAt(x: Real): Real = (x > 0.0) * (x < 1.0)
 }
 
 /**
@@ -52,16 +46,7 @@ object PositiveSupport extends Support {
   def transform(v: Variable): Real =
     v.exp
 
-  /*
-  Jacobian time: we need pdf(x) and we have pdf(f(x)) where f(x) = e^x.
-  This is pdf(f(x))f'(x) which is pdf(e^x)e^x.
-  If we take the logs we get logPDF(e^x) + x.
-   */
-  def logJacobian(v: Variable): Real =
-    v
+  def logJacobian(v: Variable): Real = v
 
-  // (x > 0) <=> ((x + |x|) != 0) && (x != 0) <=> (x + |x|) * x != 0
-  def greaterThan0(x: Real): Real = (x + x.abs) * x
-
-  def isDefinedAt(x: Real): Real = greaterThan0(x)
+  def isDefinedAt(x: Real): Real = x > 0.0
 }

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Support.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Support.scala
@@ -1,0 +1,67 @@
+package com.stripe.rainier.core
+
+import com.stripe.rainier.compute._
+
+/**
+  * A trait for objects representing the support of a continuous distribution.
+  * Specifies a function to transform a real-valued variable to this range,
+  * and its log-jacobian.
+  */
+trait Support { self =>
+  def transform(v: Variable): Real
+
+  def logJacobian(v: Variable): Real
+
+  def isDefinedAt(x: Real): Real
+}
+
+/**
+  * A support representing the whole real line.
+  */
+object RealSupport extends Support {
+  def transform(v: Variable): Real = v
+
+  def logJacobian(v: Variable): Real = Real.zero
+
+  def isDefinedAt(x: Real): Real = Real.one
+}
+
+/**
+  * A support representing the open (0, 1) interval.
+  */
+object OpenUnitSupport extends Support {
+  def transform(v: Variable): Real =
+    Real.one / (Real.one + (v * -1).exp)
+
+  def logJacobian(v: Variable): Real =
+    transform(v).log + (1 - transform(v)).log
+
+  // (x > 0) <=> ((x + |x|) != 0) && (x != 0) <=> (x + |x|) * x != 0
+  def greaterThan0(x: Real): Real = (x + x.abs) * x
+
+  // x is in (0, 1) <=> (x > 0) && (1 - x > 0)
+  def in01(x: Real): Real = greaterThan0(x) * greaterThan0(1 - x)
+
+  def isDefinedAt(x: Real): Real = in01(x)
+}
+
+/**
+  * A support representing the open {r > 0} interval.
+  */
+object PositiveSupport extends Support {
+  def transform(v: Variable): Real =
+    v.exp
+
+  /*
+  Jacobian time: we need pdf(x) and we have pdf(f(x)) where f(x) = e^x.
+  This is pdf(f(x))f'(x) which is pdf(e^x)e^x.
+  If we take the logs we get logPDF(e^x) + x.
+   */
+  def logJacobian(v: Variable): Real =
+    v
+
+  // (x > 0) <=> ((x + |x|) != 0) && (x != 0) <=> (x + |x|) * x != 0
+  def greaterThan0(x: Real): Real = (x + x.abs) * x
+
+  def isDefinedAt(x: Real): Real = greaterThan0(x)
+}


### PR DESCRIPTION
WIP: adds support for continuous Mixture Distributions. 

This requires factoring out the support transform and the logJacobian of the support transform for each Continuous distribution, so they can be exposed to the mixture distribution class. As a bonus, we get to make the `param` method into a pattern.

APIwise, the Mixture needs to know what support transform (and its Jacobian) to use. I implemented creating from a `Map[Continuous, Real]` if the transform is specified explicitly, or from a `Seq[(Continuous, Real)]` if not; in this case the support of the first distribution is used.

This passes the existing tests, but I haven't written tests specifically for these changes yet. 