### PR TITLE
smarter packer

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/ir/Packer.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/ir/Packer.scala
@@ -15,34 +15,34 @@ private class Packer(methodSizeLimit: Int) {
     p match {
       case v: VarDef =>
         val (rhsIR, rhsSize) =
-          traverseAndMaybePack(v.rhs, methodSizeLimit - 1)
+          traverseAndMaybePack(v.rhs, 1)
         (new VarDef(v.sym, rhsIR), rhsSize + 1)
       case b: BinaryIR =>
         val (leftIR, leftSize) =
-          traverseAndMaybePack(b.left, methodSizeLimit / 2)
+          traverseAndMaybePack(b.left, 2)
         val (rightIR, rightSize) =
-          traverseAndMaybePack(b.right, methodSizeLimit / 2)
+          traverseAndMaybePack(b.right, leftSize + 1)
         (new BinaryIR(leftIR, rightIR, b.op), leftSize + rightSize + 1)
       case u: UnaryIR =>
         val (originalIR, irSize) =
-          traverseAndMaybePack(u.original, methodSizeLimit - 1)
+          traverseAndMaybePack(u.original, 1)
         (new UnaryIR(originalIR, u.op), irSize + 1)
       case f: IfIR =>
         val (testIR, testSize) =
-          traverseAndMaybePack(f.test, methodSizeLimit / 3)
+          traverseAndMaybePack(f.test, 3)
         val (nzIR, nzSize) =
-          traverseAndMaybePack(f.whenNonZero, methodSizeLimit / 3)
+          traverseAndMaybePack(f.whenNonZero, testSize + 2)
         val (zIR, zSize) =
-          traverseAndMaybePack(f.whenZero, methodSizeLimit / 3)
+          traverseAndMaybePack(f.whenZero, testSize + nzSize + 1)
         (new IfIR(testIR, nzIR, zIR), testSize + nzSize + zSize + 1)
       case _: Ref => (p, 1)
       case MethodDef(_, _) | MethodRef(_) =>
         sys.error("This should never happen")
     }
 
-  private def traverseAndMaybePack(p: IR, localSizeLimit: Int): (IR, Int) = {
+  private def traverseAndMaybePack(p: IR, parentSize: Int): (IR, Int) = {
     val (pt, size) = traverse(p)
-    if (size >= localSizeLimit)
+    if ((size + parentSize) > methodSizeLimit)
       (createMethod(pt), 1)
     else
       (pt, size)


### PR DESCRIPTION
The packer is responsible for splitting up the method tree so that no individual subtree exceeds the maximum size we can JIT.

Before, for an n-ary operation (like If, which is ternary), we would evenly divide the method size allocation between each branch. This could lead to unnecessarily creating a new method when the branches were different sizes. Now, if the first branch is small, that will increase the allocation we give to the subsequent branches (and vice versa if the first branch is extremely large).