### PR TITLE
add dep on google flogger

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -77,6 +77,7 @@ lazy val V = new {
   val evilplot = "0.2.0"
   val scalacheck = "1.14.0"
   val scalatest = "3.0.5"
+  val flogger = "0.3.1"
 }
 
 // primary modules
@@ -91,6 +92,9 @@ lazy val rainierCore = project.
       BazelDep("//.rainier-shaded-asm", "asmTreeShaded") +
       BazelDep("//.rainier-shaded-asm", "asmShaded") -
       BazelDep("//.rainier-shaded-asm", "shadedAsm"),
+    libraryDependencies ++= Seq(
+      "com.google.flogger" % "flogger" % V.flogger,
+      "com.google.flogger" % "flogger-system-backend" % V.flogger)
   )
 
 lazy val rainierPlot = project.

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Compiler.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Compiler.scala
@@ -81,6 +81,12 @@ final case class Compiler(methodSizeLimit: Int, classSizeLimit: Int) {
 
   def compile(inputs: Seq[Variable],
               outputs: Seq[(String, Real)]): CompiledFunction = {
+    logger
+      .atInfo()
+      .log("Compiling method with %d inputs and %d outputs",
+           inputs.size,
+           outputs.size)
+
     val translator = new Translator
     val params = inputs.map { v =>
       v.param

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/_package.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/_package.scala
@@ -1,0 +1,7 @@
+package com.stripe.rainier
+
+import com.google.common.flogger.FluentLogger
+
+package object compute {
+  private[compute] val logger = FluentLogger.forEnclosingClass
+}


### PR DESCRIPTION
As a first step towards having better logging, this adds a dep on google's flogger and demonstrates using it by creating an instance for the `compute` package and adding a log message in `Compiler.compile`.

I don't yet actually know how you set the log level but presume there's some standard java way of doing this. I'm also violating the expectations a bit by allocating the logger in the package object vs in the companion object of each class, which would have given more finegrained control but was too much boilerplate for me (especially in Scala, it's better in Java).