### PR TITLE
conveniences for Regression example

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Real.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Real.scala
@@ -53,6 +53,9 @@ object Real {
   def sum(seq: Iterable[Real]): Real =
     seq.foldLeft(Real.zero)(_ + _)
 
+  def dot(left: Iterable[Real], right: Iterable[Real]): Real =
+    sum(left.zip(right).map { case (a, b) => a * b })
+
   def logSumExp(seq: Iterable[Real]): Real = {
     val max = seq.reduce(_ max _)
     val shifted = seq.map { x =>

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Predictor.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Predictor.scala
@@ -59,4 +59,8 @@ object Predictor {
   def fromDouble[Y, B](
       fn: Real => Distribution.Aux[Y, B]): Predictor[Double, Y] =
     from[Double, Y, Real, B](fn)
+
+  def fromDoubleVector[Y, B](
+      fn: Seq[Real] => Distribution.Aux[Y, B]): Predictor[Seq[Double], Y] =
+    from[Seq[Double], Y, Seq[Real], B](fn)
 }

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/RandomVariable.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/RandomVariable.scala
@@ -167,6 +167,9 @@ object RandomVariable {
       .map(_.reverse)
   }
 
+  def fill[A](k: Int)(fn: => RandomVariable[A]): RandomVariable[Seq[A]] =
+    traverse(List.fill(k)(fn))
+
   def fit[T, L](lh: L, value: T)(
       implicit ev: L <:< Likelihood[T]): RandomVariable[L] =
     new RandomVariable(lh, Set(ev(lh).target(value)))


### PR DESCRIPTION
A few things I've been meaning to add that are unrelated except that each of them makes the `Regression` example a bit nicer:

* `RandomVariable.fill` which is a `RandomVariable.traverse` combined with a `List.fill`
* `Real.dot` for dot products (not adding a new node type, just the convenience method)
* a `Mapping` from `Seq[Double]` to `Seq[Real]` (or any other Seq[T], Seq[U] where we have a mapping between T and U)
* a `Predictor.fromDoubleVector` which makes use of the above