### PR TITLE
[wip] discrete distributions/mixtures

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Discrete.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Discrete.scala
@@ -6,10 +6,10 @@ trait Discrete extends Distribution[Int] { self: Discrete =>
   def logDensity(v: Real): Real
 
   def zeroInflated(psi: Real) =
-    DiscreteMixture(Map(DiscreteConstant(0.0) -> (1 - psi), self -> psi))
+    constantInflated(0.0, psi)
 
   def constantInflated(constant: Real, psi: Real) =
-    DiscreteMixture(Map(DiscreteConstant(constant) -> (1 - psi), self -> psi))
+    DiscreteMixture(Map(DiscreteConstant(constant) -> psi, self -> (1 - psi)))
 }
 
 object Discrete {

--- a/rainier-tests/src/test/scala/com/stripe/rainier/core/DiscreteTest.scala
+++ b/rainier-tests/src/test/scala/com/stripe/rainier/core/DiscreteTest.scala
@@ -94,9 +94,9 @@ class DiscreteTest extends FunSuite {
 
   /** Zero Inflated Negative Binomial test **/
   check(
-    "NegativeBinomial(20, .3).constantInflated(0, psi), psi = 0.2, 0.5, 0.9")(
+    "NegativeBinomial(20, .3).constantInflated(0, psi), psi = 0.3, 0.5, 0.9")(
     psi => NegativeBinomial(20, .3).constantInflated(0, psi),
-    List(0.2, 0.5, 0.9))
+    List(0.3, 0.5, 0.9))
 
   /** Zero Inflated Negative Binomial test **/
   check("NegativeBinomial(20, p).constantInflated(0, .3), p = 0.2, 0.5, 0.9")(
@@ -104,9 +104,9 @@ class DiscreteTest extends FunSuite {
     List(0.2, 0.5, 0.9))
 
   /** Zero Inflated Binomial test **/
-  check("Binomial(.3, 20).constantInflated(0, psi), psi = 0.2, 0.5, 0.9, 1.0")(
+  check("Binomial(.3, 20).constantInflated(0, psi), psi = 0.3, 0.5, 0.9, 1.0")(
     psi => Binomial(.3, 20).constantInflated(0, psi),
-    List(0.2, 0.5, 0.9, 1.0))
+    List(0.3, 0.5, 0.9, 1.0))
 
   /** Zero Inflated Binomial test **/
   check("Binomial(p, 20).constantInflated(0, .3), p = 0.2, 0.5, 0.9, 1.0")(

--- a/rainier-tests/src/test/scala/com/stripe/rainier/core/DiscreteTest.scala
+++ b/rainier-tests/src/test/scala/com/stripe/rainier/core/DiscreteTest.scala
@@ -16,7 +16,7 @@ class DiscreteTest extends FunSuite {
         probs.foreach { trueValue =>
           val trueDist = fn(Real(trueValue))
           val syntheticData =
-            RandomVariable(trueDist.generator).sample(1000)
+            RandomVariable(trueDist.generator).sample(10000)
           val model =
             for {
               x <- Uniform(0, 1).param
@@ -56,4 +56,34 @@ class DiscreteTest extends FunSuite {
   checkLogDensity("Binomial(0.0, 10)")(0.0, 10, 1, 0)
   checkLogDensity("Binomial(1.0, 10)")(1.0, 10, 10, 1)
   checkLogDensity("Binomial(1.0, 10)")(1.0, 10, 9, 0)
+
+  /** Bernoulli test **/
+  check("Bernoulli(x), x = 0.1, 0.2, 0.5, 0.8, 0.9, 1.0")(
+    x => Bernoulli(x),
+    List(0.1, 0.2, 0.5, 0.8, 0.9, 1.0))
+
+  /** Geometric test **/
+  check("Geometric(x), x = 0.01, 0.1, 0.5, 0.99, 1.0")(
+    x => Geometric(x),
+    List(0.01, 0.1, 0.5, 0.99, 1.0))
+
+  /** Negative Binomial test **/
+  check("NegativeBinomial(10, x), x = 0.1, 0.5, 0.8")(
+    x => NegativeBinomial(10, x),
+    List(0.1, 0.5, 0.8))
+
+  /** Zero Inflated Poisson test **/
+  check("ZeroInflatedPoisson(psi, 10), psi = 0.1, 0.5, 0.9, 1.0")(
+    psi => ZeroInflatedPoisson(psi, 10),
+    List(0.1, 0.5, 0.9, 1.0))
+
+  /** Zero Inflated Negative Binomial test **/
+  check("ZeroInflatedNegativeBinomial(psi, 10, .3), psi = 0.1, 0.5, 0.9, 1.0")(
+    psi => ZeroInflatedNegativeBinomial(psi, 10, .3),
+    List(0.1, 0.5, 0.9, 1.0))
+
+  /** Zero Inflated Negative Binomial test **/
+  check("ZeroInflatedNegativeBinomial(.3, 10, p), p = 0.1, 0.5, 0.9, 1.0")(
+    p => ZeroInflatedNegativeBinomial(.3, 10, p),
+    List(0.1, 0.5, 0.9, 1.0))
 }

--- a/rainier-tests/src/test/scala/com/stripe/rainier/core/DiscreteTest.scala
+++ b/rainier-tests/src/test/scala/com/stripe/rainier/core/DiscreteTest.scala
@@ -16,7 +16,7 @@ class DiscreteTest extends FunSuite {
         probs.foreach { trueValue =>
           val trueDist = fn(Real(trueValue))
           val syntheticData =
-            RandomVariable(trueDist.generator).sample(10000)
+            RandomVariable(trueDist.generator).sample(1000)
           val model =
             for {
               x <- Uniform(0, 1).param
@@ -27,8 +27,8 @@ class DiscreteTest extends FunSuite {
           val xErr = (fitMean - trueValue) / trueValue
 
           test(
-            s"y ~ $description, x = $trueValue, sampler = $sampler, E(x) within 5%") {
-            assert(xErr.abs < 0.05)
+            s"y ~ $description, x = $trueValue, sampler = $sampler, E(x) within 10%") {
+            assert(xErr.abs < 0.1)
           }
         }
     }
@@ -72,18 +72,44 @@ class DiscreteTest extends FunSuite {
     x => NegativeBinomial(10, x),
     List(0.1, 0.5, 0.8))
 
+  /** Negative Binomial test, Normal Approximation **/
+  check("NegativeBinomial(300, x), x = 0.2, 0.4, 0.6")(
+    x => NegativeBinomial(300, x),
+    List(0.2, 0.4, 0.6))
+
+  /** Zero Inflated Geometric test **/
+  check("Geometric(.3).constantInflated(0, psi), psi = 0.3, 0.5, 0.9, 1.0")(
+    psi => Geometric(.3).constantInflated(0, psi),
+    List(0.3, 0.5, 0.9, 1.0))
+
+  /** Zero Inflated Poisson test, convience method check **/
+  check("Poisson(5).zeroInflated(psi), psi = 0.2, 0.5, 0.9, 1.0")(
+    psi => Poisson(5).constantInflated(0, psi),
+    List(0.2, 0.5, 0.9, 1.0))
+
   /** Zero Inflated Poisson test **/
-  check("ZeroInflatedPoisson(psi, 10), psi = 0.1, 0.5, 0.9, 1.0")(
-    psi => ZeroInflatedPoisson(psi, 10),
-    List(0.1, 0.5, 0.9, 1.0))
+  check("Poisson(5).constantInflated(0, psi), psi = 0.2, 0.5, 0.9, 1.0")(
+    psi => Poisson(5).constantInflated(0, psi),
+    List(0.2, 0.5, 0.9, 1.0))
 
   /** Zero Inflated Negative Binomial test **/
-  check("ZeroInflatedNegativeBinomial(psi, 10, .3), psi = 0.1, 0.5, 0.9, 1.0")(
-    psi => ZeroInflatedNegativeBinomial(psi, 10, .3),
-    List(0.1, 0.5, 0.9, 1.0))
+  check(
+    "NegativeBinomial(20, .3).constantInflated(0, psi), psi = 0.2, 0.5, 0.9")(
+    psi => NegativeBinomial(20, .3).constantInflated(0, psi),
+    List(0.2, 0.5, 0.9))
 
   /** Zero Inflated Negative Binomial test **/
-  check("ZeroInflatedNegativeBinomial(.3, 10, p), p = 0.1, 0.5, 0.9, 1.0")(
-    p => ZeroInflatedNegativeBinomial(.3, 10, p),
-    List(0.1, 0.5, 0.9, 1.0))
+  check("NegativeBinomial(20, p).constantInflated(0, .3), p = 0.2, 0.5, 0.9")(
+    p => NegativeBinomial(20, p).constantInflated(0, .3),
+    List(0.2, 0.5, 0.9))
+
+  /** Zero Inflated Binomial test **/
+  check("Binomial(.3, 20).constantInflated(0, psi), psi = 0.2, 0.5, 0.9, 1.0")(
+    psi => Binomial(.3, 20).constantInflated(0, psi),
+    List(0.2, 0.5, 0.9, 1.0))
+
+  /** Zero Inflated Binomial test **/
+  check("Binomial(p, 20).constantInflated(0, .3), p = 0.2, 0.5, 0.9, 1.0")(
+    p => Binomial(p, 20).constantInflated(0, .3),
+    List(0.2, 0.5, 0.9, 1.0))
 }


### PR DESCRIPTION
[wip] feedback regarding the discrete distributions would be greatly appreciated. For example, the negative binomial, samples grow linearly with n. Should the ZeroInflatedPoisson and ZeroInflatedNegativeBinomial distributions be removed? Is the use of `support`, here, possibly confusing (since the continuous dists use this to mean something else)? Lastly, is there an preferred way to create unit tests for a mixture of discrete distributions?