### PR TITLE
Use placeholders from Predictor

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Categorical.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Categorical.scala
@@ -41,8 +41,8 @@ final case class Categorical[T](pmf: Map[T, Real]) extends Distribution[T] {
   def toMixture[V](implicit ev: T <:< Continuous): Mixture =
     Mixture(pmf.map { case (k, v) => (ev(k), v) })
 
-  def toMultinomial: Predictor[Int, Map[T, Int], Multinomial[T]] =
-    Predictor.from { k: Int =>
+  def toMultinomial =
+    Predictor.from[Int] { k: Real =>
       Multinomial(pmf, k)
     }
 }
@@ -51,8 +51,8 @@ object Categorical {
 
   def boolean(p: Real): Categorical[Boolean] =
     Categorical(Map(true -> p, false -> (Real.one - p)))
-  def binomial(p: Real): Predictor[Int, Int, Binomial] =
-    Predictor.from { k: Int =>
+  def binomial(p: Real) =
+    Predictor.from[Int] { k: Real =>
       Binomial(p, k)
     }
 

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala
@@ -173,7 +173,7 @@ final case class Beta(a: Real, b: Real) extends StandardContinuous {
       u.log + (b - 1) *
       (1 - u).log - Combinatorics.beta(a, b)
 
-  def binomial: Predictor[Int, Int, BetaBinomial] = Predictor.from { k: Int =>
+  def binomial = Predictor.from[Int] { k: Real =>
     BetaBinomial(a, b, k)
   }
 }

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Predictor.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Predictor.scala
@@ -3,9 +3,11 @@ package com.stripe.rainier.core
 /**
   * Predictor class, for fitting data with covariates
   */
-abstract class Predictor[X, Y, Z](implicit ev: Z <:< Distribution[Y])
+abstract class Predictor[X, Y, Z, A](implicit ev: Z <:< Distribution[Y],
+                                     placeholder: Placeholder[X, A])
     extends Fittable[(X, Y)] {
-  def apply(x: X): Z
+  def apply(x: X): Z = create(placeholder.wrap(x))
+  def create(a: A): Z
 
   def predict(x: X): Generator[Y] = ev(apply(x)).generator
 
@@ -21,15 +23,20 @@ abstract class Predictor[X, Y, Z](implicit ev: Z <:< Distribution[Y])
   * Predictor object, for fitting data with covariates
   */
 object Predictor {
-  def from[X, Y, Z](fn: X => Z)(
-      implicit ev: Z <:< Distribution[Y]): Predictor[X, Y, Z] =
-    new Predictor[X, Y, Z] {
-      def apply(x: X): Z = fn(x)
-    }
+  class PredictorFactory[X] {
+    def apply[Y, Z, A](fn: A => Z)(
+        implicit ev: Z <:< Distribution[Y],
+        placeholder: Placeholder[X, A]): Predictor[X, Y, Z, A] =
+      new Predictor[X, Y, Z, A] {
+        def create(a: A): Z = fn(a)
+      }
+  }
 
-  implicit def likelihood[X, Y, Z](implicit lh: Likelihood[Z, Y]) =
-    new Likelihood[Predictor[X, Y, Z], (X, Y)] {
-      def target(predictor: Predictor[X, Y, Z], value: (X, Y)) =
+  def from[X] = new PredictorFactory[X]
+
+  implicit def likelihood[X, Y, Z, A](implicit lh: Likelihood[Z, Y]) =
+    new Likelihood[Predictor[X, Y, Z, A], (X, Y)] {
+      def target(predictor: Predictor[X, Y, Z, A], value: (X, Y)) =
         lh.target(predictor(value._1), value._2)
     }
 }

--- a/rainier-docs/src/main/tut/tour.md
+++ b/rainier-docs/src/main/tut/tour.md
@@ -7,6 +7,7 @@ The `rainier.core` package defines some key traits like `Distribution`, `RandomV
 ```tut:silent
 import com.stripe.rainier.core._
 import com.stripe.rainier.repl._
+import com.stripe.rainier.compute._
 ```
 
 Together, those traits let you define bayesian models in Rainier. To throw you a little bit into the deep end, here's a simple linear regression that we'll return to later. This probably won't entirely make sense yet. That's ok. Hopefully it will serve as a bit of a roadmap that put the rest of the tour in context as we build up to it. 
@@ -17,7 +18,7 @@ val data =  List((0,8), (1,12), (2,16), (3,20), (4,21), (5,31), (6,23), (7,33), 
 val model = for {
     slope <- LogNormal(0,1).param
     intercept <- LogNormal(0,1).param
-    regression <- Predictor.from{x: Int => Poisson(x*slope + intercept)}.fit(data)
+    regression <- Predictor.from[Int]{x: Real => Poisson(x*slope + intercept)}.fit(data)
 } yield regression.predict(21)
 ```
 
@@ -241,7 +242,7 @@ Like `Distribution`, `Predictor` implements `fit` (in fact, they both extend the
 ```tut
 val regr = for {
     (slope, intercept) <- prior
-    predictor <- Predictor.from{i: Int =>
+    predictor <- Predictor.from[Int]{i: Real =>
                     Poisson(intercept + slope*i)
                 }.fit(data) 
 } yield (slope, intercept)
@@ -258,7 +259,7 @@ Alternatively, as in the earlier example, we could try to predict what will happ
 val regr2 = for {
     slope <- LogNormal(0,1).param
     intercept <- LogNormal(0,1).param
-    predictor <- Predictor.from{i: Int => 
+    predictor <- Predictor.from[Int]{i: Real => 
                     Poisson(intercept + slope*i)
                 }.fit(data)
 } yield predictor.predict(21)
@@ -283,8 +284,8 @@ val regr3 = for {
     slope1 <- LogNormal(0,1).param
     slope2 <- LogNormal(0,1).param
     intercept <- LogNormal(0,1).param
-    pred1 <- Predictor.from{i: Int => Poisson(intercept + slope1*i)}.fit(data)
-    pred2 <- Predictor.from{i: Int => Poisson(intercept + slope2*i)}.fit(data2)
+    pred1 <- Predictor.from[Int]{i: Real => Poisson(intercept + slope1*i)}.fit(data)
+    pred2 <- Predictor.from[Int]{i: Real => Poisson(intercept + slope2*i)}.fit(data2)
 } yield (slope1, intercept)
 ```
 

--- a/rainier-example/src/main/scala/com/stripe/rainier/example/FitSparse.scala
+++ b/rainier-example/src/main/scala/com/stripe/rainier/example/FitSparse.scala
@@ -1,5 +1,6 @@
 package com.stripe.rainier.example
 
+import com.stripe.rainier.compute._
 import com.stripe.rainier.core._
 import com.stripe.rainier.repl._
 
@@ -17,7 +18,7 @@ object FitSparse {
       w3 <- Normal(0, 0.01).param
       w4 <- Normal(0, 0.01).param
       _ <- Predictor
-        .from { i: Int =>
+        .from[Int] { i: Real =>
           Normal(i * w1 + i * w2 + i * w3 + i * w4, noiseStddev)
         }
         .fit(data)
@@ -31,7 +32,7 @@ object FitSparse {
       w3 <- Laplace(0, 0.01).param
       w4 <- Laplace(0, 0.01).param
       _ <- Predictor
-        .from { i: Int =>
+        .from[Int] { i: Real =>
           Normal(i * w1 + i * w2 + i * w3 + i * w4, noiseStddev)
         }
         .fit(data)

--- a/rainier-example/src/main/scala/com/stripe/rainier/example/LogReg.scala
+++ b/rainier-example/src/main/scala/com/stripe/rainier/example/LogReg.scala
@@ -37,7 +37,7 @@ object LogReg {
       beta0 <- Normal(0, 5).param
       beta1 <- Normal(0, 5).param
       _ <- Predictor
-        .from { x: Double =>
+        .from[Double] { x: Real =>
           {
             val theta = beta0 + beta1 * x
             val p = Real(1.0) / (Real(1.0) + (Real(0.0) - theta).exp)


### PR DESCRIPTION
This changes `Predictor` to expect that its covariate -> noise-distribution function takes inputs in `Real`-space (by way of a `Placeholder`) instead of the raw representation of the covariate.