### PR TITLE
cover all IR cases in packer

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/ir/Packer.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/ir/Packer.scala
@@ -11,23 +11,34 @@ private class Packer(methodSizeLimit: Int) {
     createMethod(pIR)
   }
 
-  private def traverse(p: IR): (IR, Int) = p match {
-    case v: VarDef =>
-      val (rhsIR, rhsSize) =
-        traverseAndMaybePack(v.rhs, methodSizeLimit - 1)
-      (new VarDef(v.sym, rhsIR), rhsSize + 1)
-    case b: BinaryIR =>
-      val (leftIR, leftSize) =
-        traverseAndMaybePack(b.left, methodSizeLimit / 2)
-      val (rightIR, rightSize) =
-        traverseAndMaybePack(b.right, methodSizeLimit / 2)
-      (new BinaryIR(leftIR, rightIR, b.op), leftSize + rightSize + 1)
-    case u: UnaryIR =>
-      val (originalIR, irSize) =
-        traverseAndMaybePack(u.original, methodSizeLimit - 1)
-      (new UnaryIR(originalIR, u.op), irSize + 1)
-    case _ => (p, 1)
-  }
+  private def traverse(p: IR): (IR, Int) =
+    p match {
+      case v: VarDef =>
+        val (rhsIR, rhsSize) =
+          traverseAndMaybePack(v.rhs, methodSizeLimit - 1)
+        (new VarDef(v.sym, rhsIR), rhsSize + 1)
+      case b: BinaryIR =>
+        val (leftIR, leftSize) =
+          traverseAndMaybePack(b.left, methodSizeLimit / 2)
+        val (rightIR, rightSize) =
+          traverseAndMaybePack(b.right, methodSizeLimit / 2)
+        (new BinaryIR(leftIR, rightIR, b.op), leftSize + rightSize + 1)
+      case u: UnaryIR =>
+        val (originalIR, irSize) =
+          traverseAndMaybePack(u.original, methodSizeLimit - 1)
+        (new UnaryIR(originalIR, u.op), irSize + 1)
+      case f: IfIR =>
+        val (testIR, testSize) =
+          traverseAndMaybePack(f.test, methodSizeLimit / 3)
+        val (nzIR, nzSize) =
+          traverseAndMaybePack(f.whenNonZero, methodSizeLimit / 3)
+        val (zIR, zSize) =
+          traverseAndMaybePack(f.whenZero, methodSizeLimit / 3)
+        (new IfIR(testIR, nzIR, zIR), testSize + nzSize + zSize + 1)
+      case _: Ref => (p, 1)
+      case MethodDef(_, _) | MethodRef(_) =>
+        sys.error("This should never happen")
+    }
 
   private def traverseAndMaybePack(p: IR, localSizeLimit: Int): (IR, Int) = {
     val (pt, size) = traverse(p)


### PR DESCRIPTION
We were using a default case when traversing the IR tree in Packer, which was obscuring the fact that we weren't handling `IfIR`, leading methods to be too big if there were large sub-trees under an if. This fixes that and explicitly enumerates all of the cases so we'll notice if we ever add another node type.