### PR TITLE
optimizations for simple sample generation

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Evaluator.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Evaluator.scala
@@ -2,13 +2,17 @@ package com.stripe.rainier.compute
 
 class Evaluator(var cache: Map[Real, Double]) extends Numeric[Real] {
 
-  def toDouble(x: Real): Double = cache.get(x) match {
-    case Some(v) => v
-    case None => {
-      val v = eval(x)
-      cache += x -> v
-      v
-    }
+  def toDouble(x: Real): Double = x match {
+    case Constant(v) => v.toDouble
+    case _ =>
+      cache.get(x) match {
+        case Some(v) => v
+        case None => {
+          val v = eval(x)
+          cache += x -> v
+          v
+        }
+      }
   }
 
   private def eval(real: Real): Double = real match {

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Injection.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Injection.scala
@@ -84,6 +84,8 @@ final case class Translate(b: Real) extends Injection {
   */
 object Exp extends Injection {
   def forwards(x: Real): Real = x.exp
+  override def fastForwards(x: Double)(implicit n: Numeric[Real]) =
+    Math.exp(n)
   def backwards(y: Real): Real = y.log
   def logJacobian(y: Real): Real = y.log * -1
 

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Injection.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Injection.scala
@@ -85,7 +85,7 @@ final case class Translate(b: Real) extends Injection {
 object Exp extends Injection {
   def forwards(x: Real): Real = x.exp
   override def fastForwards(x: Double)(implicit n: Numeric[Real]) =
-    Math.exp(n)
+    Math.exp(x)
   def backwards(y: Real): Real = y.log
   def logJacobian(y: Real): Real = y.log * -1
 


### PR DESCRIPTION
This adds a couple of simple optimizations that can dramatically speed up sampling from `Generator`s derived from simple distributions:

* in `Evaluator`, bypass the cache for `Constant` since we can just read the value directly from the object
* in `Injection` add an optional `fastForwards` version of the `forwards` method that works in `Double`-space instead of `Real`-space to avoid round-tripping through `Real` where that's not needed.

These were motivated by work Jack D is doing that relies on forwards-only generative use of Rainier.