### PR TITLE
fix sbc for more complex cases

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/core/SBC.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/SBC.scala
@@ -3,15 +3,21 @@ package com.stripe.rainier.core
 import com.stripe.rainier.sampler._
 import com.stripe.rainier.compute._
 
-//implements Simulation-Based Calibration from https://arxiv.org/abs/1804.06788
-final case class SBC[T, L <: Distribution[T]](
-    priorGenerators: Seq[Generator[Double]],
-    priorParams: Seq[Real],
-    posterior: RandomVariable[(L, Real)]) {
+/*
+implements Simulation-Based Calibration from https://arxiv.org/abs/1804.06788
+
+fn is a function that takes a Seq[Real]
+specifying the values of all the parameters (one for each Continuous in the prior)
+and returns a (Distribution[T], Real) which is a pair of values:
+1) a distribution describing the likelihood of the observed data, given the parameter values,
+2) the parameter value or summary stat we're calibrating on
+ */
+final case class SBC[T, L <: Distribution[T]](priors: Seq[Continuous],
+                                              fn: Seq[Real] => (L, Real)) {
 
   import SBC._
 
-  val priorGenerator = Generator.traverse(priorGenerators)
+  val priorGenerator = Generator.traverse(priors.map(_.generator))
 
   def animate(sampler: Sampler,
               warmupIterations: Int,
@@ -96,21 +102,27 @@ final case class SBC[T, L <: Distribution[T]](
                      warmupIterations: Int,
                      syntheticSamples: Int,
                      thin: Int)(implicit rng: RNG): (Int, Double, Double) = {
-    val trueValues = priorGenerator.get(rng, emptyEvaluator)
-    implicit val trueEval = new Evaluator(priorParams.zip(trueValues).toMap)
-    val trueOutput = posterior.map(_._2).toGenerator.value.get
-    val syntheticValues =
-      posterior
-        .map { case (l, _) => l.generator.repeat(syntheticSamples) }
-        .toGenerator
-        .value
-        .get
-    val model = posterior.flatMap {
-      case (d, r) =>
-        RandomVariable.fit(d, syntheticValues).map { _ =>
-          r
+    val (syntheticValues, trueOutput) =
+      priorGenerator
+        .flatMap { priorParams =>
+          val (d, r) = fn(Real.seq(priorParams))
+          d.generator
+            .repeat(syntheticSamples)
+            .zip(Generator.real(r))
         }
-    }
+        .get(rng, emptyEvaluator)
+
+    val model =
+      RandomVariable
+        .traverse(priors.map(_.param))
+        .flatMap { priorParams =>
+          val (d, r) = fn(priorParams)
+          RandomVariable
+            .fit(d, syntheticValues)
+            .map { _ =>
+              r
+            }
+        }
     val (samples, diag) = model.sampleWithDiagnostics(sampler,
                                                       Chains,
                                                       warmupIterations,
@@ -193,26 +205,11 @@ final case class SBC[T, L <: Distribution[T]](
 object SBC {
   val emptyEvaluator = new Evaluator(Map.empty)
 
-  /*
-  fn is a function that takes a Seq[Real]
-  specifying the values of all the parameters (one for each Continuous in the prior)
-  and returns a (Distribution[T], Real) which is a pair of values:
-  1) a distribution describing the likelihood of the observed data, given the parameter values,
-  2) the parameter value or summary stat we're calibrating on
-   */
-  def apply[T, L <: Distribution[T]](priors: Seq[Continuous])(
-      fn: Seq[Real] => (L, Real)): SBC[T, L] = {
-    val priorParams = priors.map(_.param)
-    val priorGenerators = priors.map(_.generator)
-    val posterior = RandomVariable.traverse(priorParams).map(fn)
-    SBC(priorGenerators, priorParams.map(_.value), posterior)
-  }
-
   def apply[T, L <: Distribution[T]](prior: Continuous)(
       fn: Real => L): SBC[T, L] =
-    apply(List(prior)) { l =>
+    apply(List(prior), { l =>
       (fn(l.head), l.head)
-    }
+    })
 
   val Samples = 1024
   val Chains = 4


### PR DESCRIPTION
(this is a standalone version of a fix I already added to mio's branch)

This gives the `SBC` case class the `(priors: Seq[Continuous], fn: Seq[Real] => (L, Real))` interface that used to be just a convenience `apply` method on its companion object. By giving it the `prior => noise dist` as a function, rather than a pre-constructed RV, we can evaluate it in double-space rather than Real-space when we're synthesizing data, which is faster, simpler, and more robust. The parallel structure between the synthesis mode and the inference mode is now also more obvious.