### PR TITLE
rename BoxedReal to Target

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Target.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Target.scala
@@ -1,0 +1,3 @@
+package com.stripe.rainier.compute
+
+class Target(val toReal: Real)


### PR DESCRIPTION
One of a series of PRs building towards having batched likelihood computations.

Renames `BoxedReal` to `Target` and splits it out to its own file in anticipation of it becoming a richer object later on.