### PR TITLE
optimize `product` for `cats.Monad` instance for `Generator`

### DIFF
--- a/rainier-cats/src/main/scala/com/stripe/rainier/cats/package.scala
+++ b/rainier-cats/src/main/scala/com/stripe/rainier/cats/package.scala
@@ -21,6 +21,10 @@ private[cats] class MonadGenerator extends Monad[Generator] {
   override def map[A, B](fa: Generator[A])(f: A => B): Generator[B] =
     fa.map(f)
 
+  override def product[A, B](fa: Generator[A],
+                             fb: Generator[B]): Generator[(A, B)] =
+    fa.zip(fb)
+
   def flatMap[A, B](fa: Generator[A])(f: A => Generator[B]): Generator[B] =
     fa.flatMap(f)
 

--- a/rainier-cats/src/main/scala/com/stripe/rainier/cats/package.scala
+++ b/rainier-cats/src/main/scala/com/stripe/rainier/cats/package.scala
@@ -51,6 +51,9 @@ private[cats] class MonadRandomVariable extends Monad[RandomVariable] {
       f: A => RandomVariable[B]): RandomVariable[B] =
     fa.flatMap(f)
 
+  override def product[A, B](fa: RandomVariable[A], fb: RandomVariable[B]): RandomVariable[(A, B)] =
+    fa.zip(fb)
+
   @tailrec final def tailRecM[A, B](a: A)(
       f: A => RandomVariable[Either[A, B]]): RandomVariable[B] =
     f(a).value match {


### PR DESCRIPTION
also changed the one for `RandomVariable`to point to zip but it's essentially the same implementation. 