### PR TITLE
roll back Sampleable

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Sampleable.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Sampleable.scala
@@ -51,11 +51,31 @@ object Sampleable {
         value.get
     }
 
-  implicit def placeholder[T, P](
-      implicit p: Placeholder[T, P]): Sampleable[P, T] =
-    new Sampleable[P, T] {
-      def requirements(value: P): Set[Real] = p.requirements(value)
-      def get(value: P)(implicit r: RNG, n: Numeric[Real]): T =
-        p.get(value)
+  implicit val real: Sampleable[Real, Double] =
+    new Sampleable[Real, Double] {
+      def requirements(value: Real): Set[Real] = Set(value)
+      def get(value: Real)(implicit r: RNG, n: Numeric[Real]): Double =
+        n.toDouble(value)
+    }
+
+  implicit def map[K, S, T](
+      implicit s: Sampleable[S, T]): Sampleable[Map[K, S], Map[K, T]] =
+    new Sampleable[Map[K, S], Map[K, T]] {
+      def requirements(value: Map[K, S]): Set[Real] =
+        value.values.flatMap { v =>
+          s.requirements(v)
+        }.toSet
+      def get(value: Map[K, S])(implicit r: RNG, n: Numeric[Real]): Map[K, T] =
+        value.map { case (k, v) => k -> s.get(v) }.toMap
+    }
+
+  implicit def zip[A, B, X, Y](
+      implicit ab: Sampleable[A, B],
+      xy: Sampleable[X, Y]): Sampleable[(A, X), (B, Y)] =
+    new Sampleable[(A, X), (B, Y)] {
+      def requirements(value: (A, X)): Set[Real] =
+        ab.requirements(value._1) ++ xy.requirements(value._2)
+      def get(value: (A, X))(implicit r: RNG, n: Numeric[Real]): (B, Y) =
+        (ab.get(value._1), xy.get(value._2))
     }
 }

--- a/rainier-tests/src/test/scala/com/stripe/rainier/core/RandomVariableTest.scala
+++ b/rainier-tests/src/test/scala/com/stripe/rainier/core/RandomVariableTest.scala
@@ -38,11 +38,11 @@ class RandomVariableTest extends FunSuite {
       f: A => F,
       g: A => RandomVariable[G],
       h: G => RandomVariable[H])(
-      implicit a1: Placeholder[A1, A],
-      b1: Placeholder[B1, B],
-      f1: Placeholder[F1, F],
-      g1: Placeholder[G1, G],
-      h1: Placeholder[H1, H]
+      implicit a1: Sampleable[A, A1],
+      b1: Sampleable[B, B1],
+      f1: Sampleable[F, F1],
+      g1: Sampleable[G, G1],
+      h1: Sampleable[H, H1]
   ): Unit = {
 
     assertEquiv(a.map(f), a.flatMap { x =>


### PR DESCRIPTION
One of a series of PRs building towards having batched likelihood computations.

This rolls back the changes to `Sampleable` made in https://github.com/stripe/rainier/pull/173 so that we are no longer using `Placeholder` there, since that turned out to be an overly optimistic generalization; this frees us up to make major changes to the `Placeholder` API later.