### PR TITLE
Disregard version format for shaded asm jar

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -164,6 +164,7 @@ lazy val shadedAsm = project.
     autoScalaLibrary := false,
     exportJars := true,
     packageBin in Compile := (assembly in asmDeps).value,
+    releaseVersion := { ver => ver }
   )
 
 /* phantom project to bundle deps for shading */


### PR DESCRIPTION
This should allow us to publish the infrequently updated shaded asm jar.