### PR TITLE
sbc-based benchmarks

### DIFF
--- a/rainier-benchmark/src/main/scala/com/stripe/rainier/bench/SBCBenchmark.scala
+++ b/rainier-benchmark/src/main/scala/com/stripe/rainier/bench/SBCBenchmark.scala
@@ -1,0 +1,24 @@
+package com.stripe.rainier.bench
+
+import org.openjdk.jmh.annotations._
+import java.util.concurrent.TimeUnit
+
+import com.stripe.rainier.compute._
+import com.stripe.rainier.core._
+import com.stripe.rainier.sampler._
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(3)
+@Threads(4)
+@State(Scope.Benchmark)
+abstract class SBCBenchmark {
+  implicit val rng: RNG = RNG.default
+
+  protected def sbc: SBC[_,_]
+  
+  @Benchmark
+  def build = expression
+}

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/SBC.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/SBC.scala
@@ -53,6 +53,31 @@ final case class SBC[T, L <: Distribution[T]](priors: Seq[Continuous],
     repStream(sampler, warmupIterations, syntheticSamples, bins, reps)
   }
 
+  def synthesize(samples: Int)(implicit rng: RNG): (Seq[T], Double) =
+    priorGenerator
+      .flatMap { priorParams =>
+        val (d, r) = fn(Real.seq(priorParams))
+        d.generator
+          .repeat(samples)
+          .zip(Generator.real(r))
+      }
+      .get(rng, emptyEvaluator)
+
+  def fit(values: Seq[T]): RandomVariable[Real] =
+    RandomVariable
+      .traverse(priors.map(_.param))
+      .flatMap { priorParams =>
+        val (d, r) = fn(priorParams)
+        RandomVariable
+          .fit(d, values)
+          .map { _ =>
+            r
+          }
+      }
+
+  def model(syntheticSamples: Int)(implicit rng: RNG): RandomVariable[Real] =
+    fit(synthesize(syntheticSamples)._1)
+
   private def repStream(sampler: Sampler,
                         warmupIterations: Int,
                         syntheticSamples: Int,
@@ -102,34 +127,17 @@ final case class SBC[T, L <: Distribution[T]](priors: Seq[Continuous],
                      warmupIterations: Int,
                      syntheticSamples: Int,
                      thin: Int)(implicit rng: RNG): (Int, Double, Double) = {
-    val (syntheticValues, trueOutput) =
-      priorGenerator
-        .flatMap { priorParams =>
-          val (d, r) = fn(Real.seq(priorParams))
-          d.generator
-            .repeat(syntheticSamples)
-            .zip(Generator.real(r))
-        }
-        .get(rng, emptyEvaluator)
+    val (syntheticValues, trueOutput) = synthesize(syntheticSamples)
+    val model = fit(syntheticValues)
 
-    val model =
-      RandomVariable
-        .traverse(priors.map(_.param))
-        .flatMap { priorParams =>
-          val (d, r) = fn(priorParams)
-          RandomVariable
-            .fit(d, syntheticValues)
-            .map { _ =>
-              r
-            }
-        }
-    val (samples, diag) = model.sampleWithDiagnostics(sampler,
-                                                      Chains,
-                                                      warmupIterations,
-                                                      (Samples / Chains) * thin,
-                                                      true,
-                                                      1,
-                                                      thin)
+    val (samples, diag) =
+      model.sampleWithDiagnostics(sampler,
+                                  Chains,
+                                  warmupIterations,
+                                  (Samples / Chains) * thin,
+                                  true,
+                                  1,
+                                  thin)
 
     val maxRHat = diag.map(_.rHat).max
     val minEffectiveSampleSize = diag.map(_.effectiveSampleSize).min


### PR DESCRIPTION
Consistent with the SBC-based testing, start to move to benchmarks that also use the SBC objects as a model specification - this does away with any need to explicitly provide synthetic data as part of a benchmark.

This does not use the same SBCModel objects as the tests do, because I'm not sure how well the benchmark annotations would mesh with the test classes, and because it's not clear you want to benchmark the exact same models as you use for testing. But the basic idea is the same.

This also allows us to benchmark batched/placeholdered vs inlined treatment of data, though I'm not happy with the need to define separate classes for different parameterizations of the batching and data size; I'd rather automatically do a kind of grid search over that.