### PR TITLE
Narrow the use of Context

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Real.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Real.scala
@@ -64,7 +64,6 @@ object Real {
   //print out Scala code that is equivalent to what the Compiler
   //would produce as JVM bytecode
   def trace(real: Real): Unit = {
-    val context = Context(real)
     val translator = new Translator
     val irs = List(translator.toIR(real))
     val params = RealOps.variables(real).toList.map(_.param)

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Real.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Real.scala
@@ -39,7 +39,7 @@ sealed trait Real {
   def >=(other: Real): Real = If(this - other, this > other, Real.one)
   def <=(other: Real): Real = If(this - other, this < other, Real.one)
 
-  lazy val variables: List[Variable] = RealOps.variables(this)
+  lazy val variables: List[Variable] = RealOps.variables(this).toList
   lazy val gradient: List[Real] = Gradient.derive(variables, this)
 }
 

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Real.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Real.scala
@@ -67,7 +67,7 @@ object Real {
     val context = Context(real)
     val translator = new Translator
     val irs = List(translator.toIR(real))
-    val params = context.variables.map(_.param)
+    val params = RealOps.variables(real).toList.map(_.param)
     ir.Tracer.trace(params, irs)
   }
 

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/RealOps.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/RealOps.scala
@@ -153,7 +153,7 @@ private[compute] object RealOps {
     else
       BigDecimal(Math.pow(a.toDouble, b.toDouble))
 
-  def variables(real: Real): List[Variable] = {
+  def variables(real: Real): Set[Variable] = {
     var seen = Set.empty[Real]
     var vars = List.empty[Variable]
     def loop(r: Real): Unit =
@@ -177,6 +177,6 @@ private[compute] object RealOps {
 
     loop(real)
 
-    vars.sortBy(_.param.sym.id)
+    vars.toSet
   }
 }

--- a/rainier-tests/src/test/scala/com/stripe/rainier/compute/RealTest.scala
+++ b/rainier-tests/src/test/scala/com/stripe/rainier/compute/RealTest.scala
@@ -8,7 +8,7 @@ class RealTest extends FunSuite {
     test(description) {
       val x = new Variable
       val result = fn(x)
-      val c = Context(result).compiler.compile(List(x), result)
+      val c = IRCompiler(200, 100).compile(List(x), result)
       List(1.0, 0.0, -1.0, 2.0, -2.0, 0.5, -0.5).foreach { n =>
         val constant = Try { fn(Constant(n)) } match {
           case Success(Infinity)                 => 1.0 / 0.0


### PR DESCRIPTION
One of a series of PRs building towards having batched likelihood computations.

This makes some very minor changes to limit the places where we use `Context` so that we can change its API later.
