### PR TITLE
Mapping -> Placeholder -> Target

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Target.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Target.scala
@@ -1,0 +1,26 @@
+package com.stripe.rainier.compute
+
+class Target(val real: Real, val placeholders: Map[Variable, Array[Double]]) {
+  def inlined = inl(placeholders)
+
+  def inl(data: Map[Variable, Array[Double]]): Real =
+    if (data.isEmpty)
+      real
+    else {
+      val inlined = 0.until(nRows(data)).map { i =>
+        val row: Map[Variable, Real] = data.map {
+          case (v, a) => v -> Real(a(i))
+        }
+        PartialEvaluator.inline(real, row)
+      }
+      Real.sum(inlined.toList)
+    }
+
+  private def nRows(data: Map[Variable, Array[Double]]): Int =
+    data.head._2.size
+}
+
+object Target {
+  def apply(real: Real): Target = new Target(real, Map.empty)
+  val empty: Target = apply(Real.zero)
+}

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Likelihood.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Likelihood.scala
@@ -1,6 +1,7 @@
 package com.stripe.rainier.core
 
 import com.stripe.rainier.compute._
+import scala.collection.mutable.ArrayBuffer
 
 trait Likelihood[T] {
   private[core] type P
@@ -8,12 +9,26 @@ trait Likelihood[T] {
   private[core] def logDensity(value: P): Real
 
   def target(value: T): Target =
-    new Target(logDensity(wrapping.wrap(value)))
+    Target(logDensity(wrapping.wrap(value)))
 
-  def sequence(seq: Seq[T]) =
-    new Target(Real.sum(seq.map { t =>
-      target(t).toReal
-    }))
+  def sequence(seq: Seq[T]): Target = {
+    val ph = wrapping.placeholder(seq)
+    val real = logDensity(ph.value)
+    val variables = ph.variables
+    val arrayBufs =
+      variables.map { _ =>
+        new ArrayBuffer[Double]
+      }
+    seq.foreach { t =>
+      val doubles = ph.extract(t, Nil)
+      arrayBufs.zip(doubles).foreach {
+        case (a, d) => a += d
+      }
+    }
+    val placeholdersMap =
+      variables.zip(arrayBufs.map(_.toArray)).toMap
+    new Target(real, placeholdersMap)
+  }
 }
 
 object Likelihood {

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Placeholder.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Placeholder.scala
@@ -1,0 +1,16 @@
+package com.stripe.rainier.core
+
+import com.stripe.rainier.compute._
+
+trait Placeholder[T, U] { self =>
+  def value: U
+  def variables: Seq[Variable]
+  def extract(value: T, acc: List[Double]): List[Double]
+  def zip[A, B](other: Placeholder[A, B]): Placeholder[(T, A), (U, B)] =
+    new Placeholder[(T, A), (U, B)] {
+      val value = (self.value, other.value)
+      val variables = self.variables ++ other.variables
+      def extract(value: (T, A), acc: List[Double]) =
+        self.extract(value._1, other.extract(value._2, acc))
+    }
+}

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Placeholder.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Placeholder.scala
@@ -5,7 +5,7 @@ import com.stripe.rainier.compute._
 trait Placeholder[T, U] { self =>
   def value: U
   def variables: Seq[Variable]
-  def extract(value: T, acc: List[Double]): List[Double]
+  def extract(t: T, acc: List[Double]): List[Double]
   def zip[A, B](other: Placeholder[A, B]): Placeholder[(T, A), (U, B)] =
     new Placeholder[(T, A), (U, B)] {
       val value = (self.value, other.value)

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Predictor.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Predictor.scala
@@ -18,6 +18,7 @@ trait Predictor[X, Y] extends Likelihood[(X, Y)] {
       val qr = create(q).wrapping
       (q, qr.wrap(value._2))
     }
+    def placeholder(seq: Seq[(X, Y)]) = ???
   }
 
   def logDensity(value: P) =

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Predictor.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Predictor.scala
@@ -18,7 +18,11 @@ trait Predictor[X, Y] extends Likelihood[(X, Y)] {
       val qr = create(q).wrapping
       (q, qr.wrap(value._2))
     }
-    def placeholder(seq: Seq[(X, Y)]) = ???
+    def placeholder(seq: Seq[(X, Y)]) = {
+      val qph = xq.placeholder(seq.map(_._1))
+      val z = create(qph.value)
+      qph.zip(z.wrapping.placeholder(seq.map(_._2)))
+    }
   }
 
   def logDensity(value: P) =

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/RandomVariable.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/RandomVariable.scala
@@ -121,8 +121,7 @@ class RandomVariable[+T](val value: T, private val targets: Set[Target]) {
     (allSamples, diagnostics)
   }
 
-  lazy val density: Real =
-    Real.sum(targets.toList.map(_.toReal))
+  lazy val density: Real = Real.sum(targets.map(_.inlined))
 
   //this is really just here to allow destructuring in for{}
   def withFilter(fn: T => Boolean): RandomVariable[T] =
@@ -141,7 +140,7 @@ class RandomVariable[+T](val value: T, private val targets: Set[Target]) {
   */
 object RandomVariable {
   def apply[A](a: A, density: Real): RandomVariable[A] =
-    new RandomVariable(a, Set(new Target(density)))
+    new RandomVariable(a, Set(Target(density)))
 
   def apply[A](a: A): RandomVariable[A] =
     apply(a, Real.zero)

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Target.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Target.scala
@@ -1,3 +1,0 @@
-package com.stripe.rainier.compute
-
-class Target(val toReal: Real)


### PR DESCRIPTION
Depends on https://github.com/stripe/rainier/pull/198 . This still has a couple of `???` to flesh out but can mostly be reviewed as is.

The big change here is that `Target`, which is how `RandomVariable` stores each term of the density function. Now instead of just wrapping a `Real`, it also keeps a (possibly empty) mapping from `Variable` nodes that appear in the `Real`, to columns of `Array[Double]` values for that variable. Each column should be the same length (call that `n`). Conceptually, if you made `n` copies of the `real` wrapped by the `Target`, and for each copy at index `i` replace, for each column, the `Variable` key in that copy with the double at index `i` if the values, then summed all of the copies, you'd have the full density term (which may contain additional, un-replaced, `Variables`, for model parameters).

`Target` implements `inlined` which performs exactly this replacement, using `PartialEvaluator`, so that we can use it just as we used to, and that's all this PR does for now.

The other change here is to extend `Wrapping` to create a `Placeholder` which provides the missing pieces to allow one of these new `Target`s to be constructed:
- it can construct a `Real`-space object that generalizes a sequence of concrete values (instead of just wrapping a single concrete value)
- it tracks the `Variable`s in that object
- given a concrete value, it can extract the `Double`s that map to each of those `Variable`s