### PR TITLE
Support class for Continuous Distributions

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/RealOps.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/RealOps.scala
@@ -93,11 +93,10 @@ private[compute] object RealOps {
   def divide(left: Real, right: Real): Real =
     (left, right) match {
       case (Constant(Real.BigZero), Constant(Real.BigZero)) =>
-        throw new ArithmeticException(
-          "Cannot divide zero by zero")
+        throw new ArithmeticException("Cannot divide zero by zero")
       case (_, Constant(Real.BigZero)) => left * Infinity
-      case (Constant(x), Constant(y)) => Real(x / y)
-      case _                          => left * right.pow(-1)
+      case (Constant(x), Constant(y))  => Real(x / y)
+      case _                           => left * right.pow(-1)
     }
 
   def pow(original: Real, exponent: Real): Real =

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/RealOps.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/RealOps.scala
@@ -93,10 +93,11 @@ private[compute] object RealOps {
   def divide(left: Real, right: Real): Real =
     (left, right) match {
       case (Constant(Real.BigZero), Constant(Real.BigZero)) =>
-        throw new ArithmeticException("Cannot divide zero by zero")
+        throw new ArithmeticException(
+          "Cannot divide zero by zero")
       case (_, Constant(Real.BigZero)) => left * Infinity
-      case (Constant(x), Constant(y))  => Real(x / y)
-      case _                           => left * right.pow(-1)
+      case (Constant(x), Constant(y)) => Real(x / y)
+      case _                          => left * right.pow(-1)
     }
 
   def pow(original: Real, exponent: Real): Real =

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala
@@ -23,7 +23,7 @@ trait Continuous extends Distribution[Double] {
 /**
   * A Continuous Distribution that inherits its transforms from a Support object.
   */
-trait StandardContinuous extends Continuous {
+private trait StandardContinuous extends Continuous {
   private[rainier] val support: Support
 
   def param: RandomVariable[Real] = {
@@ -44,7 +44,7 @@ trait LocationScaleFamily { self =>
   def logDensity(x: Real): Real
   def generate(r: RNG): Double
 
-  val standard: StandardContinuous = new StandardContinuous {
+  val standard: Continuous = new StandardContinuous {
     val support: Support = RealSupport
 
     val generator: Generator[Double] =
@@ -97,7 +97,7 @@ object Gamma {
   def apply(shape: Real, scale: Real): Continuous =
     standard(shape).scale(scale)
 
-  def standard(shape: Real): StandardContinuous = new StandardContinuous {
+  def standard(shape: Real): Continuous = new StandardContinuous {
     val support = PositiveSupport
 
     def realLogDensity(real: Real): Real =
@@ -143,7 +143,7 @@ object Gamma {
   * An Exponential distribution with expectation `1/rate`
   */
 object Exponential {
-  val standard: StandardContinuous = Gamma.standard(1.0)
+  val standard: Continuous = Gamma.standard(1.0)
   def apply(rate: Real): Continuous =
     standard.scale(Real.one / rate)
 }
@@ -195,7 +195,7 @@ object LogNormal {
   */
 object Uniform {
   val beta11 = Beta(1, 1)
-  val standard: StandardContinuous = new StandardContinuous {
+  val standard: Continuous = new StandardContinuous {
     val support = beta11.support
 
     def realLogDensity(real: Real): Real = beta11.realLogDensity(real)

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala
@@ -23,7 +23,7 @@ trait Continuous extends Distribution[Double] {
 /**
   * A Continuous Distribution that inherits its transforms from a Support object.
   */
-private trait StandardContinuous extends Continuous {
+private[rainier] trait StandardContinuous extends Continuous {
   private[rainier] val support: Support
 
   def param: RandomVariable[Real] = {
@@ -176,9 +176,9 @@ final case class Beta(a: Real, b: Real) extends StandardContinuous {
 }
 
 object Beta {
-  def meanAndPrecision(mean: Real, precision: Real) =
+  def meanAndPrecision(mean: Real, precision: Real): Beta =
     Beta(mean * precision, (Real.one - mean) * precision)
-  def meanAndVariance(mean: Real, variance: Real) =
+  def meanAndVariance(mean: Real, variance: Real): Beta =
     meanAndPrecision(mean, mean * (Real.one - mean) / variance - 1)
 }
 

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Injection.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Injection.scala
@@ -7,7 +7,6 @@ import com.stripe.rainier.unused
   * Injective transformations
   */
 trait Injection { self =>
-
   def forwards(x: Real): Real
   def backwards(y: Real): Real
   def isDefinedAt(@unused y: Real): Real = Real.one

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Injection.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Injection.scala
@@ -18,9 +18,7 @@ trait Injection { self =>
    */
   def logJacobian(y: Real): Real
 
-  def transform(dist: Continuous): Continuous = new Continuous {
-    val support = dist.support
-
+  def transform(dist: BaseContinuous): BaseContinuous = new BaseContinuous {
     def realLogDensity(real: Real): Real =
       If(isDefinedAt(real),
          dist.realLogDensity(backwards(real)) +
@@ -32,7 +30,7 @@ trait Injection { self =>
         n.toDouble(forwards(dist.generator.get(r, n)))
       }
 
-    override def param: RandomVariable[Real] = dist.param.map(forwards)
+    def param: RandomVariable[Real] = dist.param.map(forwards)
   }
 }
 

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Injection.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Injection.scala
@@ -20,6 +20,8 @@ trait Injection { self =>
   def logJacobian(y: Real): Real
 
   def transform(dist: Continuous): Continuous = new Continuous {
+    val support = dist.support
+
     def realLogDensity(real: Real): Real =
       If(isDefinedAt(real),
          dist.realLogDensity(backwards(real)) +
@@ -31,7 +33,7 @@ trait Injection { self =>
         n.toDouble(forwards(dist.generator.get(r, n)))
       }
 
-    def param: RandomVariable[Real] = dist.param.map(forwards)
+    override def param: RandomVariable[Real] = dist.param.map(forwards)
   }
 }
 

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Injection.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Injection.scala
@@ -18,7 +18,7 @@ trait Injection { self =>
    */
   def logJacobian(y: Real): Real
 
-  def transform(dist: BaseContinuous): BaseContinuous = new BaseContinuous {
+  def transform(dist: Continuous): Continuous = new Continuous {
     def realLogDensity(real: Real): Real =
       If(isDefinedAt(real),
          dist.realLogDensity(backwards(real)) +

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Support.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Support.scala
@@ -7,7 +7,7 @@ import com.stripe.rainier.compute._
   * Specifies a function to transform a real-valued variable to this range,
   * and its log-jacobian.
   */
-trait Support { self =>
+trait Support {
   def transform(v: Variable): Real
 
   def logJacobian(v: Variable): Real

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Support.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Support.scala
@@ -1,0 +1,52 @@
+package com.stripe.rainier.core
+
+import com.stripe.rainier.compute._
+
+/**
+  * A trait for objects representing the support of a continuous distribution.
+  * Specifies a function to transform a real-valued variable to this range,
+  * and its log-jacobian.
+  */
+trait Support { self =>
+  def transform(v: Variable): Real
+
+  def logJacobian(v: Variable): Real
+
+  def isDefinedAt(x: Real): Real
+}
+
+/**
+  * A support representing the whole real line.
+  */
+object RealSupport extends Support {
+  def transform(v: Variable): Real = v
+
+  def logJacobian(v: Variable): Real = Real.zero
+
+  def isDefinedAt(x: Real): Real = Real.one
+}
+
+/**
+  * A support representing the open (0, 1) interval.
+  */
+object OpenUnitSupport extends Support {
+  def transform(v: Variable): Real =
+    Real.one / (Real.one + (v * -1).exp)
+
+  def logJacobian(v: Variable): Real =
+    transform(v).log + (1 - transform(v)).log
+
+  def isDefinedAt(x: Real): Real = (x > 0.0) * (x < 1.0)
+}
+
+/**
+  * A support representing the open {r > 0} interval.
+  */
+object PositiveSupport extends Support {
+  def transform(v: Variable): Real =
+    v.exp
+
+  def logJacobian(v: Variable): Real = v
+
+  def isDefinedAt(x: Real): Real = x > 0.0
+}

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Support.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Support.scala
@@ -11,8 +11,6 @@ trait Support { self =>
   def transform(v: Variable): Real
 
   def logJacobian(v: Variable): Real
-
-  def isDefinedAt(x: Real): Real
 }
 
 /**
@@ -22,8 +20,6 @@ object RealSupport extends Support {
   def transform(v: Variable): Real = v
 
   def logJacobian(v: Variable): Real = Real.zero
-
-  def isDefinedAt(x: Real): Real = Real.one
 }
 
 /**
@@ -35,8 +31,6 @@ object OpenUnitSupport extends Support {
 
   def logJacobian(v: Variable): Real =
     transform(v).log + (1 - transform(v)).log
-
-  def isDefinedAt(x: Real): Real = (x > 0.0) * (x < 1.0)
 }
 
 /**
@@ -47,6 +41,4 @@ object PositiveSupport extends Support {
     v.exp
 
   def logJacobian(v: Variable): Real = v
-
-  def isDefinedAt(x: Real): Real = x > 0.0
 }


### PR DESCRIPTION
Adds the `Support` class.

As discussed, this class factors out the transforms we need for calculating `logDensity` and `param` methods on continuous distributions.

I did make `param` into a pattern because almost every instance of `Continuous` can use it, but overrode the definition for `Injection`. The injective transforms won't change the support so `injection.transform(cntsDist).support` inherits directly from `cntsDist`.

This passes the existing tests.