### PR TITLE
fix broken lookup

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/ir/ExprMethodGenerator.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/ir/ExprMethodGenerator.scala
@@ -62,6 +62,7 @@ final private case class ExprMethodGenerator(method: MethodDef,
         swapIfEqThenPop()
       case l: LookupIR =>
         traverse(l.index)
+        doubleToInt()
         tableSwitch(l.table) {
           case Some(r) => traverse(r)
           case None    => throwNPE()

--- a/rainier-core/src/main/scala/com/stripe/rainier/ir/MethodGenerator.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/ir/MethodGenerator.scala
@@ -130,6 +130,10 @@ private trait MethodGenerator {
     methodNode.visitInsn(POP2)
   }
 
+  def doubleToInt(): Unit = {
+    methodNode.visitInsn(D2I)
+  }
+
   def pop(): Unit = {
     methodNode.visitInsn(POP2)
   }

--- a/rainier-example/src/main/scala/com/stripe/rainier/example/LookupNormal.scala
+++ b/rainier-example/src/main/scala/com/stripe/rainier/example/LookupNormal.scala
@@ -9,7 +9,7 @@ object LookupNormal {
     for {
       globalMean <- Uniform(0, 10).param
       means <- RandomVariable
-        .fill(k)(Normal(globalMean, 10).param)
+        .fill(k)(Normal(globalMean, 1).param)
         .map(Lookup(_))
       stddev <- Uniform(0, 10).param
       _ <- Predictor
@@ -24,7 +24,7 @@ object LookupNormal {
     val r = new scala.util.Random
     val trueStddev = 2.0
     val globalMean = 3.0
-    val means = List.fill(k)((r.nextGaussian * 10) + globalMean)
+    val means = List.fill(k)((r.nextGaussian) + globalMean)
     List.fill(n) {
       val i = r.nextInt(k)
       val v = (r.nextGaussian * trueStddev) + means(i)
@@ -33,6 +33,6 @@ object LookupNormal {
   }
 
   def main(args: Array[String]): Unit = {
-    plot2D(model(100, 10000).sample())
+    plot2D(model(30, 10000).sample())
   }
 }

--- a/rainier-tests/src/test/scala/com/stripe/rainier/compute/RealTest.scala
+++ b/rainier-tests/src/test/scala/com/stripe/rainier/compute/RealTest.scala
@@ -84,6 +84,11 @@ class RealTest extends FunSuite {
       (x * x * x))
   }
 
+  run("lookup") { x =>
+    val i = x.abs * 2 //should be a non-negative whole number
+    Lookup(i, Real.seq(List(0, 1, 2, 3, 4)))
+  }
+
   val exponents = scala.util.Random.shuffle(-40.to(40))
   run("exponent sums") { x =>
     exponents.foldLeft(x) {


### PR DESCRIPTION
I'm really confused as to how this ever worked, but: Lookup has been broken because it tries to do a `tableswitch` with a `double` value instead of an `int`. This adds the conversion instruction so that things work again.