### PR TITLE
fix batchBits > 0

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/core/RandomVariable.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/RandomVariable.scala
@@ -111,7 +111,7 @@ class RandomVariable[+T](val value: T, private val targets: Set[Target]) {
 
   lazy val (variables, density) = compile()
   private def compile() = {
-    val (variables, dataFn) = Compiler.default.compileTargets(targets, true, 0)
+    val (variables, dataFn) = Compiler.default.compileTargets(targets, true, 4)
     val densityFn = new DensityFunction {
       val nVars = variables.size
       val inputs = new Array[Double](dataFn.numInputs)


### PR DESCRIPTION
The layout DataFunction was expecting for batchBits > 0 did not match the layout being generated by Target. This fixes them to be the same, and bumps the default batchBits to 4.