### PR TITLE
Placeholder

### DIFF
--- a/rainier-benchmark/src/main/scala/com/stripe/rainier/bench/RealBenchmark.scala
+++ b/rainier-benchmark/src/main/scala/com/stripe/rainier/bench/RealBenchmark.scala
@@ -67,15 +67,18 @@ class TrivialBenchmark extends RealBenchmark {
 class NormalBenchmark extends RealBenchmark {
   def expression: Real = {
     val x = new Variable
-    Normal(x, 1).logDensities(
-      Range.BigDecimal(0d, 2d, 0.001d).map(_.toDouble).toList)
+    Real.sum(Range.BigDecimal(0d, 2d, 0.001d).toList.map { y =>
+      Normal(x, 1).logDensity(Real(y))
+    })
   }
 }
 
 class PoissonBenchmark extends RealBenchmark {
   def expression: Real = {
     val x = new Variable
-    Poisson(x).logDensities(0.to(10).toList)
+    Real.sum(0.to(10).toList.map { y =>
+      Poisson(x).logDensity(y)
+    })
   }
 }
 

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Categorical.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Categorical.scala
@@ -45,8 +45,8 @@ final case class Categorical[T](pmf: Map[T, Real])
   def toMixture[V, P](implicit ev: T <:< Distribution[V, P],
                       placeholder: Placeholder[V, P]): Mixture[V, P, T] =
     Mixture[V, P, T](pmf)
-  def toMultinomial: Predictor[Int, Real, Map[T, Int], Multinomial[T]] =
-    Predictor.from[Int] { k =>
+  def toMultinomial: Predictor[Int, Map[T, Int], Multinomial[T]] =
+    Predictor.from { k: Int =>
       Multinomial(pmf, k)
     }
 }
@@ -55,8 +55,8 @@ object Categorical {
 
   def boolean(p: Real): Categorical[Boolean] =
     Categorical(Map(true -> p, false -> (Real.one - p)))
-  def binomial(p: Real): Predictor[Int, Real, Int, Binomial] =
-    Predictor.from[Int] { k =>
+  def binomial(p: Real): Predictor[Int, Int, Binomial] =
+    Predictor.from { k: Int =>
       Binomial(p, k)
     }
 
@@ -106,7 +106,7 @@ final case class Multinomial[T](pmf: Map[T, Real], k: Real)
   */
 final case class Binomial(p: Real, k: Real) extends Distribution[Int, Real] {
   val multi: Multinomial[Boolean] =
-    Categorical.boolean(p).toMultinomial(k)
+    Multinomial(Map(true -> p, false -> (1 - p)), k)
 
   def generator: Generator[Int] = {
     val poissonGenerator = Poisson(p * k).generator.map { _.min(k) }

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Categorical.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Categorical.scala
@@ -26,9 +26,9 @@ final case class Categorical[T](pmf: Map[T, Real])
         .toMap)
 
   //there should be exactly one value set to 1.0
-  def logDensity(t: Map[T, Real]): Real =
+  def logDensity(v: Map[T, Real]): Real =
     Real
-      .sum(t.toList.map {
+      .sum(v.toList.map {
         case (t, r) =>
           (r * pmf.getOrElse(t, Real.zero))
       })
@@ -90,10 +90,10 @@ final case class Multinomial[T](pmf: Map[T, Real], k: Real)
       seq.groupBy(identity).map { case (t, ts) => (t, ts.size) }
     }
 
-  def logDensity(t: Map[T, Real]): Real =
-    Combinatorics.factorial(k) + Real.sum(t.toList.map {
-      case (v, i) =>
-        val p = pmf.getOrElse(v, Real.zero)
+  def logDensity(v: Map[T, Real]): Real =
+    Combinatorics.factorial(k) + Real.sum(v.toList.map {
+      case (t, i) =>
+        val p = pmf.getOrElse(t, Real.zero)
         val pTerm =
           If(i, i * p.log, If(p, whenNonZero = i * p.log, whenZero = Real.zero))
 
@@ -140,8 +140,8 @@ final case class Binomial(p: Real, k: Real) extends Distribution[Int, Real] {
 
   }
 
-  def logDensity(t: Real): Real =
-    multi.logDensity(Map(true -> t, false -> (k - t)))
+  def logDensity(v: Real): Real =
+    multi.logDensity(Map(true -> v, false -> (k - v)))
 }
 
 /**
@@ -153,11 +153,11 @@ final case class Mixture[T, P, D](pmf: Map[D, Real])(
     implicit ev: D <:< Distribution[T, P],
     placeholder: Placeholder[T, P])
     extends Distribution[T, P] {
-  def logDensity(t: P): Real =
+  def logDensity(v: P): Real =
     Real
       .sum(pmf.toList.map {
         case (dist, prob) =>
-          (ev(dist).logDensity(t) + prob.log).exp
+          (ev(dist).logDensity(v) + prob.log).exp
       })
       .log
 
@@ -173,9 +173,9 @@ final case class Mixture[T, P, D](pmf: Map[D, Real])(
   */
 final case class BetaBinomial(a: Real, b: Real, k: Real)
     extends Distribution[Int, Real] {
-  def logDensity(t: Real): Real =
-    Combinatorics.choose(k, t) +
-      Combinatorics.beta(a + t, k - t + b) -
+  def logDensity(v: Real): Real =
+    Combinatorics.choose(k, v) +
+      Combinatorics.beta(a + v, k - v + b) -
       Combinatorics.beta(a, b)
 
   val generator: Generator[Int] =

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Categorical.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Categorical.scala
@@ -7,7 +7,7 @@ import com.stripe.rainier.compute.{If, Real}
   *
   * @param pmf A map with keys corresponding to the possible outcomes and values corresponding to the probabilities of those outcomes
   */
-final case class Categorical[T](pmf: Map[T, Real]) extends Distribution[T] {
+final case class Categorical[T](pmf: Map[T, Real]) extends Distribution[T,Map[T,Real]] {
   def map[U](fn: T => U): Categorical[U] =
     flatMap { t =>
       Categorical(Map(fn(t) -> Real.one))
@@ -76,14 +76,14 @@ object Categorical {
   * @param pmf A map with keys corresponding to the possible outcomes of a single multinomial trial and values corresponding to the probabilities of those outcomes
   * @param k The number of multinomial trials
   */
-final case class Multinomial[T](pmf: Map[T, Real], k: Int)
-    extends Distribution[Map[T, Int]] {
+final case class Multinomial[T](pmf: Map[T, Real], k: Real)
+    extends Distribution[Map[T, Int],Map[T,Real]] {
   def generator: Generator[Map[T, Int]] =
     Categorical(pmf).generator.repeat(k).map { seq =>
       seq.groupBy(identity).map { case (t, ts) => (t, ts.size) }
     }
 
-  def logDensity(t: Map[T, Int]): Real =
+  def logDensity(t: Map[T, Real]): Real =
     Combinatorics.factorial(k) + Real.sum(t.toList.map {
       case (v, i) =>
         val p = pmf.getOrElse(v, Real.zero)
@@ -103,7 +103,7 @@ final case class Multinomial[T](pmf: Map[T, Real], k: Int)
   * @param p The probability of success
   * @param k The number of trials
   */
-final case class Binomial(p: Real, k: Int) extends Distribution[Int] {
+final case class Binomial(p: Real, k: Real) extends Distribution[Int,Real] {
   val multi: Multinomial[Boolean] =
     Categorical.boolean(p).toMultinomial(k)
 
@@ -127,7 +127,7 @@ final case class Binomial(p: Real, k: Int) extends Distribution[Int] {
 
   }
 
-  def logDensity(t: Int): Real =
+  def logDensity(t: Real): Real =
     multi.logDensity(Map(true -> t, false -> (k - t)))
 }
 
@@ -157,9 +157,9 @@ final case class Mixture[T, D](pmf: Map[D, Real])(
   * A Beta-binomial distribution with expectation `a/(a + b) * k`
   *
   */
-final case class BetaBinomial(a: Real, b: Real, k: Int)
+final case class BetaBinomial(a: Real, b: Real, k: Real)
     extends Distribution[Int] {
-  def logDensity(t: Int): Real =
+  def logDensity(t: Real): Real =
     Combinatorics.choose(k, t) +
       Combinatorics.beta(a + t, k - t + b) -
       Combinatorics.beta(a, b)

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Combinatorics.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Combinatorics.scala
@@ -18,7 +18,7 @@ object Combinatorics {
   def beta(a: Real, b: Real): Real =
     gamma(a) + gamma(b) - gamma(a + b)
 
-  def factorial(k: Real): Real = gamma(k+1)
+  def factorial(k: Real): Real = gamma(k + 1)
 
   def choose(n: Real, k: Real): Real =
     factorial(n) - factorial(k) - factorial(n - k)

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Combinatorics.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Combinatorics.scala
@@ -1,0 +1,35 @@
+package com.stripe.rainier.core
+
+import com.stripe.rainier.compute.Real
+
+/**
+  * Combinatoric functions useful in log density calculations.
+  * Note that they all return the log of the function described.
+  */
+object Combinatorics {
+  def gamma(z: Real) =
+    if (z == Real.zero)
+      Real.infinity
+    else if (z == Real.one || z == Real.two)
+      Real.zero
+    else
+      approxGamma(z)
+
+  def beta(a: Real, b: Real): Real =
+    gamma(a) + gamma(b) - gamma(a + b)
+
+  def factorial(k: Real): Real = gamma(k+1)
+
+  def choose(n: Real, k: Real): Real =
+    factorial(n) - factorial(k) - factorial(n - k)
+
+  private def approxGamma(z: Real): Real = {
+    // This is Gergő Nemes' approximation to the log Gamma function, plus a trick taken from Boost's lgamma function:
+    // since the Nemes approximation isn't very accurate for small z, we instead calculate LogGamma(z + 1) - Log(z).
+    // See https://en.wikipedia.org/wiki/Stirling%27s_approximation and
+    // https://www.boost.org/doc/libs/1_50_0/libs/math/doc/sf_and_dist/html/math_toolkit/special/sf_gamma/lgamma.html.
+    val v = z + 1
+    val w = v + (Real.one / ((12 * v) - (Real.one / (10 * v))))
+    (Real(Math.PI * 2).log / 2) - (v.log / 2) + (v * (w.log - 1)) - z.log
+  }
+}

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala
@@ -7,17 +7,12 @@ import scala.annotation.tailrec
 /**
   * A Continuous Distribution, with method `param` allowing conversion to a RandomVariable.
   */
-trait Continuous extends Distribution[Double] {
-  def logDensity(t: Double): Real =
-    realLogDensity(Real(t))
+trait Continuous extends Distribution[Double,Real] {
+  def param: RandomVariable[Real]
 
   def scale(a: Real): Continuous = Scale(a).transform(this)
   def translate(b: Real): Continuous = Translate(b).transform(this)
   def exp: Continuous = Exp.transform(this)
-
-  private[rainier] def realLogDensity(real: Real): Real
-
-  def param: RandomVariable[Real]
 }
 
 /**
@@ -51,7 +46,7 @@ trait LocationScaleFamily { self =>
       Generator.from { (r, n) =>
         generate(r)
       }
-    def realLogDensity(real: Real): Real =
+    def logDensity(real: Real): Real =
       self.logDensity(real)
   }
 
@@ -100,7 +95,7 @@ object Gamma {
   def standard(shape: Real): Continuous = new StandardContinuous {
     val support = PositiveSupport
 
-    def realLogDensity(real: Real): Real =
+    def logDensity(real: Real): Real =
       If(real > 0,
          (shape - 1) * real.log -
            Combinatorics.gamma(shape) - real,
@@ -154,7 +149,7 @@ object Exponential {
 final case class Beta(a: Real, b: Real) extends StandardContinuous {
   val support = OpenUnitSupport
 
-  def realLogDensity(real: Real): Real =
+  def logDensity(real: Real): Real =
     If(real >= 0,
        If(real <= 1, betaDensity(real), Real.negInfinity),
        Real.negInfinity)
@@ -198,8 +193,8 @@ object Uniform {
   val standard: Continuous = new StandardContinuous {
     val support = beta11.support
 
-    def realLogDensity(real: Real): Real = beta11.realLogDensity(real)
-
+    def logDensity(real: Real): Real = beta11.logDensity(real)
+    def param: RandomVariable[Real] = beta11.param
     val generator: Generator[Double] =
       Generator.from { (r, n) =>
         r.standardUniform

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala
@@ -7,7 +7,7 @@ import scala.annotation.tailrec
 /**
   * A Continuous Distribution, with method `param` allowing conversion to a RandomVariable.
   */
-trait Continuous extends Distribution[Double,Real] {
+trait Continuous extends Distribution[Double, Real] {
   def param: RandomVariable[Real]
 
   def scale(a: Real): Continuous = Scale(a).transform(this)
@@ -26,9 +26,9 @@ private[rainier] trait StandardContinuous extends Continuous {
 
     val transformed = support.transform(x)
 
-    val logDensity = support.logJacobian(x) + realLogDensity(transformed)
+    val density = support.logJacobian(x) + logDensity(transformed)
 
-    RandomVariable(transformed, logDensity)
+    RandomVariable(transformed, density)
   }
 }
 
@@ -194,7 +194,6 @@ object Uniform {
     val support = beta11.support
 
     def logDensity(real: Real): Real = beta11.logDensity(real)
-    def param: RandomVariable[Real] = beta11.param
     val generator: Generator[Double] =
       Generator.from { (r, n) =>
         r.standardUniform

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala
@@ -165,9 +165,8 @@ final case class Beta(a: Real, b: Real) extends StandardContinuous {
       u.log + (b - 1) *
       (1 - u).log - Combinatorics.beta(a, b)
 
-  def binomial: Predictor[Int, Real, Int, BetaBinomial] = Predictor.from[Int] {
-    k =>
-      BetaBinomial(a, b, k)
+  def binomial: Predictor[Int, Int, BetaBinomial] = Predictor.from { k: Int =>
+    BetaBinomial(a, b, k)
   }
 }
 

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala
@@ -165,8 +165,9 @@ final case class Beta(a: Real, b: Real) extends StandardContinuous {
       u.log + (b - 1) *
       (1 - u).log - Combinatorics.beta(a, b)
 
-  def binomial: Predictor[Int, Int, BetaBinomial] = Predictor.from { k: Int =>
-    BetaBinomial(a, b, k)
+  def binomial: Predictor[Int, Real, Int, BetaBinomial] = Predictor.from[Int] {
+    k =>
+      BetaBinomial(a, b, k)
   }
 }
 

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Discrete.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Discrete.scala
@@ -8,8 +8,8 @@ import com.stripe.rainier.compute.Real
   * @param lambda The mean of the Poisson distribution
   */
 final case class Poisson(lambda: Real) extends Distribution[Int, Real] {
-  def logDensity(t: Real): Real = {
-    lambda.log * t - lambda - Combinatorics.factorial(t)
+  def logDensity(v: Real): Real = {
+    lambda.log * v - lambda - Combinatorics.factorial(v)
   }
 
   val generator: Generator[Int] =

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Discrete.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Discrete.scala
@@ -7,7 +7,7 @@ import com.stripe.rainier.compute.Real
   *
   * @param lambda The mean of the Poisson distribution
   */
-final case class Poisson(lambda: Real) extends Distribution[Int] {
+final case class Poisson(lambda: Real) extends Distribution[Int, Real] {
   def logDensity(t: Int): Real = {
     lambda.log * t - lambda - Combinatorics.factorial(t)
   }

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Discrete.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Discrete.scala
@@ -8,7 +8,7 @@ import com.stripe.rainier.compute.Real
   * @param lambda The mean of the Poisson distribution
   */
 final case class Poisson(lambda: Real) extends Distribution[Int, Real] {
-  def logDensity(t: Int): Real = {
+  def logDensity(t: Real): Real = {
     lambda.log * t - lambda - Combinatorics.factorial(t)
   }
 

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Distribution.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Distribution.scala
@@ -5,17 +5,17 @@ import com.stripe.rainier.compute.Real
 /**
   * Basic probability distribution trait
   */
-abstract class Distribution[T, P](implicit placeholder: Placeholder[T, P])
+abstract class Distribution[T, V](implicit placeholder: Placeholder[T, V])
     extends Likelihood[T] {
-  def logDensity(t: P): Real
-  def logValueDensity(t: T): Real = logDensity(placeholder.wrap(t))
+  def logDensity(v: V): Real
+  def valueLogDensity(t: T): Real = logDensity(placeholder.wrap(t))
 
   def generator: Generator[T]
 
-  def fit(t: T): RandomVariable[Distribution[T, P]] =
-    RandomVariable(this, logDensity(placeholder.wrap(t)))
-  def fit(list: Seq[T]): RandomVariable[Distribution[T, P]] =
+  def fit(t: T): RandomVariable[Distribution[T, V]] =
+    RandomVariable(this, valueLogDensity(t))
+  def fit(list: Seq[T]): RandomVariable[Distribution[T, V]] =
     RandomVariable(this, Real.sum(list.map { t =>
-      logDensity(placeholder.wrap(t))
+      valueLogDensity(t)
     }))
 }

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Distribution.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Distribution.scala
@@ -5,46 +5,14 @@ import com.stripe.rainier.compute.Real
 /**
   * Basic probability distribution trait
   */
-trait Distribution[T] extends Likelihood[T] { self =>
-  def logDensity(t: T): Real
-  def logDensities(list: Seq[T]): Real = Real.sum(list.map(logDensity))
+abstract class Distribution[T,P](implicit placeholder: Placeholder[T,P])
+  extends Likelihood[T] {
+  def logDensity(t: P): Real
 
   def generator: Generator[T]
 
   def fit(t: T): RandomVariable[Distribution[T]] =
-    RandomVariable(this, logDensity(t))
+    RandomVariable(this, logDensity(placeholder.wrap(t)))
   def fit(list: Seq[T]): RandomVariable[Distribution[T]] =
-    RandomVariable(this, logDensities(list))
-}
-
-/**
-  * Combinatoric functions useful in log density calculations.
-  * Note that they all return the log of the function described.
-  */
-object Combinatorics {
-  def gamma(z: Real) =
-    if (z == Real.zero)
-      Real.infinity
-    else if (z == Real.one || z == Real.two)
-      Real.zero
-    else
-      approxGamma(z)
-
-  def beta(a: Real, b: Real): Real =
-    gamma(a) + gamma(b) - gamma(a + b)
-
-  def factorial(k: Int): Real = gamma(Real(k + 1))
-
-  def choose(n: Int, k: Int): Real =
-    factorial(n) - factorial(k) - factorial(n - k)
-
-  private def approxGamma(z: Real): Real = {
-    // This is Gergő Nemes' approximation to the log Gamma function, plus a trick taken from Boost's lgamma function:
-    // since the Nemes approximation isn't very accurate for small z, we instead calculate LogGamma(z + 1) - Log(z).
-    // See https://en.wikipedia.org/wiki/Stirling%27s_approximation and
-    // https://www.boost.org/doc/libs/1_50_0/libs/math/doc/sf_and_dist/html/math_toolkit/special/sf_gamma/lgamma.html.
-    val v = z + 1
-    val w = v + (Real.one / ((12 * v) - (Real.one / (10 * v))))
-    (Real(Math.PI * 2).log / 2) - (v.log / 2) + (v * (w.log - 1)) - z.log
-  }
+    RandomVariable(this, Real.sum(list.map{t => logDensity(placeholder.wrap(t))}))
 }

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Distribution.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Distribution.scala
@@ -5,14 +5,18 @@ import com.stripe.rainier.compute.Real
 /**
   * Basic probability distribution trait
   */
-abstract class Distribution[T,P](implicit placeholder: Placeholder[T,P])
-  extends Likelihood[T] {
+abstract class Distribution[T, P](implicit placeholder: Placeholder[T, P])
+    extends Likelihood[T] {
   def logDensity(t: P): Real
+
+  def logDensity(t: T): Real = logDensity(placeholder.wrap(t))
 
   def generator: Generator[T]
 
-  def fit(t: T): RandomVariable[Distribution[T]] =
+  def fit(t: T): RandomVariable[Distribution[T, P]] =
     RandomVariable(this, logDensity(placeholder.wrap(t)))
-  def fit(list: Seq[T]): RandomVariable[Distribution[T]] =
-    RandomVariable(this, Real.sum(list.map{t => logDensity(placeholder.wrap(t))}))
+  def fit(list: Seq[T]): RandomVariable[Distribution[T, P]] =
+    RandomVariable(this, Real.sum(list.map { t =>
+      logDensity(placeholder.wrap(t))
+    }))
 }

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Distribution.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Distribution.scala
@@ -8,8 +8,7 @@ import com.stripe.rainier.compute.Real
 abstract class Distribution[T, P](implicit placeholder: Placeholder[T, P])
     extends Likelihood[T] {
   def logDensity(t: P): Real
-
-  def logDensity(t: T): Real = logDensity(placeholder.wrap(t))
+  def logValueDensity(t: T): Real = logDensity(placeholder.wrap(t))
 
   def generator: Generator[T]
 

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Generator.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Generator.scala
@@ -26,11 +26,12 @@ trait Generator[T] { self =>
     def get(implicit r: RNG, n: Numeric[Real]): (T, U) = (self.get, other.get)
   }
 
-  def repeat(k: Int): Generator[Seq[T]] = new Generator[Seq[T]] {
+  def repeat(k: Real): Generator[Seq[T]] = new Generator[Seq[T]] {
     val requirements: Set[Real] = self.requirements
-    def get(implicit r: RNG, n: Numeric[Real]): Seq[T] = 0.until(k).map { i =>
-      self.get
-    }
+    def get(implicit r: RNG, n: Numeric[Real]): Seq[T] =
+      0.until(n.toInt(k)).map { i =>
+        self.get
+      }
   }
 }
 

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Generator.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Generator.scala
@@ -50,6 +50,11 @@ object Generator {
       def get(implicit r: RNG, n: Numeric[Real]): T = fn(r, n)
     }
 
+  def real(x: Real): Generator[Double] = new Generator[Double] {
+    val requirements: Set[Real] = Set(x)
+    def get(implicit r: RNG, n: Numeric[Real]) = n.toDouble(x)
+  }
+
   def require[T](reqs: Set[Real])(fn: (RNG, Numeric[Real]) => T): Generator[T] =
     new Generator[T] {
       val requirements: Set[Real] = reqs

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Injection.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Injection.scala
@@ -19,9 +19,9 @@ trait Injection { self =>
   def logJacobian(y: Real): Real
 
   def transform(dist: Continuous): Continuous = new Continuous {
-    def realLogDensity(real: Real): Real =
+    def logDensity(real: Real): Real =
       If(isDefinedAt(real),
-         dist.realLogDensity(backwards(real)) +
+         dist.logDensity(backwards(real)) +
            logJacobian(real),
          Real.zero.log)
 

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Placeholder.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Placeholder.scala
@@ -1,10 +1,12 @@
 package com.stripe.rainier.core
 
 import com.stripe.rainier.compute.Real
+import com.stripe.rainier.unused
 
 trait Placeholder[T, U] {
   def wrap(value: T): U
   def get(placeholder: U)(implicit n: Numeric[Real]): T
+  def requirements(placeholder: U): Set[Real]
 }
 
 object Placeholder {
@@ -12,12 +14,14 @@ object Placeholder {
     def wrap(value: Double) = Real(value)
     def get(placeholder: Real)(implicit n: Numeric[Real]) =
       n.toDouble(placeholder)
+    def requirements(placeholder: Real) = Set(placeholder)
   }
 
   implicit val int = new Placeholder[Int, Real] {
     def wrap(value: Int) = Real(value)
     def get(placeholder: Real)(implicit n: Numeric[Real]) =
       n.toInt(placeholder)
+    def requirements(placeholder: Real) = Set(placeholder)
   }
 
   implicit def map[K, T, U](
@@ -27,5 +31,29 @@ object Placeholder {
         value.map { case (k, t) => k -> p.wrap(t) }
       def get(placeholder: Map[K, U])(implicit n: Numeric[Real]): Map[K, T] =
         placeholder.map { case (k, u) => k -> p.get(u) }
+      def requirements(placeholder: Map[K, U]) =
+        placeholder.values.flatMap { u =>
+          p.requirements(u)
+        }.toSet
+    }
+
+  implicit def zip[A, B, X, Y](
+      implicit ab: Placeholder[A, B],
+      xy: Placeholder[X, Y]): Placeholder[(A, X), (B, Y)] =
+    new Placeholder[(A, X), (B, Y)] {
+      def wrap(value: (A, X)): (B, Y) =
+        (ab.wrap(value._1), xy.wrap(value._2))
+      def get(placeholder: (B, Y))(implicit n: Numeric[Real]): (A, X) =
+        (ab.get(placeholder._1), xy.get(placeholder._2))
+      def requirements(placeholder: (B, Y)): Set[Real] =
+        ab.requirements(placeholder._1) ++ xy.requirements(placeholder._2)
+    }
+
+  def enum[T](@unused keys: Iterable[T]): Placeholder[T, Map[T, Real]] =
+    new Placeholder[T, Map[T, Real]] {
+      def wrap(value: T): Map[T, Real] = Map(value -> Real.one)
+      def get(placeholder: Map[T, Real])(implicit n: Numeric[Real]): T =
+        placeholder.find { case (_, r) => n.toDouble(r) > 0 }.get._1
+      def requirements(placeholder: Map[T, Real]) = placeholder.values.toSet
     }
 }

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Placeholder.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Placeholder.scala
@@ -2,7 +2,30 @@ package com.stripe.rainier.core
 
 import com.stripe.rainier.compute.Real
 
-trait Placeholder[T,U] {
+trait Placeholder[T, U] {
   def wrap(value: T): U
   def get(placeholder: U)(implicit n: Numeric[Real]): T
+}
+
+object Placeholder {
+  implicit val double = new Placeholder[Double, Real] {
+    def wrap(value: Double) = Real(value)
+    def get(placeholder: Real)(implicit n: Numeric[Real]) =
+      n.toDouble(placeholder)
+  }
+
+  implicit val int = new Placeholder[Int, Real] {
+    def wrap(value: Int) = Real(value)
+    def get(placeholder: Real)(implicit n: Numeric[Real]) =
+      n.toInt(placeholder)
+  }
+
+  implicit def map[K, T, U](
+      implicit p: Placeholder[T, U]): Placeholder[Map[K, T], Map[K, U]] =
+    new Placeholder[Map[K, T], Map[K, U]] {
+      def wrap(value: Map[K, T]): Map[K, U] =
+        value.map { case (k, t) => k -> p.wrap(t) }
+      def get(placeholder: Map[K, U])(implicit n: Numeric[Real]): Map[K, T] =
+        placeholder.map { case (k, u) => k -> p.get(u) }
+    }
 }

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Placeholder.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Placeholder.scala
@@ -1,0 +1,8 @@
+package com.stripe.rainier.core
+
+import com.stripe.rainier.compute.Real
+
+trait Placeholder[T,U] {
+  def wrap(value: T): U
+  def get(placeholder: U)(implicit n: Numeric[Real]): T
+}

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Placeholder.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Placeholder.scala
@@ -9,18 +9,20 @@ trait Placeholder[T, U] {
   def requirements(placeholder: U): Set[Real]
 }
 
-object Placeholder {
-  implicit val double = new Placeholder[Double, Real] {
-    def wrap(value: Double) = Real(value)
-    def get(placeholder: Real)(implicit n: Numeric[Real]) =
-      n.toDouble(placeholder)
-    def requirements(placeholder: Real) = Set(placeholder)
-  }
-
+trait LowPriPlaceholders {
   implicit val int = new Placeholder[Int, Real] {
     def wrap(value: Int) = Real(value)
     def get(placeholder: Real)(implicit n: Numeric[Real]) =
       n.toInt(placeholder)
+    def requirements(placeholder: Real) = Set(placeholder)
+  }
+}
+
+object Placeholder extends LowPriPlaceholders {
+  implicit val double = new Placeholder[Double, Real] {
+    def wrap(value: Double) = Real(value)
+    def get(placeholder: Real)(implicit n: Numeric[Real]) =
+      n.toDouble(placeholder)
     def requirements(placeholder: Real) = Set(placeholder)
   }
 

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Predictor.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Predictor.scala
@@ -10,11 +10,11 @@ abstract class Predictor[X, Y, Z](implicit ev: Z <:< Distribution[Y, _])
   def apply(x: X): Z
 
   def fit(pair: (X, Y)): RandomVariable[Predictor[X, Y, Z]] =
-    RandomVariable(this, ev(apply(pair._1)).logValueDensity(pair._2))
+    RandomVariable(this, ev(apply(pair._1)).valueLogDensity(pair._2))
 
   def fit(seq: Seq[(X, Y)]): RandomVariable[Predictor[X, Y, Z]] =
     RandomVariable(this, Real.sum(seq.map {
-      case (x, y) => ev(apply(x)).logValueDensity(y)
+      case (x, y) => ev(apply(x)).valueLogDensity(y)
     }))
 
   def predict(x: X): Generator[Y] = ev(apply(x)).generator

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Predictor.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Predictor.scala
@@ -10,11 +10,11 @@ abstract class Predictor[X, Y, Z](implicit ev: Z <:< Distribution[Y, _])
   def apply(x: X): Z
 
   def fit(pair: (X, Y)): RandomVariable[Predictor[X, Y, Z]] =
-    RandomVariable(this, ev(apply(pair._1)).logDensity(pair._2))
+    RandomVariable(this, ev(apply(pair._1)).logValueDensity(pair._2))
 
   def fit(seq: Seq[(X, Y)]): RandomVariable[Predictor[X, Y, Z]] =
     RandomVariable(this, Real.sum(seq.map {
-      case (x, y) => ev(apply(x)).logDensity(y)
+      case (x, y) => ev(apply(x)).logValueDensity(y)
     }))
 
   def predict(x: X): Generator[Y] = ev(apply(x)).generator

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Predictor.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Predictor.scala
@@ -5,14 +5,16 @@ import com.stripe.rainier.compute._
 /**
   * Predictor class, for fitting data with covariates
   */
-abstract class Predictor[X, Y, Z](implicit ev: Z <:< Distribution[Y])
+abstract class Predictor[X, P, Y, Z](implicit ev: Z <:< Distribution[Y, _],
+                                     placeholder: Placeholder[X, P])
     extends Likelihood[(X, Y)] {
-  def apply(x: X): Z
+  def apply(x: P): Z
+  def apply(x: X): Z = apply(placeholder.wrap(x))
 
-  def fit(pair: (X, Y)): RandomVariable[Predictor[X, Y, Z]] =
+  def fit(pair: (X, Y)): RandomVariable[Predictor[X, P, Y, Z]] =
     RandomVariable(this, ev(apply(pair._1)).logDensity(pair._2))
 
-  def fit(seq: Seq[(X, Y)]): RandomVariable[Predictor[X, Y, Z]] =
+  def fit(seq: Seq[(X, Y)]): RandomVariable[Predictor[X, P, Y, Z]] =
     RandomVariable(this, Real.sum(seq.map {
       case (x, y) => ev(apply(x)).logDensity(y)
     }))
@@ -31,9 +33,14 @@ abstract class Predictor[X, Y, Z](implicit ev: Z <:< Distribution[Y])
   * Predictor object, for fitting data with covariates
   */
 object Predictor {
-  def from[X, Y, Z](fn: X => Z)(
-      implicit ev: Z <:< Distribution[Y]): Predictor[X, Y, Z] =
-    new Predictor[X, Y, Z] {
-      def apply(x: X): Z = fn(x)
-    }
+  def from[X] = new From[X]
+
+  class From[X] {
+    def apply[P, Y, Z](fn: P => Z)(
+        implicit placeholder: Placeholder[X, P],
+        ev: Z <:< Distribution[Y, _]): Predictor[X, P, Y, Z] =
+      new Predictor[X, P, Y, Z] {
+        def apply(x: P): Z = fn(x)
+      }
+  }
 }

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/SBC.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/SBC.scala
@@ -6,7 +6,7 @@ import com.stripe.rainier.compute._
 //implements Simulation-Based Calibration from https://arxiv.org/abs/1804.06788
 final case class SBC[T](priorGenerators: Seq[Generator[Double]],
                         priorParams: Seq[Real],
-                        posterior: RandomVariable[(Distribution[T], Real)]) {
+                        posterior: RandomVariable[(Distribution[T, _], Real)]) {
 
   import SBC._
 
@@ -205,14 +205,14 @@ object SBC {
   2) the parameter value or summary stat we're calibrating on
    */
   def apply[T](priors: Seq[Continuous])(
-      fn: Seq[Real] => (Distribution[T], Real)): SBC[T] = {
+      fn: Seq[Real] => (Distribution[T, _], Real)): SBC[T] = {
     val priorParams = priors.map(_.param)
     val priorGenerators = priors.map(_.generator)
     val posterior = RandomVariable.traverse(priorParams).map(fn)
     SBC(priorGenerators, priorParams.map(_.value), posterior)
   }
 
-  def apply[T](prior: Continuous)(fn: Real => Distribution[T]): SBC[T] =
+  def apply[T](prior: Continuous)(fn: Real => Distribution[T, _]): SBC[T] =
     apply(List(prior)) { l =>
       (fn(l.head), l.head)
     }

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Sampleable.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Sampleable.scala
@@ -51,11 +51,11 @@ object Sampleable {
         value.get
     }
 
-  implicit val real: Sampleable[Real, Double] =
-    new Sampleable[Real, Double] {
-      def requirements(value: Real): Set[Real] = Set(value)
-      def get(value: Real)(implicit r: RNG, n: Numeric[Real]): Double =
-        n.toDouble(value)
+  implicit def placeholder[T,P](implicit p: Placeholder[T,P]): Sampleable[P, T] =
+    new Sampleable[P, T] {
+      def requirements(value: P): Set[Real] = p.requirements(value)
+      def get(value: P)(implicit r: RNG, n: Numeric[Real]): Double =
+        p.get(value)
     }
 
   implicit def map[K, S, T](

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Sampleable.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Sampleable.scala
@@ -51,7 +51,8 @@ object Sampleable {
         value.get
     }
 
-  implicit def placeholder[T,P](implicit p: Placeholder[T,P]): Sampleable[P, T] =
+  implicit def placeholder[T, P](
+      implicit p: Placeholder[T, P]): Sampleable[P, T] =
     new Sampleable[P, T] {
       def requirements(value: P): Set[Real] = p.requirements(value)
       def get(value: P)(implicit r: RNG, n: Numeric[Real]): Double =

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Sampleable.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Sampleable.scala
@@ -55,28 +55,7 @@ object Sampleable {
       implicit p: Placeholder[T, P]): Sampleable[P, T] =
     new Sampleable[P, T] {
       def requirements(value: P): Set[Real] = p.requirements(value)
-      def get(value: P)(implicit r: RNG, n: Numeric[Real]): Double =
+      def get(value: P)(implicit r: RNG, n: Numeric[Real]): T =
         p.get(value)
-    }
-
-  implicit def map[K, S, T](
-      implicit s: Sampleable[S, T]): Sampleable[Map[K, S], Map[K, T]] =
-    new Sampleable[Map[K, S], Map[K, T]] {
-      def requirements(value: Map[K, S]): Set[Real] =
-        value.values.flatMap { v =>
-          s.requirements(v)
-        }.toSet
-      def get(value: Map[K, S])(implicit r: RNG, n: Numeric[Real]): Map[K, T] =
-        value.map { case (k, v) => k -> s.get(v) }.toMap
-    }
-
-  implicit def zip[A, B, X, Y](
-      implicit ab: Sampleable[A, B],
-      xy: Sampleable[X, Y]): Sampleable[(A, X), (B, Y)] =
-    new Sampleable[(A, X), (B, Y)] {
-      def requirements(value: (A, X)): Set[Real] =
-        ab.requirements(value._1) ++ xy.requirements(value._2)
-      def get(value: (A, X))(implicit r: RNG, n: Numeric[Real]): (B, Y) =
-        (ab.get(value._1), xy.get(value._2))
     }
 }

--- a/rainier-tests/src/test/scala/com/stripe/rainier/compute/RealTest.scala
+++ b/rainier-tests/src/test/scala/com/stripe/rainier/compute/RealTest.scala
@@ -51,8 +51,9 @@ class RealTest extends FunSuite {
     t + t
   }
   run("normal") { x =>
-    Normal(x, 1).logDensities(
-      Range.BigDecimal(0d, 2d, 1d).map(_.toDouble).toList)
+    Real.sum(Range.BigDecimal(0d, 2d, 1d).toList.map { y =>
+      Normal(x, 1).logDensity(Real(y))
+    })
   }
 
   run("logistic") { x =>
@@ -72,7 +73,9 @@ class RealTest extends FunSuite {
     If(x, x * 2, x * 3) * 5
   }
   run("poisson") { x =>
-    Poisson(x.abs + 1).logDensities(0.to(10).toList)
+    Real.sum(0.to(10).toList.map { y =>
+      Poisson(x.abs + 1).logDensity(y)
+    })
   }
 
   run("4x^3") { x =>

--- a/rainier-tests/src/test/scala/com/stripe/rainier/core/DiscreteTest.scala
+++ b/rainier-tests/src/test/scala/com/stripe/rainier/core/DiscreteTest.scala
@@ -7,7 +7,7 @@ import org.scalatest.FunSuite
 class DiscreteTest extends FunSuite {
   implicit val rng: RNG = ScalaRNG(1527608515939L)
 
-  def check[N: Numeric](description: String)(fn: Real => Distribution[N],
+  def check[N: Numeric](description: String)(fn: Real => Distribution[N, _],
                                              probs: List[Double]): Unit = {
     println(description)
     List((Walkers(100), 10000), (HMC(5), 1000)).foreach {

--- a/rainier-tests/src/test/scala/com/stripe/rainier/core/RandomVariableTest.scala
+++ b/rainier-tests/src/test/scala/com/stripe/rainier/core/RandomVariableTest.scala
@@ -38,11 +38,11 @@ class RandomVariableTest extends FunSuite {
       f: A => F,
       g: A => RandomVariable[G],
       h: G => RandomVariable[H])(
-      implicit a1: Sampleable[A, A1],
-      b1: Sampleable[B, B1],
-      f1: Sampleable[F, F1],
-      g1: Sampleable[G, G1],
-      h1: Sampleable[H, H1]
+      implicit a1: Placeholder[A1, A],
+      b1: Placeholder[B1, B],
+      f1: Placeholder[F1, F],
+      g1: Placeholder[G1, G],
+      h1: Placeholder[H1, H]
   ): Unit = {
 
     assertEquiv(a.map(f), a.flatMap { x =>


### PR DESCRIPTION
This is a refactoring preparing the way for mini-batch style computation. The primary change is that it changes `Distribution` from being parameterized as `Distribution[T]` to `Distribution[T,P]`, where `P` is now a "placeholder type" that is in `Real`-space instead of concrete number space. For example, what would previously have been `Distribution[Double]` is now `Distribution[Double,Real]`, and what would have previously been `Distribution[(Int,Int)]` is now `Distribution[(Int,Int),(Real,Real)]`.

The `logDensity` method is now defined in terms of the `P` type instead of the `T` type. (This was already effectively true for `Continuous` with `realLogDensity`, so in some sense this is just a generalization of that pattern).

The relationship between any given `T,P` pair is managed by a `Placeholder[T,P]` typeclass, which should generally be implicitly inferrable through a combination of primitive mappings (like `(Int,Real)` and `(Double,Real)`) and composition rules. Currently, `Placeholder` handles the `T->P` conversion (necessary for taking the `logDensity` of a `T` value), and the `P->T` conversion, which is used for producing sampler output (in this role, `Placeholder` subsumes some of what used to be provided by `Sampleable`).

In the future, `Placeholder` will also need to create and manage `Variable`-space versions of the placeholder objects, but that will introduce a lot more type complexity and will be done as a follow-on PR.

This PR ignores `Predictor` (which is not a `Distribution`), though we will eventually need to make it `Placeholder`-aware as well.

cc @mio-stripe @roban-stripe @mikeheaton-stripe @andyscott-stripe for possible reviews