### PR TITLE
Add record and replay to RandomVariable

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Recording.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Recording.scala
@@ -1,0 +1,35 @@
+package com.stripe.rainier.compute
+
+import java.io._
+
+trait Recording {
+  def save(path: String): Unit
+  def samples: List[Array[Double]]
+}
+
+case class RecordedSample(params: List[List[Double]]) extends Recording {
+
+  def save(path: String): Unit = {
+    val file = new File(path)
+
+    /** Make directory and an empty file if they don't exist **/
+    (new File(file.getCanonicalFile().getParentFile().toString)).mkdirs()
+    file.createNewFile()
+
+    val outputStream = new ObjectOutputStream(new FileOutputStream(file))
+    outputStream.writeObject(params)
+    outputStream.close()
+  }
+
+  def samples: List[Array[Double]] = params.map(_.toArray)
+}
+
+object RecordedSample {
+
+  def load(path: String): RecordedSample = {
+    val inputStream = new ObjectInputStream(new FileInputStream(path))
+    val samples = inputStream.readObject.asInstanceOf[List[List[Double]]]
+    inputStream.close
+    RecordedSample(samples)
+  }
+}

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Recording.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Recording.scala
@@ -54,8 +54,6 @@ object Recording {
     bytes
   }
 
-  def load(path: String): Recording = {
-    val bytes = loadBytes(path)
-    deserialize(bytes)
-  }
+  def load(path: String): Recording = deserialize(loadBytes(path))
+
 }

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/RandomVariable.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/RandomVariable.scala
@@ -41,6 +41,27 @@ class RandomVariable[+T](val value: T,
              num: Numeric[Real]): V =
     sampleable.get(value)(rng, num)
 
+  def record()(implicit rng: RNG): Recording =
+    record(Sampler.Default.iterations)
+
+  def record(iterations: Int)(implicit rng: RNG): Recording =
+    record(Sampler.Default.sampler,
+           Sampler.Default.warmupIterations,
+           iterations)
+
+  def record(sampler: Sampler,
+             warmupIterations: Int,
+             iterations: Int,
+             keepEvery: Int = 1)(implicit rng: RNG): Recording = {
+    val posteriorParams = Sampler
+      .sample(Context(density),
+              sampler,
+              warmupIterations,
+              iterations,
+              keepEvery)
+    RecordedSample(posteriorParams.map(_.toList))
+  }
+
   def sample[V]()(implicit rng: RNG, sampleable: Sampleable[T, V]): List[V] =
     sample(Sampler.Default.iterations)
 

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/RandomVariable.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/RandomVariable.scala
@@ -59,7 +59,7 @@ class RandomVariable[+T](val value: T,
               warmupIterations,
               iterations,
               keepEvery)
-    RecordedSample(posteriorParams.map(_.toList))
+    Recording(posteriorParams.map(_.toList))
   }
 
   def replay[V](recording: Recording)(implicit rng: RNG,

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/RandomVariable.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/RandomVariable.scala
@@ -62,6 +62,23 @@ class RandomVariable[+T](val value: T,
     RecordedSample(posteriorParams.map(_.toList))
   }
 
+  def replay[V](recording: Recording)(implicit rng: RNG,
+                                      sampleable: Sampleable[T, V]): List[V] = {
+    val context = Context(density)
+    val fn = sampleable.prepare(value, context)
+    recording.samples.map(fn)
+  }
+
+  def replay[V](recording: Recording, iterations: Int)(
+      implicit rng: RNG,
+      sampleable: Sampleable[T, V]): List[V] = {
+    val context = Context(density)
+    val fn = sampleable.prepare(value, context)
+    val sampledParams = RandomVariable(
+      Categorical.list(recording.samples).generator).sample(iterations)
+    sampledParams.map(fn)
+  }
+
   def sample[V]()(implicit rng: RNG, sampleable: Sampleable[T, V]): List[V] =
     sample(Sampler.Default.iterations)
 


### PR DESCRIPTION
Add `Recording` type to store sample from the posterior and `record` and `replay` to `RandomVariable`. (More directly) addresses https://github.com/stripe/rainier/issues/135