### PR TITLE
Standardize shaded-asm version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -204,12 +204,12 @@ lazy val rainierTrace = project.
 /* publishable project with the shaded deps */
 lazy val shadedAsm = project.
   in(file(".rainier-shaded-asm")).
-  settings(name := "rainier-shaded-asm").
+  // note: bump version suffix when the shaded asm jar needs to be
+  // republished for a particular version of the underlying asm lib
+  settings(name := "rainier-shaded-asm_6.0").
+  settings(moduleName := "rainier-shaded-asm_6.0").
   settings(commonSettings).
   settings(
-    // note: bump version suffix when the shaded asm jar needs to be
-    // republished for a particular version of the underlying asm lib
-    version := s"${V.asm}_0",
     crossPaths := false,
     autoScalaLibrary := false,
     exportJars := true,


### PR DESCRIPTION
I just ran into a somewhat confusing issue where I'd run `sbt +publishLocal` on rainier, and a bazel build then picked up the local `rainier-shaded-asm` artifact, which had a jar with a different hash, etc.

This change moves the `6.0` suffix into the artifact ID and uses the same version as the other rainier artifacts for `rainier-shaded-asm`. I've also updated the `version.sbt` version.

I think in general it's safe to assume (and people do tend to assume) that running `sbt + publishLocal` on an sbt project won't publish non-snapshot versions into your local Ivy cache, and after this change that assumption holds for rainier.

r? @andyscott-stripe 