### PR TITLE
Use a multi-output CF to compile batched targets

### DIFF
--- a/rainier-benchmark/src/main/scala/com/stripe/rainier/bench/SBCBenchmark.scala
+++ b/rainier-benchmark/src/main/scala/com/stripe/rainier/bench/SBCBenchmark.scala
@@ -21,25 +21,25 @@ abstract class SBCBenchmark {
   protected def batches: Int = 1
 
   val s = sbc
-  val context = build
+  val model = build
+  val context = model.context
   val vars = context.variables
   val cf = compile
-  val inlined = inline
+  val inlined = context.density
   val inlinecf = compileInlined
 
   @Benchmark
   def synthesize = s.synthesize(syntheticSamples)
 
   @Benchmark
-  def build = s.model(syntheticSamples).context(batches)
+  def build = s.model(syntheticSamples)
 
   @Benchmark
   def compile =
     context.compileDensity
 
   @Benchmark
-  def inline =
-    context.base + context.batched.inlined
+  def inline = model.context.density
 
   @Benchmark
   def compileInlined =

--- a/rainier-benchmark/src/main/scala/com/stripe/rainier/bench/SBCBenchmark.scala
+++ b/rainier-benchmark/src/main/scala/com/stripe/rainier/bench/SBCBenchmark.scala
@@ -18,7 +18,6 @@ abstract class SBCBenchmark {
 
   protected def sbc: SBC[_, _]
   protected def syntheticSamples: Int = 1000
-  protected def batches: Int = 1
 
   val s = sbc
   val model = build
@@ -67,7 +66,6 @@ class SBCNormalBenchmark extends SBCBenchmark {
 
 class SBCNormalBenchmark100k extends SBCNormalBenchmark {
   override def syntheticSamples = 100000
-  override def batches = 100
 }
 
 class SBCLaplaceBenchmark extends SBCBenchmark {
@@ -78,5 +76,4 @@ class SBCLaplaceBenchmark extends SBCBenchmark {
 
 class SBCLaplaceBenchmark100k extends SBCLaplaceBenchmark {
   override def syntheticSamples = 100000
-  override def batches = 100
 }

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Context.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Context.scala
@@ -1,70 +1,30 @@
 package com.stripe.rainier.compute
 
-case class Context(base: Real, batched: Target) {
+case class Context(base: Real, batched: Seq[Target]) {
   val compiler: Compiler = IRCompiler(200, 100)
 
   val variables: List[Variable] = {
     val allVariables =
-      RealOps.variables(base) ++
-        RealOps.variables(batched.real) --
-        batched.placeholderVariables
+      batched.foldLeft(RealOps.variables(base)) {
+        case (set, target) =>
+          set ++ target.variables
+      }
     allVariables.toList.sortBy(_.param.sym.id)
   }
 
   //convenience method for simple cases like Walkers
-  def compileDensity: Array[Double] => Double = {
-    val baseCF = compiler.compile(variables, base)
-    val batchCF = compileBatched
-
-    val result = { input: Array[Double] =>
-      baseCF(input) + batchCF(input)
-    }
-    result
-  }
-
-  //not terribly efficient
-  private def compileBatched: Array[Double] => Double = {
-    if (batched.nRows == 0) {
-      compiler.compile(variables, base + batched.real)
-    } else {
-      val cf = compiler.compile(variables ++ batched.placeholderVariables,
-                                batched.real)
-
-      val result = { input: Array[Double] =>
-        0.until(batched.nRows)
-          .map { i =>
-            val extraInputs =
-              batched.placeholderVariables.map { v =>
-                batched.placeholders(v)(i)
-              }.toArray
-            cf(input ++ extraInputs)
-          }
-          .sum
-      }
-      result
-    }
-  }
+  def compileDensity: Array[Double] => Double = ???
 
   //these are for backwards compatibility to allow HMC to keep working
   //they will not make sense in the general case going forward
-  lazy val density: Real = base + batched.inlined
+  lazy val density: Real =
+    batched.foldLeft(base) { case (r, t) => r + t.inlined }
 
   lazy val gradient: List[Real] =
     Gradient.derive(variables, density)
 }
 
 object Context {
-  def apply(real: Real): Context = Context(real, Target.empty)
-  def apply(nBatches: Int, targets: Iterable[Target]): Context = {
-    val (base, batched, batches) =
-      targets
-        .foldLeft((Real.zero, Real.zero, Map.empty[Variable, Array[Double]])) {
-          case ((oldBase, oldBatched, oldBatches), target) =>
-            val (batchedTarget, remainder) = target.batched(nBatches)
-            (oldBase + remainder,
-             oldBatched + batchedTarget.real,
-             oldBatches ++ batchedTarget.placeholders)
-        }
-    Context(base, new Target(batched, batches))
-  }
+  def apply(real: Real): Context = Context(real, Nil)
+  def apply(targets: Iterable[Target]): Context = ???
 }

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Context.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Context.scala
@@ -13,7 +13,51 @@ case class Context(base: Real, batched: Seq[Target]) {
   }
 
   //convenience method for simple cases like Walkers
-  def compileDensity: Array[Double] => Double = ???
+  def compileDensity: Array[Double] => Double = {
+    val batchedVariables = batched.flatMap(_.placeholderVariables)
+    val updaters = batched.map(_.updater)
+    val updaterVariables = updaters.flatMap(_._2)
+    val inputVars = variables ++ batchedVariables ++ updaterVariables
+    val outputs = base :: batched.map(_.real).toList ++ updaters
+      .map(_._1)
+      .toList
+    val cf = compiler.compileUnsafe(inputVars, outputs)
+
+    { inputs: Array[Double] =>
+      val globals = new Array[Double](cf.numGlobals)
+      //collect the log-prior from the `base` output
+      var output = cf.output(inputs, globals, 0)
+      val fullInputs = new Array[Double](inputVars.size)
+      System.arraycopy(inputs, 0, fullInputs, 0, inputs.size)
+      //for each of the targets, in order, collect the log-likelihood from the
+      //first observation, thereby also inializing any needed global state
+      batched.zipWithIndex.foreach {
+        case (target, j) =>
+          var i = inputs.size
+          target.placeholderVariables.foreach { v =>
+            fullInputs(i) = target.placeholders(v)(0)
+            i += 1
+          }
+          output += cf.output(fullInputs, globals, j + 1)
+      }
+      //for each of the targets, in turn, collect the log-likelihood from each of
+      //their remaining observations
+      batched.zipWithIndex.foreach {
+        case (target, j) =>
+          var k = 1
+          while (k < target.nRows) {
+            var i = inputs.size + batchedVariables.size
+            target.placeholderVariables.foreach { v =>
+              fullInputs(i) = target.placeholders(v)(k)
+              i += 1
+            }
+            output += cf.output(fullInputs, globals, j + batched.size + 1)
+            k += 1
+          }
+      }
+      output
+    }
+  }
 
   //these are for backwards compatibility to allow HMC to keep working
   //they will not make sense in the general case going forward
@@ -26,5 +70,10 @@ case class Context(base: Real, batched: Seq[Target]) {
 
 object Context {
   def apply(real: Real): Context = Context(real, Nil)
-  def apply(targets: Iterable[Target]): Context = ???
+  def apply(targets: Iterable[Target]): Context = {
+    val (noPlaceholders, hasPlaceholders) =
+      targets.partition(_.placeholders.isEmpty)
+    val base = Real.sum(noPlaceholders.map(_.real))
+    Context(base, hasPlaceholders.toList)
+  }
 }

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Target.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Target.scala
@@ -7,7 +7,7 @@ class Target(val real: Real, val placeholders: Map[Variable, Array[Double]]) {
     else
       placeholders.head._2.size
 
-  val placeholderVariables = placeholders.keys.toList
+  val placeholderVariables: List[Variable] = placeholders.keys.toList
   val variables: Set[Variable] = RealOps.variables(real) -- placeholderVariables
 
   def inlined: Real =
@@ -22,6 +22,15 @@ class Target(val real: Real, val placeholders: Map[Variable, Array[Double]]) {
       }
       Real.sum(inlinedRows.toList)
     }
+
+  def updater: (Real, List[Variable]) = {
+    val newVars = placeholderVariables.map { _ =>
+      new Variable
+    }
+    val newReal =
+      PartialEvaluator.inline(real, placeholderVariables.zip(newVars).toMap)
+    (newReal, newVars)
+  }
 }
 
 object Target {

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Target.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Target.scala
@@ -40,7 +40,6 @@ class Target(val real: Real, val placeholders: Map[Variable, Array[Double]]) {
         i += 1
         result match {
           case l: Line if (l.ax.size > MAX_INLINE_TERMS) =>
-            println("!" + l.ax.size)
             return None
           case _ => ()
         }

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Target.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Target.scala
@@ -10,17 +10,42 @@ class Target(val real: Real, val placeholders: Map[Variable, Array[Double]]) {
   val placeholderVariables: List[Variable] = placeholders.keys.toList
   val variables: Set[Variable] = RealOps.variables(real) -- placeholderVariables
 
+  private def inlineRow(i: Int): Real = {
+    val row: Map[Variable, Real] = placeholders.map {
+      case (v, a) => v -> Real(a(i))
+    }
+    PartialEvaluator.inline(real, row)
+  }
+
   def inlined: Real =
     if (placeholders.isEmpty)
       real
     else {
-      val inlinedRows = 0.until(nRows).map { i =>
-        val row: Map[Variable, Real] = placeholders.map {
-          case (v, a) => v -> Real(a(i))
+      val inlinedRows =
+        0.until(nRows).map { i =>
+          inlineRow(i)
         }
-        PartialEvaluator.inline(real, row)
-      }
       Real.sum(inlinedRows.toList)
+    }
+
+  val MAX_INLINE_TERMS = 5000
+  def maybeInlined: Option[Real] =
+    if (placeholders.isEmpty)
+      Some(real)
+    else {
+      var result = Real.zero
+      var i = 0
+      while (i < nRows) {
+        result += inlineRow(i)
+        i += 1
+        result match {
+          case l: Line if (l.ax.size > MAX_INLINE_TERMS) =>
+            println("!" + l.ax.size)
+            return None
+          case _ => ()
+        }
+      }
+      Some(result)
     }
 
   def updater: (Real, List[Variable]) = {

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Target.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Target.scala
@@ -1,76 +1,27 @@
 package com.stripe.rainier.compute
 
 class Target(val real: Real, val placeholders: Map[Variable, Array[Double]]) {
-  val nRows = size(placeholders)
-  val placeholderVariables = placeholders.keys.toList
-
-  def inlined = inl(placeholders)
-
-  def batched(nBatches: Int): (Target, Real) =
+  val nRows =
     if (placeholders.isEmpty)
-      (this, Real.zero)
-    else if (nBatches == 1)
-      (Target.empty, inlined)
-    else {
-      val nCopies = nRows / nBatches
-      val (realCopies, variableCopies) = makeCopies(nCopies)
-      val newReal = Real.sum(realCopies)
-      val newPlaceholders = makePlaceholders(variableCopies, nBatches).toMap
-      val newTarget = new Target(newReal, newPlaceholders)
-      val remainder = makeRemainder(nBatches, nCopies)
-      (newTarget, remainder)
-    }
+      0
+    else
+      placeholders.head._2.size
 
-  private def makeCopies(
-      nCopies: Int): (Seq[Real], Seq[Map[Variable, Variable]]) =
-    0.until(nCopies)
-      .map { _ =>
-        val variablesCopy = placeholderVariables.map { v =>
-          v -> new Variable
-        }.toMap
-        val realCopy = PartialEvaluator.inline(real, variablesCopy)
-        (realCopy, variablesCopy)
-      }
-      .unzip
+  val placeholderVariables = placeholders.keys.toList
+  val variables: Set[Variable] = RealOps.variables(real) -- placeholderVariables
 
-  private def makePlaceholders(variableCopies: Seq[Map[Variable, Variable]],
-                               nBatches: Int): Seq[(Variable, Array[Double])] =
-    for {
-      (copyVariables, i) <- variableCopies.zipWithIndex
-      (v, cv) <- copyVariables
-    } yield {
-      cv -> placeholders(v).slice(i * nBatches, (i + 1) * nBatches)
-    }
-
-  private def makeRemainder(nBatches: Int, nCopies: Int): Real =
-    if (nCopies * nBatches == nRows)
-      Real.zero
-    else {
-      val data = placeholders.map {
-        case (v, d) =>
-          v -> d.slice(nCopies * nBatches, nRows)
-      }
-      inl(data)
-    }
-
-  private def inl(data: Map[Variable, Array[Double]]): Real =
-    if (data.isEmpty)
+  def inlined: Real =
+    if (placeholders.isEmpty)
       real
     else {
-      val inlined = 0.until(size(data)).map { i =>
-        val row: Map[Variable, Real] = data.map {
+      val inlinedRows = 0.until(nRows).map { i =>
+        val row: Map[Variable, Real] = placeholders.map {
           case (v, a) => v -> Real(a(i))
         }
         PartialEvaluator.inline(real, row)
       }
-      Real.sum(inlined.toList)
+      Real.sum(inlinedRows.toList)
     }
-
-  private def size(data: Map[Variable, Array[Double]]): Int =
-    if (data.isEmpty)
-      0
-    else
-      data.head._2.size
 }
 
 object Target {

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/RandomVariable.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/RandomVariable.scala
@@ -42,7 +42,7 @@ class RandomVariable[+T](val value: T, private val targets: Set[Target]) {
              batches: Int = 1,
              keepEvery: Int = 1)(implicit rng: RNG): Recording = {
     val posteriorParams = Sampler
-      .sample(Context(batches, targets),
+      .sample(Context(targets),
               sampler,
               warmupIterations,
               iterations,
@@ -82,7 +82,7 @@ class RandomVariable[+T](val value: T, private val targets: Set[Target]) {
       iterations: Int,
       batches: Int = 1,
       keepEvery: Int = 1)(implicit rng: RNG, tg: ToGenerator[T, V]): List[V] = {
-    val ctx = context(batches)
+    val ctx = Context(targets)
     val fn = tg(value).prepare(ctx)
     Sampler
       .sample(ctx, sampler, warmupIterations, iterations, keepEvery)
@@ -100,7 +100,7 @@ class RandomVariable[+T](val value: T, private val targets: Set[Target]) {
                                keepEvery: Int = 1)(
       implicit rng: RNG,
       tg: ToGenerator[T, V]): (List[V], List[Diagnostics]) = {
-    val ctx = context(batches)
+    val ctx = Context(targets)
     val fn = tg(value).prepare(ctx)
     val range = if (parallel) 1.to(chains).par else 1.to(chains)
     val samples =
@@ -133,7 +133,7 @@ class RandomVariable[+T](val value: T, private val targets: Set[Target]) {
       implicit tg: ToGenerator[T, U]): RandomVariable[Generator[U]] =
     new RandomVariable(tg(value), targets)
 
-  def context(batches: Int) = Context(batches, targets)
+  def context = Context(targets)
 }
 
 /**

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/RandomVariable.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/RandomVariable.scala
@@ -39,7 +39,6 @@ class RandomVariable[+T](val value: T, private val targets: Set[Target]) {
   def record(sampler: Sampler,
              warmupIterations: Int,
              iterations: Int,
-             batches: Int = 1,
              keepEvery: Int = 1)(implicit rng: RNG): Recording = {
     val posteriorParams = Sampler
       .sample(Context(targets),
@@ -80,7 +79,6 @@ class RandomVariable[+T](val value: T, private val targets: Set[Target]) {
       sampler: Sampler,
       warmupIterations: Int,
       iterations: Int,
-      batches: Int = 1,
       keepEvery: Int = 1)(implicit rng: RNG, tg: ToGenerator[T, V]): List[V] = {
     val ctx = Context(targets)
     val fn = tg(value).prepare(ctx)
@@ -96,7 +94,6 @@ class RandomVariable[+T](val value: T, private val targets: Set[Target]) {
                                warmupIterations: Int,
                                iterations: Int,
                                parallel: Boolean = true,
-                               batches: Int = 1,
                                keepEvery: Int = 1)(
       implicit rng: RNG,
       tg: ToGenerator[T, V]): (List[V], List[Diagnostics]) = {

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/SBC.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/SBC.scala
@@ -136,7 +136,6 @@ final case class SBC[T, L <: Distribution[T]](priors: Seq[Continuous],
                                   warmupIterations,
                                   (Samples / Chains) * thin,
                                   true,
-                                  1,
                                   thin)
 
     val maxRHat = diag.map(_.rHat).max

--- a/rainier-example/src/main/scala/com/stripe/rainier/example/BatchNormal.scala
+++ b/rainier-example/src/main/scala/com/stripe/rainier/example/BatchNormal.scala
@@ -22,6 +22,6 @@ object BatchNormal {
   }
 
   def main(args: Array[String]): Unit = {
-    plot2D(model(100000).sample(Walkers(100), 10000, 10000, batches = 1000))
+    plot2D(model(100000).sample(Walkers(100), 10000, 10000))
   }
 }


### PR DESCRIPTION
This is an alternative approach to the single-matrix batched evaluation currently in `develop`. The meat of it is in `Context.compileDensity`.

There's two ideas here:

1. Previously, we did a lot of work to assemble a single matrix with a consistent number of rows (`batches`), which covered potentially multiple `Target` objects from different calls to `fit` in the same model. This allowed us to minimize the number of calls to a compiled function as we streamed through the observational data. 

Here, we instead arrange to make exactly one compiled function call for each observation (plus one call to compute the prior). This makes everything much simpler, at the cost of having potentially many more individual calls.

2. Because we are now making a lot more calls, it is much more important that they be able to reuse intermediate results rather than computing everything from scratch each time. To achieve this, we do the following:

- first, we compile everything (the prior and all of the likelihood targets) into a single CompileFunction, which means that they all share the same `globals` array, and if some value is referenced by more than one of them, it will be stored there and reused rather than recomputed. However, due to https://github.com/stripe/rainier/pull/212, this does not stop us from individually computing the outputs, including calling different output functions different numbers of times, as long as we are careful about the order in which we do so.
- second, we create a *second copy* of each likelihood function coming from a `Target` (via `Target.updater`), which replaces the original placeholder variables with a new set of placeholder variables. We sequence these copies after all of the originals in the compilation. This means that any intermediate computations that occur in the likelihood function, that do *not* depend on the placeholder variables, will turn into global state and the second, "updater" copy will have those as global var references; however, anything that *does* depend on the placeholder variables will, because these have been replaced with new ones, still be recomputed.

With this setup, if we first use the original copy of the likelihood function for the first observation from each target, thereby setting up global state, we can then use the "updater" copy for all subsequence observations, and recompute only what is necessary given the new values there.

We make no attempt in this PR to do the equivalent computation for gradients, although it's a fairly straightforward extension of the above.