### PR TITLE
Make logging useful

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Compiler.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Compiler.scala
@@ -81,12 +81,6 @@ final case class Compiler(methodSizeLimit: Int, classSizeLimit: Int) {
 
   def compile(inputs: Seq[Variable],
               outputs: Seq[(String, Real)]): CompiledFunction = {
-    logger
-      .atInfo()
-      .log("Compiling method with %d inputs and %d outputs",
-           inputs.size,
-           outputs.size)
-
     val translator = new Translator
     val params = inputs.map { v =>
       v.param

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Log.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Log.scala
@@ -1,0 +1,8 @@
+package com.stripe.rainier.compute
+
+import com.stripe.rainier.log._
+import com.google.common.flogger.FluentLogger
+
+object Log extends Logger {
+  val logger = FluentLogger.forEnclosingClass
+}

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Log.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Log.scala
@@ -1,8 +1,7 @@
 package com.stripe.rainier.compute
 
 import com.stripe.rainier.log._
-import com.google.common.flogger.FluentLogger
 
 object Log extends Logger {
-  val logger = FluentLogger.forEnclosingClass
+  val logger = init
 }

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/_package.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/_package.scala
@@ -1,7 +1,0 @@
-package com.stripe.rainier
-
-import com.google.common.flogger.FluentLogger
-
-package object compute {
-  private[compute] val logger = FluentLogger.forEnclosingClass
-}

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Log.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Log.scala
@@ -1,8 +1,7 @@
 package com.stripe.rainier.core
 
 import com.stripe.rainier.log._
-import com.google.common.flogger.FluentLogger
 
 object Log extends Logger {
-  val logger = FluentLogger.forEnclosingClass
+  val logger = init
 }

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Log.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Log.scala
@@ -1,0 +1,8 @@
+package com.stripe.rainier.core
+
+import com.stripe.rainier.log._
+import com.google.common.flogger.FluentLogger
+
+object Log extends Logger {
+  val logger = FluentLogger.forEnclosingClass
+}

--- a/rainier-core/src/main/scala/com/stripe/rainier/ir/Log.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/ir/Log.scala
@@ -1,8 +1,7 @@
 package com.stripe.rainier.ir
 
 import com.stripe.rainier.log._
-import com.google.common.flogger.FluentLogger
 
 object Log extends Logger {
-  val logger = FluentLogger.forEnclosingClass
+  val logger = init
 }

--- a/rainier-core/src/main/scala/com/stripe/rainier/ir/Log.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/ir/Log.scala
@@ -1,0 +1,8 @@
+package com.stripe.rainier.ir
+
+import com.stripe.rainier.log._
+import com.google.common.flogger.FluentLogger
+
+object Log extends Logger {
+  val logger = FluentLogger.forEnclosingClass
+}

--- a/rainier-core/src/main/scala/com/stripe/rainier/log/Logger.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/log/Logger.scala
@@ -2,12 +2,15 @@ package com.stripe.rainier.log
 
 import com.google.common.flogger.{FluentLogger, LoggerConfig}
 import FluentLogger.Api
-import java.util.logging.Level
+import java.util.logging.{Level, ConsoleHandler}
 
 abstract class Logger {
   def logger: FluentLogger
-  def setLevel(level: Level) =
-    LoggerConfig.of(logger).setLevel(level)
+  def setLevel(level: Level) = {
+    logger.atInfo.log("Setting level of %s to %s", this, level)
+    val config = LoggerConfig.of(logger)
+    config.setLevel(level)
+  }
 
   def SEVERE: Api = logger.at(Level.SEVERE)
   def WARNING: Api = logger.at(Level.WARNING)

--- a/rainier-core/src/main/scala/com/stripe/rainier/log/Logger.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/log/Logger.scala
@@ -7,7 +7,7 @@ import java.util.logging.{Level, ConsoleHandler}
 
 trait Logger {
   def logger: FluentLogger
-  def setConsoleLevel(level: Level) = {
+  def setConsoleLevel(level: Level): Unit = {
     val config = LoggerConfig.of(logger)
     config.setUseParentHandlers(false)
     config.setLevel(level)
@@ -28,6 +28,11 @@ trait Logger {
   def FINE: Api = logger.at(Level.FINE)
   def FINER: Api = logger.at(Level.FINER)
   def FINEST: Api = logger.at(Level.FINEST)
+
+  def showInfo(): Unit = setConsoleLevel(Level.INFO)
+  def showFine(): Unit = setConsoleLevel(Level.FINE)
+  def showFiner(): Unit = setConsoleLevel(Level.FINE)
+  def showFinest(): Unit = setConsoleLevel(Level.FINE)
 
   protected def init: FluentLogger = {
     val cons = classOf[FluentLogger].getDeclaredConstructors.head

--- a/rainier-core/src/main/scala/com/stripe/rainier/log/Logger.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/log/Logger.scala
@@ -6,8 +6,7 @@ import java.util.logging.{Level, ConsoleHandler}
 
 abstract class Logger {
   def logger: FluentLogger
-  def setLevel(level: Level) = {
-    logger.atInfo.log("Setting level of %s to %s", this, level)
+  def setConsoleLevel(level: Level) = {
     val config = LoggerConfig.of(logger)
     config.setLevel(level)
   }

--- a/rainier-core/src/main/scala/com/stripe/rainier/log/Logger.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/log/Logger.scala
@@ -1,0 +1,18 @@
+package com.stripe.rainier.compute
+
+import com.google.common.flogger.FluentLogger
+import java.util.logging.Level
+import Level._
+
+abstract class Logger {
+  def logger: FluentLogger
+  def setLevel(level: Level) = 
+    LoggerConfig.of(logger).setLevel(level)
+
+  def SEVERE = logger.as(SEVERE)
+  def WARNING = logger.as(WARNING)
+  def INFO = logger.as(INFO)
+  def FINE = logger.as(FINE)
+  def FINER = logger.as(FINER)
+  def FINEST = logger.as(FINEST)
+}

--- a/rainier-core/src/main/scala/com/stripe/rainier/log/Logger.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/log/Logger.scala
@@ -1,18 +1,18 @@
-package com.stripe.rainier.compute
+package com.stripe.rainier.log
 
-import com.google.common.flogger.FluentLogger
+import com.google.common.flogger.{FluentLogger, LoggerConfig}
+import FluentLogger.Api
 import java.util.logging.Level
-import Level._
 
 abstract class Logger {
   def logger: FluentLogger
-  def setLevel(level: Level) = 
+  def setLevel(level: Level) =
     LoggerConfig.of(logger).setLevel(level)
 
-  def SEVERE = logger.as(SEVERE)
-  def WARNING = logger.as(WARNING)
-  def INFO = logger.as(INFO)
-  def FINE = logger.as(FINE)
-  def FINER = logger.as(FINER)
-  def FINEST = logger.as(FINEST)
+  def SEVERE: Api = logger.at(Level.SEVERE)
+  def WARNING: Api = logger.at(Level.WARNING)
+  def INFO: Api = logger.at(Level.INFO)
+  def FINE: Api = logger.at(Level.FINE)
+  def FINER: Api = logger.at(Level.FINER)
+  def FINEST: Api = logger.at(Level.FINEST)
 }

--- a/rainier-core/src/main/scala/com/stripe/rainier/sampler/Log.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/sampler/Log.scala
@@ -1,0 +1,8 @@
+package com.stripe.rainier.sampler
+
+import com.stripe.rainier.log._
+import com.google.common.flogger.FluentLogger
+
+object Log extends Logger {
+  val logger = FluentLogger.forEnclosingClass
+}

--- a/rainier-core/src/main/scala/com/stripe/rainier/sampler/Log.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/sampler/Log.scala
@@ -1,8 +1,7 @@
 package com.stripe.rainier.sampler
 
 import com.stripe.rainier.log._
-import com.google.common.flogger.FluentLogger
 
 object Log extends Logger {
-  val logger = FluentLogger.forEnclosingClass
+  val logger = init
 }

--- a/rainier-core/src/main/scala/com/stripe/rainier/sampler/RNG.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/sampler/RNG.scala
@@ -19,7 +19,7 @@ object RNG {
 
 final case class ScalaRNG(seed: Long) extends RNG {
   FINE.log("Initializing RNG with seed %d", seed)
-  
+
   val rand: Random = new Random(seed)
   def standardUniform: Double = rand.nextDouble
   def standardNormal: Double = rand.nextGaussian

--- a/rainier-core/src/main/scala/com/stripe/rainier/sampler/RNG.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/sampler/RNG.scala
@@ -1,6 +1,7 @@
 package com.stripe.rainier.sampler
 
 import scala.util.Random
+import Log._
 
 trait RNG {
   def standardUniform: Double
@@ -12,12 +13,13 @@ trait RNG {
 object RNG {
   lazy val default: RNG = {
     val seed = System.currentTimeMillis
-    println("Initializing RNG with seed " + seed)
     ScalaRNG(seed)
   }
 }
 
 final case class ScalaRNG(seed: Long) extends RNG {
+  FINE.log("Initializing RNG with seed %d", seed)
+  
   val rand: Random = new Random(seed)
   def standardUniform: Double = rand.nextDouble
   def standardNormal: Double = rand.nextGaussian

--- a/rainier-core/src/main/scala/com/stripe/rainier/sampler/Walkers.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/sampler/Walkers.scala
@@ -2,29 +2,41 @@ package com.stripe.rainier.sampler
 
 import scala.collection.mutable.ListBuffer
 
+import Log._
+import java.util.concurrent.TimeUnit._
+
 final case class Walkers(walkers: Int) extends Sampler {
   def sample(density: DensityFunction,
              warmupIterations: Int,
              iterations: Int,
              keepEvery: Int)(implicit rng: RNG): List[Array[Double]] = {
+    FINE.log("Initializing %d walkers", walkers)
     val initial = WalkersChain(density, walkers)
+
+    FINE.log("Starting %d warmup iterations", warmupIterations)
     val warmedUp =
-      1.to(warmupIterations)
+      0.until(warmupIterations)
         .foldLeft(initial) {
-          case (chain, _) =>
+          case (chain, i) =>
+            FINE.atMostEvery(1, SECONDS).log("Iteration %d", i)
             chain.next
         }
 
     val buf = new ListBuffer[Array[Double]]
     var i = 0
     var chain = warmedUp
+
+    FINE.log("Starting %d iterations", iterations)
     while (i < iterations) {
+      FINE.atMostEvery(1, SECONDS).log("Iteration %d", i)
       chain = chain.next
       //keep every nth state of each walker, vs every nth walker
       if ((i / walkers) % keepEvery == 0)
         buf += chain.variables
       i += 1
     }
+
+    FINE.log("Finished sampling")
     buf.toList
   }
 }

--- a/rainier-example/src/main/scala/com/stripe/rainier/example/BatchNormal.scala
+++ b/rainier-example/src/main/scala/com/stripe/rainier/example/BatchNormal.scala
@@ -4,6 +4,7 @@ import com.stripe.rainier.compute.Real
 import com.stripe.rainier.core._
 import com.stripe.rainier.repl._
 import com.stripe.rainier.sampler._
+import java.util.logging.Level
 
 object BatchNormal {
   def model(k: Int): RandomVariable[(Real, Real)] = {
@@ -22,6 +23,7 @@ object BatchNormal {
   }
 
   def main(args: Array[String]): Unit = {
+    com.stripe.rainier.sampler.Log.setLevel(Level.FINE)
     plot2D(model(100000).sample(Walkers(100), 10000, 10000))
   }
 }

--- a/rainier-example/src/main/scala/com/stripe/rainier/example/BatchNormal.scala
+++ b/rainier-example/src/main/scala/com/stripe/rainier/example/BatchNormal.scala
@@ -23,7 +23,6 @@ object BatchNormal {
   }
 
   def main(args: Array[String]): Unit = {
-    com.stripe.rainier.sampler.Log.setLevel(Level.FINE)
     plot2D(model(100000).sample(Walkers(100), 10000, 10000))
   }
 }

--- a/rainier-example/src/main/scala/com/stripe/rainier/example/BatchNormal.scala
+++ b/rainier-example/src/main/scala/com/stripe/rainier/example/BatchNormal.scala
@@ -4,7 +4,6 @@ import com.stripe.rainier.compute.Real
 import com.stripe.rainier.core._
 import com.stripe.rainier.repl._
 import com.stripe.rainier.sampler._
-import java.util.logging.Level
 
 object BatchNormal {
   def model(k: Int): RandomVariable[(Real, Real)] = {


### PR DESCRIPTION
This adds:

* a `log.Logger` trait which has methods for `INFO`, `FINE`, etc that return flogger `Api` objects for logging with; it also includes `showInfo`, `showFine`, etc for programmatic control of what gets shown on the console (logging to files etc can be controlled by config files)
* `sampler.Log`, `core.Log`, `compute.Log` etc instances of `Logger` to give per-package control over logging
* the convention of `import Log._` in classes that want to produce log statements so that they can just say `FINE.log(....)`
* a smattering of examples of using the above

Note that we have to do some annoying tricks with reflection to get around the mismatch between the assumptions flogger has about being used from java and the realities of using it from scala.