### PR TITLE
Better types for IR

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Compiler.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Compiler.scala
@@ -95,10 +95,10 @@ final case class IRCompiler(methodSizeLimit: Int, classSizeLimit: Int)
     val params = inputs.map { v =>
       v.param
     }
-    val irs = outputs.map { r =>
-      translator.toIR(r)
+    val exprs = outputs.map { r =>
+      translator.toExpr(r)
     }
-    CompiledFunction(params, irs, methodSizeLimit, classSizeLimit)
+    CompiledFunction(params, exprs, methodSizeLimit, classSizeLimit)
   }
 }
 

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Gradient.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Gradient.scala
@@ -100,6 +100,7 @@ private object Gradient {
         If(child.original, gradient.toReal * child.original / child, Real.zero)
       case RectifierOp =>
         If(child.original < 0, Real.zero, gradient.toReal)
+      case NoOp => gradient.toReal
     }
   }
 

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Real.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Real.scala
@@ -68,20 +68,20 @@ object Real {
   //would produce as JVM bytecode
   def trace(real: Real): Unit = {
     val translator = new Translator
-    val irs = List(translator.toIR(real))
+    val exprs = List(translator.toExpr(real))
     val params = RealOps.variables(real).toList.map(_.param)
-    ir.Tracer.trace(params, irs)
+    ir.Tracer.trace(params, exprs)
   }
 
   def traceGradient(real: Real): Unit = {
     val translator = new Translator
     val variables = RealOps.variables(real).toList
     val gradient = Gradient.derive(variables, real)
-    val irs = gradient.map { r =>
-      translator.toIR(r)
+    val exprs = gradient.map { r =>
+      translator.toExpr(r)
     }
     val params = variables.map(_.param)
-    ir.Tracer.trace(params, irs)
+    ir.Tracer.trace(params, exprs)
   }
 
   private[compute] val BigZero = BigDecimal(0.0)

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/RealOps.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/RealOps.scala
@@ -15,6 +15,7 @@ private[compute] object RealOps {
               "Cannot take the log of a negative number")
           case AbsOp       => Infinity
           case RectifierOp => Real.zero
+          case NoOp        => original
         }
       case Constant(Real.BigZero) =>
         op match {
@@ -22,6 +23,7 @@ private[compute] object RealOps {
           case LogOp       => NegInfinity
           case AbsOp       => Real.zero
           case RectifierOp => Real.zero
+          case NoOp        => original
         }
       case Constant(value) =>
         op match {
@@ -38,6 +40,7 @@ private[compute] object RealOps {
               Real.zero
             else
               original
+          case NoOp => original
         }
       case nc: NonConstant =>
         val opt = (op, nc) match {

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Translator.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Translator.scala
@@ -6,30 +6,32 @@ private class Translator {
   private val binary = new SymCache[BinaryOp]
   private val unary = new SymCache[UnaryOp]
   private val ifs = new SymCache[Unit]
-  private var reals = Map.empty[Real, IR]
+  private var reals = Map.empty[Real, Expr]
 
-  def toIR(r: Real): IR = reals.get(r) match {
-    case Some(ir) => ref(ir)
+  def toExpr(r: Real): Expr = reals.get(r) match {
+    case Some(expr) => ref(expr)
     case None =>
-      val ir = r match {
+      val expr = r match {
         case v: Variable         => v.param
         case Infinity            => Const(1.0 / 0.0)
         case NegInfinity         => Const(-1.0 / 0.0)
         case Constant(value)     => Const(value.toDouble)
-        case Unary(original, op) => unaryIR(toIR(original), op)
-        case i: If               => ifIR(toIR(i.whenNonZero), toIR(i.whenZero), toIR(i.test))
-        case l: Line             => lineIR(l)
-        case l: LogLine          => logLineIR(l)
-        case Pow(base, exponent) => binaryIR(toIR(base), toIR(exponent), PowOp)
+        case Unary(original, op) => unaryExpr(toExpr(original), op)
+        case i: If =>
+          ifExpr(toExpr(i.whenNonZero), toExpr(i.whenZero), toExpr(i.test))
+        case l: Line    => lineExpr(l)
+        case l: LogLine => logLineExpr(l)
+        case Pow(base, exponent) =>
+          binaryExpr(toExpr(base), toExpr(exponent), PowOp)
       }
-      reals += r -> ir
-      ir
+      reals += r -> expr
+      expr
   }
 
-  private def unaryIR(original: IR, op: UnaryOp): IR =
+  private def unaryExpr(original: Expr, op: UnaryOp): Expr =
     unary.memoize(List(List(original)), op, new UnaryIR(original, op))
 
-  private def binaryIR(left: IR, right: IR, op: BinaryOp): IR = {
+  private def binaryExpr(left: Expr, right: Expr, op: BinaryOp): Expr = {
     val key = List(left, right)
     val keys =
       if (op.isCommutative)
@@ -39,17 +41,17 @@ private class Translator {
     binary.memoize(keys, op, new BinaryIR(left, right, op))
   }
 
-  private def ifIR(whenZero: IR, whenNonZero: IR, test: IR): IR =
+  private def ifExpr(whenZero: Expr, whenNonZero: Expr, test: Expr): Expr =
     ifs.memoize(List(List(test, whenZero, whenNonZero)),
                 (),
                 new IfIR(test, whenZero, whenNonZero))
 
-  private def lineIR(line: Line): IR = {
+  private def lineExpr(line: Line): Expr = {
     val (y, k) = LineOps.factor(line)
     factoredLine(y.ax, y.b, k.toDouble, multiplyRing)
   }
 
-  private def logLineIR(line: LogLine): IR = {
+  private def logLineExpr(line: LogLine): Expr = {
     val (y, k) = LogLineOps.factor(line)
     factoredLine(y.ax, Real.BigOne, k.toDouble, powRing)
   }
@@ -84,7 +86,7 @@ private class Translator {
   private def factoredLine(ax: Coefficients,
                            b: BigDecimal,
                            factor: Double,
-                           ring: Ring): IR = {
+                           ring: Ring): Expr = {
     val terms = ax.toList
     val posTerms = terms.filter(_._2 > Real.BigZero)
     val negTerms =
@@ -96,7 +98,7 @@ private class Translator {
       else
         (Constant(b), Real.BigOne) :: posTerms
 
-    val (ir, sign) =
+    val (expr, sign) =
       (allPosTerms.isEmpty, negTerms.isEmpty) match {
         case (true, true)  => (Const(0.0), 1.0)
         case (true, false) => (combineTerms(negTerms, ring), -1.0)
@@ -104,39 +106,39 @@ private class Translator {
         case (false, false) =>
           val posSum = combineTerms(allPosTerms, ring)
           val negSum = combineTerms(negTerms, ring)
-          (binaryIR(posSum, negSum, ring.minus), 1.0)
+          (binaryExpr(posSum, negSum, ring.minus), 1.0)
       }
 
     (factor * sign) match {
-      case 1.0 => ir
+      case 1.0 => expr
       case -1.0 =>
-        binaryIR(Const(ring.zero), ir, ring.minus)
+        binaryExpr(Const(ring.zero), expr, ring.minus)
       case 2.0 =>
-        binaryIR(ir, ref(ir), ring.plus)
+        binaryExpr(expr, ref(expr), ring.plus)
       case k =>
-        binaryIR(ir, Const(k), ring.times)
+        binaryExpr(expr, Const(k), ring.times)
     }
   }
 
-  private def combineTerms(terms: Seq[(Real, BigDecimal)], ring: Ring): IR = {
-    val lazyIR = terms.map {
+  private def combineTerms(terms: Seq[(Real, BigDecimal)], ring: Ring): Expr = {
+    val lazyExpr = terms.map {
       case (x, Real.BigOne) =>
         () =>
-          toIR(x)
+          toExpr(x)
       case (x, Real.BigTwo) =>
         () =>
-          binaryIR(toIR(x), toIR(x), ring.plus)
+          binaryExpr(toExpr(x), toExpr(x), ring.plus)
       case (l: LogLine, a) => //this can only happen for a Line's terms
         () =>
           factoredLine(l.ax, a, 1.0, powRing)
       case (x, a) =>
         () =>
-          binaryIR(toIR(x), Const(a.toDouble), ring.times)
+          binaryExpr(toExpr(x), Const(a.toDouble), ring.times)
     }
-    combineTree(lazyIR, ring)
+    combineTree(lazyExpr, ring)
   }
 
-  private def combineTree(terms: Seq[() => IR], ring: Ring): IR =
+  private def combineTree(terms: Seq[() => Expr], ring: Ring): Expr =
     terms match {
       case Seq(t) => t()
       case _ =>
@@ -145,18 +147,17 @@ private class Translator {
             case Seq(t) => t
             case Seq(left, right) =>
               () =>
-                binaryIR(left(), right(), ring.plus)
+                binaryExpr(left(), right(), ring.plus)
             case _ => sys.error("Should only have 1 or 2 elems")
           },
           ring
         )
     }
 
-  private def ref(ir: IR): Ref =
-    ir match {
+  private def ref(expr: Expr): Ref =
+    expr match {
       case r: Ref         => r
       case VarDef(sym, _) => VarRef(sym)
-      case _              => sys.error("Should only see refs and vardefs")
     }
 
   private final class Ring(val times: BinaryOp,
@@ -168,16 +169,16 @@ private class Translator {
 
   /*
   This performs hash-consing aka the flyweight pattern to ensure that we don't
-  generate code to compute the same quantity twice. It keeps a cache keyed by one or more IR objects
-  along with some operation that will combine them to form a new IR. The IR keys are required
+  generate code to compute the same quantity twice. It keeps a cache keyed by one or more Expr objects
+  along with some operation that will combine them to form a new IR. The Expr keys are required
   to be in their lightweight Ref form rather than VarDefs - this is both to avoid the expensive
   recursive equality/hashing of a def, and also to ensure that we can memoize values derived from a def
   and its ref equally well.
    */
   private class SymCache[K] {
     var cache: Map[(List[Ref], K), Sym] = Map.empty
-    def memoize(irKeys: Seq[List[IR]], opKey: K, ir: => IR): IR = {
-      val refKeys = irKeys.map { l =>
+    def memoize(exprKeys: Seq[List[Expr]], opKey: K, ir: => IR): Expr = {
+      val refKeys = exprKeys.map { l =>
         l.map(ref)
       }
       val hit = refKeys.foldLeft(Option.empty[Sym]) {
@@ -186,7 +187,7 @@ private class Translator {
       }
       hit match {
         case Some(sym) =>
-          if (!irKeys.head.collect { case d: VarDef => d }.isEmpty)
+          if (!exprKeys.head.collect { case d: VarDef => d }.isEmpty)
             sys.error("VarRef was used before its VarDef")
           VarRef(sym)
         case None =>

--- a/rainier-core/src/main/scala/com/stripe/rainier/ir/CompiledFunction.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/ir/CompiledFunction.scala
@@ -9,13 +9,13 @@ trait CompiledFunction {
 
 object CompiledFunction {
   def apply(inputs: Seq[Parameter],
-            irs: Seq[IR],
+            exprs: Seq[Expr],
             methodSizeLimit: Int,
             classSizeLimit: Int): CompiledFunction = {
     val classPrefix = ClassGenerator.freshName
     val packer = new Packer(methodSizeLimit)
-    val outputMeths = irs.map { ir =>
-      packer.pack(ir)
+    val outputMeths = exprs.map { expr =>
+      packer.pack(expr)
     }
     val allMeths = packer.methods
     val varTypes = VarTypes.methods(allMeths.toList)

--- a/rainier-core/src/main/scala/com/stripe/rainier/ir/ExprMethodGenerator.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/ir/ExprMethodGenerator.scala
@@ -16,25 +16,12 @@ final private case class ExprMethodGenerator(method: MethodDef,
   traverse(method.rhs)
   returnDouble()
 
-  def traverse(ir: IR): Unit = {
-    ir match {
+  def traverse(expr: Expr): Unit =
+    expr match {
       case Const(value) =>
         constant(value)
       case p: Parameter =>
         loadParameter(varIndices(p))
-      case b: BinaryIR =>
-        traverse(b.left)
-        traverse(b.right)
-        binaryOp(b.op)
-      case u: UnaryIR =>
-        traverse(u.original)
-        unaryOp(u.op)
-      case i: IfIR =>
-        traverse(i.whenNonZero)
-        traverse(i.whenZero)
-        traverse(i.test)
-        constant(0.0)
-        swapIfEqThenPop()
       case v: VarDef =>
         varTypes(v.sym) match {
           case Inline =>
@@ -56,10 +43,24 @@ final private case class ExprMethodGenerator(method: MethodDef,
           case Global(i) =>
             loadGlobalVar(i)
         }
-      case MethodRef(sym) =>
-        callExprMethod(sym.id)
-      case _: MethodDef =>
-        sys.error("Should not have nested method defs")
     }
-  }
+
+  def traverse(ir: IR): Unit =
+    ir match {
+      case b: BinaryIR =>
+        traverse(b.left)
+        traverse(b.right)
+        binaryOp(b.op)
+      case u: UnaryIR =>
+        traverse(u.original)
+        unaryOp(u.op)
+      case i: IfIR =>
+        traverse(i.whenNonZero)
+        traverse(i.whenZero)
+        traverse(i.test)
+        constant(0.0)
+        swapIfEqThenPop()
+      case m: MethodRef =>
+        callExprMethod(m.sym.id)
+    }
 }

--- a/rainier-core/src/main/scala/com/stripe/rainier/ir/IR.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/ir/IR.scala
@@ -1,22 +1,23 @@
 package com.stripe.rainier.ir
 
-sealed trait IR
-
-sealed trait Ref extends IR
+sealed trait Expr
+sealed trait Ref extends Expr
 final class Parameter extends Ref {
   val sym = Sym.freshSym
 }
 final case class Const(value: Double) extends Ref
 final case class VarRef(sym: Sym) extends Ref
 
-final case class BinaryIR(left: IR, right: IR, op: BinaryOp) extends IR
-final case class UnaryIR(original: IR, op: UnaryOp) extends IR
-final case class IfIR(test: IR, whenNonZero: IR, whenZero: IR) extends IR
+final case class VarDef(sym: Sym, rhs: IR) extends Expr
 
-final case class VarDef(sym: Sym, rhs: IR) extends IR
-
-final case class MethodDef(sym: Sym, rhs: IR) extends IR
+sealed trait IR
+final case class BinaryIR(left: Expr, right: Expr, op: BinaryOp) extends IR
+final case class UnaryIR(original: Expr, op: UnaryOp) extends IR
+final case class IfIR(test: Expr, whenNonZero: Expr, whenZero: Expr) extends IR
 final case class MethodRef(sym: Sym) extends IR
+final case class MethodRoot(expr: Expr) extends IR
+
+final case class MethodDef(sym: Sym, rhs: IR)
 
 final case class Sym private (id: Int)
 object Sym {

--- a/rainier-core/src/main/scala/com/stripe/rainier/ir/IR.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/ir/IR.scala
@@ -15,7 +15,6 @@ final case class BinaryIR(left: Expr, right: Expr, op: BinaryOp) extends IR
 final case class UnaryIR(original: Expr, op: UnaryOp) extends IR
 final case class IfIR(test: Expr, whenNonZero: Expr, whenZero: Expr) extends IR
 final case class MethodRef(sym: Sym) extends IR
-final case class MethodRoot(expr: Expr) extends IR
 
 final case class MethodDef(sym: Sym, rhs: IR)
 

--- a/rainier-core/src/main/scala/com/stripe/rainier/ir/MethodGenerator.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/ir/MethodGenerator.scala
@@ -77,17 +77,20 @@ private trait MethodGenerator {
     }
 
   def unaryOp(op: UnaryOp): Unit = {
-    val (className, methodName) = op match {
-      case LogOp       => ("java/lang/Math", "log")
-      case ExpOp       => ("java/lang/Math", "exp")
-      case AbsOp       => ("java/lang/Math", "abs")
-      case RectifierOp => ("com/stripe/rainier/ir/MathOps", "rectifier")
+    (op match {
+      case LogOp       => Some(("java/lang/Math", "log"))
+      case ExpOp       => Some(("java/lang/Math", "exp"))
+      case AbsOp       => Some(("java/lang/Math", "abs"))
+      case RectifierOp => Some(("com/stripe/rainier/ir/MathOps", "rectifier"))
+      case NoOp        => None
+    }).foreach {
+      case (className, methodName) =>
+        methodNode.visitMethodInsn(INVOKESTATIC,
+                                   className,
+                                   methodName,
+                                   "(D)D",
+                                   false)
     }
-    methodNode.visitMethodInsn(INVOKESTATIC,
-                               className,
-                               methodName,
-                               "(D)D",
-                               false)
   }
 
   def classNameForMethod(id: Int): String =

--- a/rainier-core/src/main/scala/com/stripe/rainier/ir/Ops.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/ir/Ops.scala
@@ -24,3 +24,4 @@ case object ExpOp extends UnaryOp
 case object LogOp extends UnaryOp
 case object AbsOp extends UnaryOp
 case object RectifierOp extends UnaryOp
+case object NoOp extends UnaryOp

--- a/rainier-core/src/main/scala/com/stripe/rainier/ir/Packer.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/ir/Packer.scala
@@ -6,47 +6,49 @@ private class Packer(methodSizeLimit: Int) {
   private val methodDefs: mutable.Map[Sym, MethodDef] = mutable.Map.empty
   def methods: Set[MethodDef] = methodDefs.values.toSet
 
-  def pack(p: IR): MethodRef = {
-    val (pIR, _) = traverse(p)
-    createMethod(pIR)
+  def pack(p: Expr): MethodRef = {
+    val (pExpr, _) = traverse(p, 0)
+    createMethod(MethodRoot(pExpr))
   }
 
-  private def traverse(p: IR): (IR, Int) =
+  private def traverse(p: Expr, parentSize: Int): (Expr, Int) =
     p match {
       case v: VarDef =>
-        val (rhsIR, rhsSize) =
-          traverseAndMaybePack(v.rhs, 1)
-        (new VarDef(v.sym, rhsIR), rhsSize + 1)
-      case b: BinaryIR =>
-        val (leftIR, leftSize) =
-          traverseAndMaybePack(b.left, 2)
-        val (rightIR, rightSize) =
-          traverseAndMaybePack(b.right, leftSize + 1)
-        (new BinaryIR(leftIR, rightIR, b.op), leftSize + rightSize + 1)
-      case u: UnaryIR =>
-        val (originalIR, irSize) =
-          traverseAndMaybePack(u.original, 1)
-        (new UnaryIR(originalIR, u.op), irSize + 1)
-      case f: IfIR =>
-        val (testIR, testSize) =
-          traverseAndMaybePack(f.test, 3)
-        val (nzIR, nzSize) =
-          traverseAndMaybePack(f.whenNonZero, testSize + 2)
-        val (zIR, zSize) =
-          traverseAndMaybePack(f.whenZero, testSize + nzSize + 1)
-        (new IfIR(testIR, nzIR, zIR), testSize + nzSize + zSize + 1)
+        val (ir, irSize) =
+          traverseAndMaybePack(v.rhs, parentSize: Int)
+        (new VarDef(v.sym, ir), irSize + 1)
       case _: Ref => (p, 1)
-      case MethodDef(_, _) | MethodRef(_) =>
-        sys.error("This should never happen")
     }
 
   private def traverseAndMaybePack(p: IR, parentSize: Int): (IR, Int) = {
-    val (pt, size) = traverse(p)
-    if ((size + parentSize) > methodSizeLimit)
-      (createMethod(pt), 1)
+    val (ir, irSize) = traverseIR(p)
+    if ((irSize + parentSize) > methodSizeLimit)
+      (createMethod(ir), 1)
     else
-      (pt, size)
+      (ir, irSize)
   }
+
+  private def traverseIR(p: IR): (IR, Int) =
+    p match {
+      case b: BinaryIR =>
+        val (leftExpr, leftSize) =
+          traverse(b.left, 2)
+        val (rightExpr, rightSize) =
+          traverse(b.right, leftSize + 1)
+        (new BinaryIR(leftExpr, rightExpr, b.op), leftSize + rightSize + 1)
+      case u: UnaryIR =>
+        val (expr, exprSize) =
+          traverse(u.original, 1)
+        (new UnaryIR(expr, u.op), exprSize + 1)
+      case f: IfIR =>
+        val (testExpr, testSize) =
+          traverse(f.test, 3)
+        val (nzExpr, nzSize) =
+          traverse(f.whenNonZero, testSize + 2)
+        val (zExpr, zSize) =
+          traverse(f.whenZero, testSize + nzSize + 1)
+        (new IfIR(testExpr, nzExpr, zExpr), testSize + nzSize + zSize + 1)
+    }
 
   private def createMethod(rhs: IR): MethodRef = {
     val s = Sym.freshSym()

--- a/rainier-core/src/main/scala/com/stripe/rainier/ir/Packer.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/ir/Packer.scala
@@ -8,7 +8,7 @@ private class Packer(methodSizeLimit: Int) {
 
   def pack(p: Expr): MethodRef = {
     val (pExpr, _) = traverse(p, 0)
-    createMethod(MethodRoot(pExpr))
+    createMethod(UnaryIR(pExpr, NoOp))
   }
 
   private def traverse(p: Expr, parentSize: Int): (Expr, Int) =
@@ -48,6 +48,8 @@ private class Packer(methodSizeLimit: Int) {
         val (zExpr, zSize) =
           traverse(f.whenZero, testSize + nzSize + 1)
         (new IfIR(testExpr, nzExpr, zExpr), testSize + nzSize + zSize + 1)
+      case _: MethodRef =>
+        sys.error("there shouldn't be any method refs yet")
     }
 
   private def createMethod(rhs: IR): MethodRef = {

--- a/rainier-core/src/main/scala/com/stripe/rainier/ir/Tracer.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/ir/Tracer.scala
@@ -33,15 +33,43 @@ object Tracer {
 
     println(
       "def f" + method.sym.id + "(params: Array[Double], globals: Array[Double]): Double = {")
-    println("  " + traverse(method.rhs))
+    println("  " + traverseIR(method.rhs))
     println("}")
 
-    def traverse(ir: IR, needsParens: Boolean = false): String = {
-      ir match {
+    def traverse(expr: Expr, needsParens: Boolean = false): String =
+      expr match {
         case Const(value) => value.toString
         case p: Parameter =>
           val i = varIndices(p)
           s"params($i)"
+        case v: VarDef =>
+          varTypes(v.sym) match {
+            case Inline =>
+              traverseIR(v.rhs, needsParens)
+            case Local(i) =>
+              val r = traverseIR(v.rhs)
+              val n = "tmp" + i
+              println(s"  val $n = $r")
+              n
+            case Global(i) =>
+              val r = traverseIR(v.rhs)
+              val n = s"globals($i)"
+              println(s"  val $n = $r")
+              n
+          }
+        case VarRef(sym) =>
+          varTypes(sym) match {
+            case Inline =>
+              sys.error("Should not have references to inlined vars")
+            case Local(i) =>
+              s"tmp$i"
+            case Global(i) =>
+              s"globals($i)"
+          }
+      }
+
+    def traverseIR(ir: IR, needsParens: Boolean = false): String =
+      ir match {
         case b: BinaryIR =>
           b.op match {
             case PowOp =>
@@ -69,37 +97,10 @@ object Tracer {
             s"if($t == 0.0) $z else $nz"
           else
             s"(if($t == 0.0) $z else $nz)"
-        case v: VarDef =>
-          varTypes(v.sym) match {
-            case Inline =>
-              traverse(v.rhs, needsParens)
-            case Local(i) =>
-              val r = traverse(v.rhs)
-              val n = "tmp" + i
-              println(s"  val $n = $r")
-              n
-            case Global(i) =>
-              val r = traverse(v.rhs)
-              val n = s"globals($i)"
-              println(s"  val $n = $r")
-              n
-          }
-        case VarRef(sym) =>
-          varTypes(sym) match {
-            case Inline =>
-              sys.error("Should not have references to inlined vars")
-            case Local(i) =>
-              s"tmp$i"
-            case Global(i) =>
-              s"globals($i)"
-          }
         case MethodRef(sym) =>
           val i = sym.id
           s"f$i(params, globals)"
-        case _: MethodDef =>
-          sys.error("Should not have nested method defs")
       }
-    }
   }
 
   private def name(b: BinaryOp): String =
@@ -117,5 +118,6 @@ object Tracer {
       case ExpOp       => "Math.exp"
       case AbsOp       => "Math.abs"
       case RectifierOp => "MathOps.rectifier"
+      case NoOp        => ""
     }
 }

--- a/rainier-core/src/main/scala/com/stripe/rainier/ir/Tracer.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/ir/Tracer.scala
@@ -1,10 +1,10 @@
 package com.stripe.rainier.ir
 
 object Tracer {
-  def trace(inputs: Seq[Parameter], irs: Seq[IR]): Unit = {
+  def trace(inputs: Seq[Parameter], exprs: Seq[Expr]): Unit = {
     val packer = new Packer(200)
-    val outputMeths = irs.map { ir =>
-      packer.pack(ir)
+    val outputMeths = exprs.map { expr =>
+      packer.pack(expr)
     }
     val allMeths = packer.methods
     val varTypes = VarTypes.methods(allMeths.toList)


### PR DESCRIPTION
This is a large diff because some things get renamed, but a relatively simple idea. The `IR` trait was not properly capturing as much structure as actually existed in the expression trees, and this PR tightens up the types a bit to fix that. Specifically:

* The `IR` trait has been narrowed in focus to only cover the nodes that operate on other values: currently `BinaryIR`, `UnaryIR`, and `IfIR`. There's probably a better system of names for this  but keeping it reduced the size of this diff.
* The main top-level trait is now called `Expr` instead of `IR`. In general, things should now be dealing with `Expr` values rather than `IR` which are now more of an internal implementation detail.
* Under `Expr` is `Ref`, which still has the same subtypes as before.
* The only other `Expr` is `VarDef`. It holds onto an `IR` on its right-hand side. (This illuminates what it means for something to be `IR`: "an operation expensive enough to be worth caching in a var").
* To close the loop, the recursive members of the IR nodes are `Expr` values.

We also pulled `MethodDef` out of this hierarchy entirely since it's really a separate thing, and needed to add in a `NoOp` unary op to paper over an edge case.

The actual logic everywhere should be unchanged, it's just been adapted to the new types.