### PR TITLE
batched target and context

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Context.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Context.scala
@@ -25,7 +25,7 @@ case class Context(base: Real, batched: Target) {
   //not terribly efficient
   private def compileBatched: Array[Double] => Double = {
     if (batched.placeholders.isEmpty) {
-      compiler.compile(variables, base)
+      compiler.compile(variables, base + batched.real)
     } else {
       val placeholders = batched.placeholders.keys.toList
       val cf = compiler.compile(variables ++ placeholders, batched.real)

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Target.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Target.scala
@@ -3,7 +3,7 @@ package com.stripe.rainier.compute
 class Target(val real: Real, val placeholders: Map[Variable, Array[Double]]) {
   def inlined = inl(placeholders)
 
-  def inl(data: Map[Variable, Array[Double]]): Real =
+  private def inl(data: Map[Variable, Array[Double]]): Real =
     if (data.isEmpty)
       real
     else {
@@ -18,6 +18,45 @@ class Target(val real: Real, val placeholders: Map[Variable, Array[Double]]) {
 
   private def nRows(data: Map[Variable, Array[Double]]): Int =
     data.head._2.size
+
+  def batched(nBatches: Int): (Target, Real) =
+    if (placeholders.isEmpty)
+      (this, Real.zero)
+    else if (nBatches == 1)
+      (Target.empty, inlined)
+    else {
+      val n = nRows(placeholders)
+      val variables = placeholders.keys.toList
+      val nColumns = n / nBatches
+      val copies = 0.until(nColumns).map { i =>
+        val columnVariables = variables.map { v =>
+          v -> new Variable
+        }.toMap
+        val columnReal = PartialEvaluator.inline(real, columnVariables)
+        (i, columnReal, columnVariables)
+      }
+      val newReal = Real.sum(copies.map(_._2))
+      val newPlaceholders = copies.flatMap {
+        case (i, _, columnVariables) =>
+          columnVariables.toList.map {
+            case (v, cv) =>
+              val values = placeholders(v)
+              cv -> values.slice(i * nBatches, (i + 1) * nBatches)
+          }
+      }.toMap
+      val newTarget = new Target(newReal, newPlaceholders)
+      val remainder =
+        if (nColumns * nBatches == n)
+          Real.zero
+        else {
+          val data = placeholders.map {
+            case (v, d) =>
+              v -> d.slice(nColumns * nBatches, n)
+          }
+          inl(data)
+        }
+      (newTarget, remainder)
+    }
 }
 
 object Target {

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Target.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Target.scala
@@ -1,13 +1,63 @@
 package com.stripe.rainier.compute
 
 class Target(val real: Real, val placeholders: Map[Variable, Array[Double]]) {
+  val nRows = size(placeholders)
+  val placeholderVariables = placeholders.keys.toList
+
   def inlined = inl(placeholders)
+
+  def batched(nBatches: Int): (Target, Real) =
+    if (placeholders.isEmpty)
+      (this, Real.zero)
+    else if (nBatches == 1)
+      (Target.empty, inlined)
+    else {
+      val nCopies = nRows / nBatches
+      val (realCopies, variableCopies) = makeCopies(nCopies)
+      val newReal = Real.sum(realCopies)
+      val newPlaceholders = makePlaceholders(variableCopies, nBatches).toMap
+      val newTarget = new Target(newReal, newPlaceholders)
+      val remainder = makeRemainder(nBatches, nCopies)
+      (newTarget, remainder)
+    }
+
+  private def makeCopies(
+      nCopies: Int): (Seq[Real], Seq[Map[Variable, Variable]]) =
+    0.until(nCopies)
+      .map { _ =>
+        val variablesCopy = placeholderVariables.map { v =>
+          v -> new Variable
+        }.toMap
+        val realCopy = PartialEvaluator.inline(real, variablesCopy)
+        (realCopy, variablesCopy)
+      }
+      .unzip
+
+  private def makePlaceholders(variableCopies: Seq[Map[Variable, Variable]],
+                               nBatches: Int): Seq[(Variable, Array[Double])] =
+    for {
+      (copyVariables, i) <- variableCopies.zipWithIndex
+      (v, cv) <- copyVariables
+    } yield {
+      cv -> placeholders(v).slice(i * nBatches, (i + 1) * nBatches)
+    }
+
+  private def makeRemainder(nBatches: Int, nCopies: Int): Real =
+    if (nCopies * nBatches == nRows)
+      Real.zero
+    else {
+      val data = placeholders.map {
+        case (v, d) =>
+          v -> d.slice(nCopies * nBatches, nRows)
+      }
+      inl(data)
+    }
 
   private def inl(data: Map[Variable, Array[Double]]): Real =
     if (data.isEmpty)
       real
     else {
-      val inlined = 0.until(nRows(data)).map { i =>
+      val inlined = 0.until(size(data)).map { i =>
         val row: Map[Variable, Real] = data.map {
           case (v, a) => v -> Real(a(i))
         }
@@ -16,47 +66,11 @@ class Target(val real: Real, val placeholders: Map[Variable, Array[Double]]) {
       Real.sum(inlined.toList)
     }
 
-  private def nRows(data: Map[Variable, Array[Double]]): Int =
-    data.head._2.size
-
-  def batched(nBatches: Int): (Target, Real) =
-    if (placeholders.isEmpty)
-      (this, Real.zero)
-    else if (nBatches == 1)
-      (Target.empty, inlined)
-    else {
-      val n = nRows(placeholders)
-      val variables = placeholders.keys.toList
-      val nColumns = n / nBatches
-      val copies = 0.until(nColumns).map { i =>
-        val columnVariables = variables.map { v =>
-          v -> new Variable
-        }.toMap
-        val columnReal = PartialEvaluator.inline(real, columnVariables)
-        (i, columnReal, columnVariables)
-      }
-      val newReal = Real.sum(copies.map(_._2))
-      val newPlaceholders = copies.flatMap {
-        case (i, _, columnVariables) =>
-          columnVariables.toList.map {
-            case (v, cv) =>
-              val values = placeholders(v)
-              cv -> values.slice(i * nBatches, (i + 1) * nBatches)
-          }
-      }.toMap
-      val newTarget = new Target(newReal, newPlaceholders)
-      val remainder =
-        if (nColumns * nBatches == n)
-          Real.zero
-        else {
-          val data = placeholders.map {
-            case (v, d) =>
-              v -> d.slice(nColumns * nBatches, n)
-          }
-          inl(data)
-        }
-      (newTarget, remainder)
-    }
+  private def size(data: Map[Variable, Array[Double]]): Int =
+    if (data.isEmpty)
+      0
+    else
+      data.head._2.size
 }
 
 object Target {

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Likelihood.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Likelihood.scala
@@ -37,7 +37,7 @@ object Likelihood {
     `Normal(1).fit(...)` is `RandomVariable[Normal]` instead of
     `RandomVariable[Likelihood[Double]]`. This solves a similar problem to f-bounded
     polymorphism but without introducing an ugly extra type param.
-  */
+   */
   implicit class Ops[T, L](lh: L)(implicit ev: L <:< Likelihood[T]) {
     def fit(value: T): RandomVariable[L] = RandomVariable.fit(lh, value)
     def fit(seq: Seq[T]): RandomVariable[L] = RandomVariable.fit(lh, seq)

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/RandomVariable.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/RandomVariable.scala
@@ -2,7 +2,6 @@ package com.stripe.rainier.core
 
 import com.stripe.rainier.compute._
 import com.stripe.rainier.sampler._
-import com.stripe.rainier.unused
 
 /**
   * The main probability monad used in Rainier for constructing probabilistic programs which can be sampled
@@ -40,10 +39,10 @@ class RandomVariable[+T](val value: T, private val targets: Set[Target]) {
   def record(sampler: Sampler,
              warmupIterations: Int,
              iterations: Int,
-             @unused batches: Int = 1,
+             batches: Int = 1,
              keepEvery: Int = 1)(implicit rng: RNG): Recording = {
     val posteriorParams = Sampler
-      .sample(Context(density),
+      .sample(Context(batches, targets),
               sampler,
               warmupIterations,
               iterations,
@@ -81,9 +80,9 @@ class RandomVariable[+T](val value: T, private val targets: Set[Target]) {
       sampler: Sampler,
       warmupIterations: Int,
       iterations: Int,
-      @unused batches: Int = 1,
+      batches: Int = 1,
       keepEvery: Int = 1)(implicit rng: RNG, tg: ToGenerator[T, V]): List[V] = {
-    val context = Context(density)
+    val context = Context(batches, targets)
     val fn = tg(value).prepare(context)
     Sampler
       .sample(context, sampler, warmupIterations, iterations, keepEvery)
@@ -97,11 +96,11 @@ class RandomVariable[+T](val value: T, private val targets: Set[Target]) {
                                warmupIterations: Int,
                                iterations: Int,
                                parallel: Boolean = true,
-                               @unused batches: Int = 1,
+                               batches: Int = 1,
                                keepEvery: Int = 1)(
       implicit rng: RNG,
       tg: ToGenerator[T, V]): (List[V], List[Diagnostics]) = {
-    val context = Context(density)
+    val context = Context(batches, targets)
     val fn = tg(value).prepare(context)
     val range = if (parallel) 1.to(chains).par else 1.to(chains)
     val samples =


### PR DESCRIPTION
This enables batched evaluation of log-density for simple non-gradient cases like `Walkers`. The major pieces of functionality are:

* `Target.batched(k)`. Given a `Target` with a `placeholders: Map[Variable, Array[Double]]`, we assume that the `Array[Double]` values all have the same length, `n`. If we divide each of these into `k` batches, we end up with `m = n/k` items per batch. We can represent this by a dense `k x m` matrix, with a "remainder" of `n - (k*m)` items that don't fit inside it. We want to ultimately do one evaluation for each row of this matrix (ie each batch); to achieve this, we copy each `Variable` in the original `placeholders` map `m` times, and produce a new copy of the target's `real` that has these cloned `Variable`s substituted for the original ones, and then create a new `Target` whose `real` is the sum of those copies, and whose `placeholders` has the new `Variable` objects and the appropriate matrix columns as its arrays. At the same time, we inline the `remainder` as constants into `real` to produce a fully inlined (no placeholders) version that covers those items.
* `Context.apply(k,targets)`. Given a list of targets and a number of batches, this uses `batched` on all of them to produce a new target with the correct number of batches, as well as a remainder. It can then sum all of the remainders, and, because all of the `Targets` have been normalized to have the same number of items in their placeholder arrays, it can union all of them also, leading to a `Context(base: Real, batched: Target)`.
* `Context.variables` has been modified to look at both the `base` and the `real` inside the batched target, not *not* to consider the variables in the target's placeholders (since we don't want them in the gradient).
* `compileBatched` produces an `Array[Double] => Double` function for the target whose input is just the parameters array (ie the same as `variables`), but that internally compiles a function that takes the `placeholders` as input also, and then divides up the placeholders into batches and evaluates that compiled function once per batch, summing the results and returning that. (This summation is one place we could use kahan summation btw). It's worth noting some potential inefficiency here in that any intermediate values in that compiled function that do *not* depend on the placeholder variables still get recomputed for each batch; a smarter implementation of this which coordinated more deeply with the compiler could avoid that.
