### PR TITLE
Update tour.md

### DIFF
--- a/docs/tour.md
+++ b/docs/tour.md
@@ -10,8 +10,7 @@ import com.stripe.rainier.repl._
 import com.stripe.rainier.compute._
 ```
 
-Together, those traits let you define Bayesian models in Rainier. To throw you a little bit into the deep end, here's a simple linear regression that we'll return to later.
-This probably won't entirely make sense yet. That's ok. Hopefully it will serve as a bit of a roadmap that put the rest of the tour in context as we build up to it.
+Together, those traits let you define Bayesian models in Rainier. To throw you a little bit into the deep end, here's a simple linear regression that we'll return to later. This probably won't entirely make sense yet. That's ok. Hopefully it will serve as a bit of a roadmap that put the rest of the tour in context as we build up to it.
 
 ```scala
 scala> val data =  List((0,8), (1,12), (2,16), (3,20), (4,21), (5,31), (6,23), (7,33), (8,31), (9,33), (10,36), (11,42), (12,39), (13,56), (14,55), (15,63), (16,52), (17,66), (18,52), (19,80), (20,71))
@@ -22,23 +21,21 @@ scala> val model = for {
      |   intercept <- LogNormal(0,1).param
      |   regression <- Predictor.fromInt{x => Poisson(x*slope + intercept)}.fit(data)
      | } yield regression.predict(21)
-model: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@3922d4e5
+model: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@560e610a
 
 scala> model.sample(10)
-res0: List[Int] = List(71, 73, 68, 76, 73, 74, 96, 71, 77, 83)
+res0: List[Int] = List(73, 81, 81, 84, 61, 65, 68, 84, 65, 88)
 ```
 
 ## Distribution
 
 The starting point for almost any work in Rainier will be some object that implements `rainier.core.Distribution[T]`.
 
-Rainier implements various familiar families of probability distributions like the [Normal](https://en.wikipedia.org/wiki/Normal_distribution) distribution,
-the [Uniform][UC] distribution, and the [Poisson](https://en.wikipedia.org/wiki/Poisson_distribution) distribution.
-You will find these three in [Continuous.scala](/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala) and [Discrete.scala](/rainier-core/src/main/scala/com/stripe/rainier/core/Discrete.scala) - along with a few more, and we'll keep adding them as the need arises. You construct a distribution from its parameters, usually with the `apply` method on the object representing its family. So for example, this is a normal distribution with a mean of 0 and a standard deviation of 1:
+Rainier implements various familiar families of probability distributions like the [Normal](https://en.wikipedia.org/wiki/Normal_distribution) distribution, the [Uniform][UC] distribution, and the [Poisson](https://en.wikipedia.org/wiki/Poisson_distribution) distribution. You will find these three in [Continuous.scala](/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala) and [Discrete.scala](/rainier-core/src/main/scala/com/stripe/rainier/core/Discrete.scala) - along with a few more, and we'll keep adding them as the need arises. You construct a distribution from its parameters, usually with the `apply` method on the object representing its family. So for example, this is a normal distribution with a mean of 0 and a standard deviation of 1:
 
 ```scala
 scala> val normal: Distribution[Double] = Normal(0,1)
-normal: com.stripe.rainier.core.Distribution[Double] = com.stripe.rainier.core.Injection$$anon$1@2d29c75b
+normal: com.stripe.rainier.core.Distribution[Double] = com.stripe.rainier.core.Injection$$anon$1@346ee319
 ```
 
 In Rainier, `Distribution` objects play three different roles. `Continuous` distributions (like `Normal`), implement `param`, and all distributions implement `fit` and `generator`. Each of these methods is central to one of the three stages of building a model in Rainier:
@@ -51,54 +48,51 @@ We'll start by exploring each of these in turn.
 
 ## `param` and `RandomVariable`
 
-Every model in Rainier has some parameters whose values are unknown (if that's not true for your model, you don't need an inference library!).
-The first step in constructing a model is to set up these parameters.
+Every model in Rainier has some parameters whose values are unknown (if that's not true for your model, you don't need an inference library!). The first step in constructing a model is to set up these parameters.
 
-You create a parameter by calling `param` on the distribution that represents the prior for that parameter. `param` is only implemented for continuous distributions
-(which extend `Continuous`, which extends `Distribution[Double]`). As you might be able to tell from those types:
-in Rainier, all parameters are continuous real scalar values. There's no support for discrete model parameters, and there's no support (or need) for explicit vectorization.
+You create a parameter by calling `param` on the distribution that represents the prior for that parameter. `param` is only implemented for continuous distributions(which extend `Continuous`, which extends `Distribution[Double]`). As you might be able to tell from those types: in Rainier, all parameters are continuous real scalar values. There's no support for discrete model parameters, and there's no support (or need) for explicit vectorization.
 
 Let's use that same `Normal(0,1)` distribution as a prior for a new parameter:
 
 ```scala
 scala> val x = Normal(0,1).param
-x: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@2041c4b2
+x: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@396fb1c2
 ```
 
 You can see that the type of `x` is `RandomVariable[Real]`. `RandomVariable` pairs a type of value (in this case, a real number) with some knowledge of the relative probability density of different values of that type. We can use this knowledge to produce a sample of these possible values:
 
 ```scala
 scala> x.sample()
-res1: List[Double] = List(0.851042860312551, -0.10115873972819678, -0.2019818396177493, -0.06242326870305881, 0.07910315689936297, -0.47486515373676363, -0.12473499286691347, 0.43937959443822083, -0.0412165163852396, -0.04709140333485806, -0.1727825589365133, 0.3641927622782447, -0.47435955497055354, -0.7322526805211682, 1.1363419190428985, -1.4240714809931854, 1.516408582936893, 1.516408582936893, -1.667909084512874, 2.2296258626092333, -2.642251012149351, 1.7095348500648408, -1.2344294260603343, -1.2344294260603343, -1.2344294260603343, 0.9447687726348758, -1.1958229468003794, 1.864051158609457, -1.9420776453364645, 0.6826358066473812, 0.6826358066473812, -0.03210524538600579, -0.6123508762216829, 0.11795503664366258, -0.35659498252364596, 0.3904674386910485,...
+res1: List[Double] = List(0.07939553118788883, -0.07057442977582895, 0.16452896525633065, -0.1412383807708164, 0.1020452500957938, -0.09673007349582763, 0.09615617508287556, -0.06079168131322055, 0.06416777916083481, -0.08796364166309967, 0.04675915325093394, -0.08524635966101646, 0.13202622429606792, -0.06988675666942812, 0.03164069403370373, -0.04458355130616931, -0.01382392669019783, -0.1023459932633135, 0.17202367770386218, -0.21817320890851444, 0.20887005724937413, -0.18431844638470696, 0.1960771354883153, -0.2764282905263178, 0.2361775496972538, -0.28686115375758914, 0.298121579498149, -0.33144584103048713, 0.3815100794268398, -0.31168212170543397, 0.32170666466547715, -0.3186847642455527, 0.3377512505523024, -0.33496872495854346, 0.32778945504191376, -0....
 ```
 
 Each element of the list above represents a single sample from the distribution over `x`. It's easier to understand these if we plot them as a histogram:
 
 ```scala
 scala> plot1D(x.sample())
-     430 |                                                                                
-         |                                        · ∘                                     
-         |                                      · ○ ○                                     
-         |                                    ∘○○∘○∘○                                     
-         |                                    ○○○○○○○∘ ·                                  
-     320 |                                  ○○○○○○○○○○○○                                  
-         |                                ○∘○○○○○○○○○○○○·                                 
-         |                               ∘○○○○○○○○○○○○○○○○                                
-         |                               ○○○○○○○○○○○○○○○○○                                
-         |                              ·○○○○○○○○○○○○○○○○○ ○                              
-     210 |                             ∘○○○○○○○○○○○○○○○○○○○○                              
-         |                            ∘○○○○○○○○○○○○○○○○○○○○○∘·                            
-         |                           ∘○○○○○○○○○○○○○○○○○○○○○○○○                            
-         |                          ○○○○○○○○○○○○○○○○○○○○○○○○○○∘                           
-         |                          ○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘                         
-     100 |                        ○·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                         
-         |                      ··○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                        
-         |                    ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘·∘                    
-         |                  ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘·                  
-         |              ∘∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘∘·               
-       0 |·····  ····∘∘∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘············
+     450 |                                                                                
+         |                                     ∘  ·                                       
+         |                                    ·○∘ ○∘                                      
+         |                                   ○○○○·○○∘∘                                    
+         |                                   ○○○○○○○○○∘                                   
+     340 |                                  ○○○○○○○○○○○∘                                  
+         |                                · ○○○○○○○○○○○○ ·                                
+         |                                ○·○○○○○○○○○○○○·○                                
+         |                              ∘ ○○○○○○○○○○○○○○○○○○                              
+         |                              ○○○○○○○○○○○○○○○○○○○○                              
+     220 |                              ○○○○○○○○○○○○○○○○○○○○○                             
+         |                             ·○○○○○○○○○○○○○○○○○○○○○                             
+         |                           ··○○○○○○○○○○○○○○○○○○○○○○·                            
+         |                           ○○○○○○○○○○○○○○○○○○○○○○○○○                            
+         |                          ·○○○○○○○○○○○○○○○○○○○○○○○○○○∘                          
+     110 |                          ○○○○○○○○○○○○○○○○○○○○○○○○○○○○                          
+         |                        ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·                       
+         |                     ·∘∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·                      
+         |                    ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                    
+         |                  ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·                  
+       0 |··  · ······∘∘·○∘∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘∘∘····· ····  ·
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-       -3.76    -2.91    -2.05    -1.20    -0.35     0.50     1.35     2.20     3.05  
+        -4.3     -3.3     -2.3     -1.4     -0.4     0.5      1.5      2.4      3.4   
 ```
 
 Since the only information we have about `x` so far is its `Normal` prior, this distribution unsurprisingly looks normal. Later we'll see how to update our beliefs about `x` based on observational data.
@@ -107,102 +101,102 @@ For now, though, let's explore what we can do just with priors. `RandomVariable`
 
 ```scala
 scala> val e_x = x.map(_.exp)
-e_x: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@135c8934
+e_x: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@4df44e3d
 
 scala> plot1D(e_x.sample())
-    3300 |                                                                                
-         |∘                                                                               
-         |○                                                                               
-         |○                                                                               
-         |○○                                                                              
-    2400 |○○                                                                              
-         |○○                                                                              
-         |○○                                                                              
-         |○○                                                                              
-         |○○                                                                              
+    2100 |                                                                                
+         | ·                                                                              
+         | ○                                                                              
+         | ○                                                                              
+         |·○                                                                              
     1600 |○○                                                                              
          |○○                                                                              
-         |○○∘                                                                             
+         |○○·                                                                             
          |○○○                                                                             
          |○○○                                                                             
-     800 |○○○·                                                                            
+    1000 |○○○                                                                             
          |○○○○                                                                            
-         |○○○○·                                                                           
-         |○○○○○·                                                                          
+         |○○○○                                                                            
+         |○○○○                                                                            
+         |○○○○∘                                                                           
+     500 |○○○○○∘                                                                          
          |○○○○○○·                                                                         
-       0 |○○○○○○○○○∘∘················ ·  ·  ····  ··      ·                        ·     ·
+         |○○○○○○○·                                                                        
+         |○○○○○○○○∘                                                                       
+         |○○○○○○○○○∘∘··                                                                   
+       0 |○○○○○○○○○○○○○○∘∘∘∘···················· ····· ····· · ··· ···   ·  ·····  · ·   ·
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        0.0      5.6      11.2     16.9     22.5     28.1     33.7     39.3     44.9  
+        0.0      3.2      6.3      9.4      12.6     15.7     18.8     22.0     25.1  
 ```
 
 Or we can create another `Normal` parameter and zip the two together to produce a 2D gaussian. Since there's nothing relating these two parameters to each other, you can see in the plot that they're completely independent.
 
 ```scala
 scala> val y = Normal(0,1).param
-y: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@30394309
+y: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@4db2df87
 
 scala> val xy = x.zip(y)
-xy: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@555c3f2c
+xy: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@7c7dbe4d
 
 scala> plot2D(xy.sample())
-     3.6 |                                                                                
-         |                               ·  ·            ·                                
-         |                           ····    · ·   ·       ··  ··                         
-         |         ·             ·  · ··· ·· ··· ··  ·  ···       ··                      
-         |          · ·     ··  ·  ····· ············· · ·· ···      ·          ·         
-     1.9 |             ··   · ··································  · · ·· ·                
-         |            ·· ·   ·········································· ·    ·    ·       
-         |         ·  · ·· ········································ ·· ·  ·               
-         |  · ·    ·· ···················∘·∘····∘∘······················ · ··            ·
-         |         · · ················∘·····∘∘○∘∘∘·∘∘·∘····················              
-     0.1 |     · ··· ·· ···········∘···∘∘∘∘∘·∘∘∘○∘∘∘∘∘∘·∘∘·∘············· ·····  ·    ·   
-         |       ·  · ················∘∘∘∘∘∘∘∘∘∘○∘∘∘∘∘∘∘∘················  ·              
-         |    ·   ····················∘∘∘∘∘∘∘∘∘∘∘∘··∘∘∘∘······················     ·     ·
-         |         ···················∘·∘∘∘∘∘∘∘∘∘∘∘∘··∘·∘················ ··· ··          
-         |·       ························∘··∘·∘·∘······················ · ·              
-    -1.6 |      ·    · ···· ··············································· · ·           
-         |               · · ···································· ···· ·· ··              
-         |               ·   ···  ···· ························ ···  ·  ···               
-         |             ·    ····  · ·· ······· ·······  · ·· · ·  ·                       
-         |             · ·        ···  ·      ·· ·····  ··    ·    ·    ·                 
-    -3.3 |                          ·   ·    ·   ·     ·                                  
+     4.0 |                                                                                
+         |                                            ·                                   
+         |                          ·   ·  ·                       ·                      
+         |                       ·  ·    ···  ·    ··  ·  ·         ·                     
+         |           ·    ··    ···  · · ·  ····· ··· · ····· · ··  ·   ·                 
+     2.1 |    ·        ·  · ···· ·····························    · ·· ·     ·            
+         |  ·       ·· ······································ ······ ··· ··               
+         |       · ·  ················································ ·   ·              
+         |         ····· ··············∘·∘···∘∘·∘·∘····∘···················· · ·          
+         |  ·   ···· ················∘∘∘∘∘∘∘∘∘∘∘∘∘∘·∘∘·∘·∘············· ··· · ·  ··      ·
+     0.2 |  · ·  ··· ··· ·········∘∘∘·∘∘∘∘○∘∘∘∘∘○∘○∘∘∘∘∘·∘∘·················   ·    ·     
+         |      · ················∘·∘∘·∘∘∘∘∘∘∘∘·∘○∘∘○∘··∘∘·∘··············· · ·  ·    ·   
+         |     · ·· ··············∘·∘∘·∘∘∘∘∘∘∘○∘○∘∘∘∘∘∘∘·∘∘···∘·········· · ·· ·         ·
+         |·    ·······················∘··∘∘·○∘○∘∘○∘∘∘∘∘·∘···················· ·   ·       
+         |    · ··  ··· · ············∘···∘··∘∘∘···∘··············· ·· ···· ··· ·         
+    -1.8 |         ·   · ······ ········································   ··             
+         |     ·    ·   ····  ······························· ···· ····    ··             
+         |                 ·  · ··· ················  ·· ······· ···   ·                  
+         |·                · ·  ··   ·     ·······  · ·   · ···                           
+         |                   ·       · ·  ·         ·· ···   ·                            
+    -3.7 | ·                                       ·    ·          ·                      
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-       -3.71    -2.82    -1.93    -1.04    -0.15     0.74     1.63     2.52     3.41  
+       -3.51    -2.66    -1.81    -0.96    -0.11     0.74     1.59     2.44     3.29  
 ```
 
 Finally, we can use `flatMap` to create two parameters that *are* related to each other. In particular, we'll create a new parameter `z` that we believe to be very close to `x`: its prior is a `Normal` centered on `x` with a very small standard deviation. We'll then make a 2D plot of `(x,z)` to see the relationship.
 
 ```scala
 scala> val z = x.flatMap{a => Normal(a, 0.1).param}
-z: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@37cb600f
+z: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@6b35abb2
 
 scala> val xz = x.zip(z)
-xz: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@3dad549f
+xz: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@e6b62b0
 
 scala> plot2D(xz.sample())
-     4.1 |                                                                                
-         |                                                                             · ·
-         |                                                                         ··     
-         |                                                                     ·····      
-         |                                                              ·········         
-     2.1 |                                                           ·········            
-         |                                                      ·········                 
-         |                                                 · ········                     
-         |                                             ····∘∘∘···                         
-         |                                          ··∘∘∘∘····                            
-     0.1 |                                      ··∘○○∘∘···                                
-         |                                 ···∘○○∘∘···                                    
-         |                             ···∘○○∘···                                         
-         |                          ···∘∘∘···                                             
-         |                      ··········                                                
-    -1.9 |                 ··········                                                     
-         |              ········                                                          
-         |          ·······                                                               
-         |       ······                                                                   
-         |   ··  ··                                                                       
-    -3.9 |···                                                                             
+     3.7 |                                                                                
+         |                                                                            ····
+         |                                                                     ·······    
+         |                                                                   ·····        
+         |                                                             ········           
+     1.8 |                                                         ········               
+         |                                                    ··········                  
+         |                                                 ···∘······                     
+         |                                            ····∘∘∘···                          
+         |                                         ··∘○∘∘···                              
+    -0.1 |                                    ···∘○○○∘···                                 
+         |                                ···∘∘○∘···                                      
+         |                             ···∘∘∘∘···                                         
+         |                        ····∘∘∘····                                             
+         |                     ·········                                                  
+    -2.0 |                 ·········                                                      
+         |              ·······                                                           
+         |          ········                                                              
+         |      ·······                                                                   
+         |   ··· ·                                                                        
+    -4.0 |·· ·                                                                            
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-       -3.79    -2.93    -2.06    -1.19    -0.32     0.54     1.41     2.28     3.15  
+       -3.88    -3.02    -2.17    -1.31    -0.45     0.41     1.27     2.12     2.98  
 ```
 
 You can see that although we still sample from the full range of `x` values, for any given sample, `x` and `z` are quite close to each other.
@@ -226,7 +220,7 @@ scala> val rate = for {
      |     r <- e_x
      |     poisson <- Poisson(r).fit(sales)
      | } yield r
-rate: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@51d5e4b2
+rate: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@4f17cd5
 ```
 
 This is our first "full" model: we have a parameter with a log-normal prior bundled into the `RandomVariable` named `e_x`; we use that parameter to initialize a `Poisson` noise distribution which we fit to our observations; and at the end, we output the same parameter (referenced by `r`) as the quantity we're interested in sampling from the posterior.
@@ -235,29 +229,29 @@ Let's plot the results!
 
 ```scala
 scala> plot1D(rate.sample())
-     420 |                                                                                
-         |                               ∘  ∘                                             
-         |                          ∘   ○○  ○                                             
-         |                         ·○∘  ○○·∘○                                             
-         |                         ○○○○∘○○○○○                                             
-     320 |                         ○○○○○○○○○○○○                                           
-         |                      ·  ○○○○○○○○○○○○                                           
-         |                      ○  ○○○○○○○○○○○○ ∘∘                                        
-         |                     ○○○○○○○○○○○○○○○○○○○·                                       
-         |                    ○○○○○○○○○○○○○○○○○○○○○                                       
-     210 |                    ○○○○○○○○○○○○○○○○○○○○○·                                      
-         |                  ·∘○○○○○○○○○○○○○○○○○○○○○○·                                     
-         |                  ○○○○○○○○○○○○○○○○○○○○○○○○○∘                                    
-         |                 ∘○○○○○○○○○○○○○○○○○○○○○○○○○○                                    
-         |                 ○○○○○○○○○○○○○○○○○○○○○○○○○○○○                                   
-     100 |               ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘∘                               
-         |              ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○ ·                             
-         |             ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                             
-         |          ···○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·                           
-         |   ·     ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘∘·∘                       
-       0 |∘ ·○∘∘○∘∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○○··∘···· · · ···  · ·
+     380 |                                                                                
+         |                               ∘                                                
+         |                            ·∘∘○                                                
+         |                        · ○○○○○○·                                               
+         |                        ○·○○○○○○○   ○                                           
+     280 |                       ∘○○○○○○○○○·  ○                                           
+         |                      ○○○○○○○○○○○○∘○○ ○                                         
+         |                     ∘○○○○○○○○○○○○○○○ ○                                         
+         |                   ∘∘○○○○○○○○○○○○○○○○○○∘∘                                       
+         |                   ○○○○○○○○○○○○○○○○○○○○○○                                       
+     190 |                 ·○○○○○○○○○○○○○○○○○○○○○○○                                       
+         |                ∘○○○○○○○○○○○○○○○○○○○○○○○○·∘                                     
+         |               ○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○                                   
+         |              ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○·                                
+         |             ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                                
+      90 |           ∘·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                                
+         |           ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘∘                             
+         |        ··∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘ ·                          
+         |        ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○··                        
+         |     ○○·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘∘∘     ·               
+       0 |·○·∘∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○○··∘····· ··  ··
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        4.4      5.3      6.3      7.2      8.2      9.1      10.0     11.0     11.9  
+        4.96     5.76     6.56     7.37     8.17     8.98     9.78    10.59    11.39  
 ```
 
 Looks like our daily rate is probably somewhere between 6 and 9, and is in fact much more likely to be around 9 than 10.
@@ -266,7 +260,7 @@ Looks like our daily rate is probably somewhere between 6 and 9, and is in fact 
 
 Please feel free to skip this section if it's not helping you.
 
-One thing that sometimes confuses people at this stage is, what is the line with `fit` actually doing? It seems to return some value `poisson` that we just ignore. (That object, by the way, is just the `Poisson(r)` distribution object that we used to do the `fit`.) And yet the line is clearly doing something, because sampling from `rate` gives quite different results from just sampling directly from `e_x`.
+One thing that sometimes confuses people at this stage is, what is the line with `fit` actually doing? It seems to return a `poisson` object that we just ignore. (That object, by the way, is just the `Poisson(r)` distribution object that we used to do the `fit`.) And yet the line is clearly doing something, because sampling from `rate` gives quite different results from just sampling directly from `e_x`.
 
 The key is to remember that a `RandomVariable` has two parts: a `value` and a `density`. Mathematically, you should think of these as two different *functions* of the same latent parameter space `Q`. That is, you should think of `value` as being some deterministic function `f = F(q)`, and `density` as being the (unnormalized) probability function `P(Q=q)`.
 
@@ -314,42 +308,42 @@ scala> val prediction = for {
      |     r <- e_x
      |     poisson <- Poisson(r).fit(sales)
      | } yield poisson.generator
-prediction: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@62a7b39a
+prediction: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@3d6fed6c
 ```
 
 This is almost the same model as `rate` above, but instead of taking the real-valued `r` rate parameter as the output, we're producing poisson-distributed integers. The samples look like this:
 
 ```scala
 scala> prediction.sample()
-res9: List[Int] = List(6, 3, 9, 5, 6, 9, 13, 7, 4, 12, 7, 9, 1, 8, 12, 10, 6, 13, 9, 12, 12, 6, 8, 9, 8, 8, 5, 4, 15, 11, 10, 10, 6, 5, 15, 9, 9, 6, 13, 8, 13, 4, 5, 3, 6, 14, 14, 11, 16, 14, 9, 9, 8, 7, 10, 7, 10, 9, 5, 4, 8, 8, 9, 11, 7, 6, 13, 9, 6, 8, 8, 4, 7, 8, 7, 18, 10, 6, 3, 6, 1, 5, 7, 6, 6, 8, 6, 9, 12, 7, 8, 4, 9, 8, 10, 9, 10, 5, 10, 6, 10, 5, 10, 7, 7, 7, 4, 10, 9, 13, 14, 7, 8, 8, 5, 5, 4, 4, 9, 7, 7, 9, 8, 9, 10, 11, 8, 10, 9, 5, 13, 7, 10, 7, 10, 5, 11, 7, 8, 7, 5, 5, 5, 6, 15, 5, 13, 7, 6, 4, 6, 12, 7, 11, 5, 9, 6, 11, 10, 6, 5, 11, 4, 5, 5, 8, 5, 7, 6, 4, 5, 7, 8, 7, 14, 12, 10, 7, 6, 9, 4, 10, 4, 11, 7, 9, 5, 4, 9, 7, 10, 11, 8, 7, 8, 15, 8, 4, 4, 7, 12, 7, 5, 7, 8, 6, 9, 4, 2, 13, 8, 12, 4, 12, 11, 11, 4, 5, 3, 6, 7, 9, 17, 4, 3, 8, 6, 9, 5...
+res9: List[Int] = List(3, 8, 5, 10, 10, 8, 10, 6, 9, 10, 8, 10, 9, 10, 5, 7, 5, 9, 4, 6, 7, 7, 8, 10, 5, 14, 5, 5, 5, 5, 9, 7, 10, 10, 15, 7, 3, 5, 4, 12, 10, 3, 6, 6, 6, 11, 6, 7, 10, 5, 6, 13, 7, 8, 6, 6, 5, 7, 10, 10, 7, 15, 7, 5, 7, 4, 9, 7, 11, 6, 11, 5, 7, 5, 10, 10, 7, 9, 16, 19, 10, 7, 12, 5, 6, 8, 8, 4, 5, 8, 8, 12, 11, 8, 7, 8, 4, 1, 6, 8, 7, 7, 9, 7, 3, 5, 14, 2, 5, 11, 3, 5, 8, 7, 8, 6, 10, 7, 6, 4, 10, 10, 10, 1, 13, 4, 12, 7, 7, 4, 9, 5, 3, 10, 2, 8, 11, 7, 10, 5, 10, 7, 13, 13, 6, 6, 3, 5, 11, 9, 5, 6, 4, 9, 7, 10, 11, 2, 12, 5, 7, 12, 13, 6, 11, 5, 7, 3, 7, 6, 9, 15, 7, 13, 6, 10, 3, 8, 12, 7, 7, 6, 7, 9, 7, 9, 8, 7, 2, 8, 8, 10, 8, 5, 7, 8, 7, 11, 2, 7, 6, 15, 13, 6, 3, 14, 5, 7, 5, 6, 4, 9, 8, 8, 10, 10, 11, 3, 6, 3, 5, 14, 7, 8, 5, 18, 8, 11,...
 ```
 Or, if we plot them, like this:
 
 ```scala
 scala> plot1D(prediction.sample())
-    1300 |                                                                                
-         |                   ∘  ○  ·                                                      
-         |                   ○  ○  ○                                                      
-         |                   ○  ○  ○  ·                                                   
-         |               ○   ○  ○  ○  ○                                                   
-     970 |               ○   ○  ○  ○  ○                                                   
-         |               ○   ○  ○  ○  ○                                                   
-         |               ○   ○  ○  ○  ○  ·                                                
-         |               ○   ○  ○  ○  ○  ○                                                
-         |               ○   ○  ○  ○  ○  ○                                                
-     650 |            ∘  ○   ○  ○  ○  ○  ○   ○                                            
-         |            ○  ○   ○  ○  ○  ○  ○   ○                                            
-         |            ○  ○   ○  ○  ○  ○  ○   ○                                            
-         |            ○  ○   ○  ○  ○  ○  ○   ○                                            
-         |         ·  ○  ○   ○  ○  ○  ○  ○   ○  ·                                         
-     320 |         ○  ○  ○   ○  ○  ○  ○  ○   ○  ○                                         
-         |         ○  ○  ○   ○  ○  ○  ○  ○   ○  ○  ·                                      
-         |         ○  ○  ○   ○  ○  ○  ○  ○   ○  ○  ○  ·                                   
-         |      ○  ○  ○  ○   ○  ○  ○  ○  ○   ○  ○  ○  ○                                   
-         |      ○  ○  ○  ○   ○  ○  ○  ○  ○   ○  ○  ○  ○  ∘                                
-       0 |·  ○  ○  ○  ○  ○   ○  ○  ○  ○  ○   ○  ○  ○  ○  ○  ∘   ·  ·  ·  ·               ·
+    1350 |                                                                                
+         |                     ∘   ○  ·                                                   
+         |                     ○   ○  ○                                                   
+         |                     ○   ○  ○                                                   
+         |                     ○   ○  ○   ·                                               
+    1010 |                     ○   ○  ○   ○                                               
+         |                  ∘  ○   ○  ○   ○                                               
+         |                  ○  ○   ○  ○   ○   ∘                                           
+         |                  ○  ○   ○  ○   ○   ○                                           
+         |                  ○  ○   ○  ○   ○   ○                                           
+     670 |              ○   ○  ○   ○  ○   ○   ○                                           
+         |              ○   ○  ○   ○  ○   ○   ○  ∘                                        
+         |              ○   ○  ○   ○  ○   ○   ○  ○                                        
+         |              ○   ○  ○   ○  ○   ○   ○  ○                                        
+         |              ○   ○  ○   ○  ○   ○   ○  ○   ∘                                    
+     330 |          ∘   ○   ○  ○   ○  ○   ○   ○  ○   ○                                    
+         |          ○   ○   ○  ○   ○  ○   ○   ○  ○   ○                                    
+         |          ○   ○   ○  ○   ○  ○   ○   ○  ○   ○   ∘                                
+         |       ∘  ○   ○   ○  ○   ○  ○   ○   ○  ○   ○   ○  ∘                             
+         |       ○  ○   ○   ○  ○   ○  ○   ○   ○  ○   ○   ○  ○   ∘                         
+       0 |·  ○   ○  ○   ○   ○  ○   ○  ○   ○   ○  ○   ○   ○  ○   ○  ∘   ∘   ·  ·   ·      ·
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        0.0      2.8      5.6      8.5      11.3     14.1     16.9     19.8     22.6  
+        0.0      2.5      5.0      7.5      9.9      12.4     14.9     17.4     19.9  
 ```
 
 ## `Likelihood` and `Predictor`
@@ -397,7 +391,7 @@ scala> val prior = for {
      |     slope <- LogNormal(0,1).param
      |     intercept <- LogNormal(0,1).param
      |     } yield (slope, intercept)
-prior: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@396cbb56
+prior: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@54c52a83
 ```
 
 Now, for any given day `i`, we want to check the number of sales against `Poisson(intercept + slope*i)`. We could write some kind of recursive flatMap to build and fit each of these different distribution objects in turn, but this is a common enough pattern that Rainier already has something built in for it: `Predictor`. `Predictor` is not a `Distribution`, but instead wraps a function from `X => Distribution[Y]` for some `(X,Y)`; you can use this any time you have a dependent variable of type `Y` that you're modeling with some independent variables jointly represented as `X`.
@@ -411,7 +405,7 @@ scala> val regr = for {
      |                     Poisson(intercept + slope*i)
      |                 }.fit(data)
      | } yield (slope, intercept)
-regr: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@7c232f2
+regr: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@5b454e87
 ```
 
 As before, we're starting out by just sampling the parameters. By plotting them, we can see that the model's confidence in the intercept, in particular, is pretty low: although it's most likely to be somewhere around 8, it could be anywhere from 3 to 13 or even higher. Second, as you'd hope, the two parameters are anti-correlated:
@@ -419,29 +413,29 @@ a smaller intercept would imply a higher slope, and vice versa.
 
 ```scala
 scala> plot2D(regr.sample())
-    16.0 |                                                                                
-         |     ·            ·                                                             
-         |·             ·            ·                                                    
-         |      ··   ·  ·     ·  ·                                                        
-         |      ··  ··     ·   · ·  ·· ·                                                  
-    12.6 |  ·   · ·· ·  ············· ·   ·                                               
-         |·   ···  · ··················· ·····  · ··                                      
-         |          ·· ···························· ··                                    
-         |         ·  ································· ·    ··   ·                       
-         |      ·    ···· ·············∘·∘·∘···················· ·  ·                     
-     9.3 |          ·  ·· ············∘∘∘∘∘∘∘∘·∘∘·∘∘··············· ·····                 
-         |               · ··············∘∘∘∘○∘∘∘∘∘∘∘∘∘∘··············· ····              
-         |              · ·  ·············∘∘∘∘∘○○○○○○∘○∘∘∘∘∘··············· · ·· ·        
-         |                       · ··········∘·∘∘∘○∘○○∘∘○○∘∘∘∘∘·············  · ··        
-         |                          ··············∘∘∘∘∘∘∘∘∘∘∘○∘∘∘∘············ ··  ·      
-     5.9 |                         · · ··· ············∘∘·∘∘∘∘∘∘∘∘················ ·     ·
-         |                          ·     ·· ·   ······························· ··· ·    
-         |                                   ·      ································· · · 
-         |                                               ·· ···· ················· ·· ·  ·
-         |                                                   ·  ····  ·    ····     ···  ·
-     2.5 |                                                                 ··       ·     
+    15.8 |                                                                                
+         |   ·            ·                                                               
+         |  ·                                                                             
+         |       ·   ·  ··  ·  ·                                                          
+         |             · · ·· ·  · ·  ··                                                  
+    12.6 |·        ···· · ······ ····     · · ·    ·                                      
+         |      ·   · ············· ······· ···   ·                                       
+         |     ·     ··· ·························   ·  ·                                 
+         |         ·   ··························· ··· ·   ·                              
+         |           · ·· ··············∘·············· ····                              
+     9.4 |            ·· · ···········∘∘∘∘·∘∘∘∘···············                            
+         |               ·············∘·∘∘∘∘∘○∘○∘∘∘∘··············  ·                     
+         |                ·············∘∘∘∘∘∘∘○○○○○∘∘∘∘∘∘··········· ··                   
+         |                     · ·········∘··∘∘∘○∘○○○∘∘∘∘∘·∘·········  ·                  
+         |                     · ·  ··········∘∘∘∘∘○∘∘○○∘∘∘∘··········· ···    ·          
+     6.2 |                           ··············∘∘∘∘∘∘∘∘∘∘··············    ··         
+         |                                ················∘·∘···············    · ·       
+         |                                   · · ···························· ··          
+         |                                     ·· ·························   ··   ·     ·
+         |                                          ·  ·    ···············   · ·         
+     3.0 |                                                      ··  ··· ·  ·  ··          
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        2.42     2.58     2.74     2.90     3.06     3.22     3.38     3.55     3.71  
+        2.34     2.53     2.72     2.91     3.10     3.29     3.48     3.67     3.85  
 ```
 
 Alternatively, as in the earlier example, we could try to predict what will happen tomorrow. This is similar to calling `poisson.generator` before, but this time, we use the `predict` method on `Predictor`, which takes the covariate (the day, in this case), and returns a `Generator` for the dependent variable (the number of sales). Putting it all together, it looks like this:
@@ -454,36 +448,36 @@ scala> val regr2 = for {
      |                     Poisson(intercept + slope*i)
      |                 }.fit(data)
      | } yield predictor.predict(21)
-regr2: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@6eb4c88b
+regr2: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@68af1e2
 ```
 
 Plotting this gives us a prediction which incorporates both the natural noise of a Poisson distribution and our uncertainty about its underlying parameterization.
 
 ```scala
 scala> plot1D(regr2.sample())
-     440 |                                                                                
-         |                                 ∘∘∘   ·                                        
-         |                               ·○○○○ ○○○                                        
-         |                               ○○○○○ ○○○ ·∘                                     
-         |                              ∘○○○○○ ○○○∘○○                                     
-     330 |                            ∘ ○○○○○○ ○○○○○○                                     
-         |                            ○ ○○○○○○ ○○○○○○                                     
-         |                          ∘∘○ ○○○○○○ ○○○○○○○ ·                                  
-         |                         ·○○○ ○○○○○○ ○○○○○○○ ○∘∘                                
-         |                         ○○○○ ○○○○○○ ○○○○○○○ ○○○                                
-     220 |                        ·○○○○ ○○○○○○ ○○○○○○○ ○○○                                
-         |                       ○○○○○○ ○○○○○○ ○○○○○○○ ○○○○                               
-         |                     · ○○○○○○ ○○○○○○ ○○○○○○○ ○○○○ ∘                             
-         |                     ○ ○○○○○○ ○○○○○○ ○○○○○○○ ○○○○○○                             
-         |                    ∘○ ○○○○○○ ○○○○○○ ○○○○○○○ ○○○○○○ ∘                           
-     110 |                    ○○ ○○○○○○ ○○○○○○ ○○○○○○○ ○○○○○○ ○○·                         
-         |                 ·∘○○○ ○○○○○○ ○○○○○○ ○○○○○○○ ○○○○○○ ○○○                         
-         |                 ○○○○○ ○○○○○○ ○○○○○○ ○○○○○○○ ○○○○○○ ○○○○··                      
-         |               ○○○○○○○ ○○○○○○ ○○○○○○ ○○○○○○○ ○○○○○○ ○○○○○○ ○                    
-         |           ··∘ ○○○○○○○ ○○○○○○ ○○○○○○ ○○○○○○○ ○○○○○○ ○○○○○○ ○○·∘                 
-       0 |······· ∘∘○○○○ ○○○○○○○ ○○○○○○ ○○○○○○ ○○○○○○○ ○○○○○○ ○○○○○○ ○○○○○○∘ ·∘··∘·   ····
+     460 |                                                                                
+         |                                     ∘·   ·                                     
+         |                                  ·  ○○○ ·○                                     
+         |                                  ○ ○○○○·○○∘                                    
+         |                                 ·○ ○○○○○○○○                                    
+     340 |                                 ○○ ○○○○○○○○ ∘                                  
+         |                                 ○○ ○○○○○○○○ ○                                  
+         |                               ·○○○ ○○○○○○○○ ○∘∘                                
+         |                              ∘○○○○ ○○○○○○○○ ○○○∘∘                              
+         |                             ∘○○○○○ ○○○○○○○○ ○○○○○                              
+     230 |                             ○○○○○○ ○○○○○○○○ ○○○○○·                             
+         |                           ∘○○○○○○○ ○○○○○○○○ ○○○○○○ ∘                           
+         |                           ○○○○○○○○ ○○○○○○○○ ○○○○○○∘○                           
+         |                           ○○○○○○○○ ○○○○○○○○ ○○○○○○○○ ∘                         
+         |                        ∘○ ○○○○○○○○ ○○○○○○○○ ○○○○○○○○ ○∘                        
+     110 |                       ○○○ ○○○○○○○○ ○○○○○○○○ ○○○○○○○○ ○○·                       
+         |                      ∘○○○ ○○○○○○○○ ○○○○○○○○ ○○○○○○○○ ○○○○                      
+         |                     ·○○○○ ○○○○○○○○ ○○○○○○○○ ○○○○○○○○ ○○○○∘∘                    
+         |                   ·∘○○○○○ ○○○○○○○○ ○○○○○○○○ ○○○○○○○○ ○○○○○○∘                   
+         |              ··∘ ○○○○○○○○ ○○○○○○○○ ○○○○○○○○ ○○○○○○○○ ○○○○○○○○ ∘∘·              
+       0 |· · · ·· ····∘○○○ ○○○○○○○○ ○○○○○○○○ ○○○○○○○○ ○○○○○○○○ ○○○○○○○○ ○○○○·○∘· ··· ·  ·
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        43.0     50.8     58.5     66.3     74.1     81.9     89.6     97.4    105.2  
+        39.0     47.0     55.0     63.0     71.0     79.0     87.0     95.0    103.0  
 ```
 
 Finally, let's close with a small and somewhat contrived example of a hierarchical model, where we have two separate regressions that share a parameter. For the sake of the example, let's assume that we have a second sales dataset, much like the first, where we know they had the same rate at the start of the observations, but may have grown at different rates - so their intercepts will be equal but their slopes will not. Here's the data:
@@ -504,35 +498,35 @@ scala> val regr3 = for {
      |   intercept <- LogNormal(0,1).param
      |   _ <- Predictor.from[(Int, Int), Int, (Real, Real), Real]{ case (i,x) => Poisson(intercept + slopes(i) * x) }.fit(allData)
      | } yield (slopes(0), intercept)
-regr3: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@765ec043
+regr3: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@2c5d42e9
 ```
 Here, `i` indexes the model and `x` is the x-value of the observation. Plotting slope vs intercept now, we can see that, even though these are two separate regressions, we get tighter bounds than before by letting the new data influence the shared parameter. It makes sense that we'd get more confidence on the intercept, since we have two different time series to learn from now; but because of the anti-correlation, that also leads to somewhat more confidence than before on the `slope1` parameter as well.
 
 ```scala
 scala> plot2D(regr3.sample())
-    11.3 |                                                                                
-         |        ·                                                                       
-         |·                                                                               
-         |         ·        ··  ··                                                        
-         |  · ·    · ·· · ···   ··· · ·· ·    ··                                          
-     9.2 |   ··  ··· · ·······················    ··   ·                                  
-         |      ····· ··· ··················· ····· ·      ·   ·                          
-         |    · ·· ································ ·      ·  ··                          
-         |     ·  ··································· ····· ·       ·                     
-         |        ·   ···············∘·∘∘·∘·∘···················    · ·                   
-     7.2 |        · ···············∘·∘∘∘∘∘∘∘∘∘∘∘·∘···∘···············                     
-         |             ··············∘∘∘∘∘○∘∘∘∘∘○∘∘∘∘················· ·   ·              
-         |          ···· ·· ·········∘·∘∘∘∘∘○∘∘○∘∘∘∘∘∘∘∘∘∘∘∘··············    · ·         
-         |           ·    · ·············∘∘∘∘∘∘∘○○∘∘∘○∘∘∘∘∘∘··············  ·             
-         |               ·  ················∘·∘·∘∘∘∘∘∘∘·∘∘∘∘∘················ ·           
-     5.1 |                ·  ·   ·············∘·····∘···∘∘······················          
-         |                     ·    · ······································ ····  ··    ·
-         |                       ·    ·  · ·· ······························ ··  ·        
-         |                                   · ·· ··················· ·  · ·  · ··  ·     
-         |                                               ··  · ·      ·        ·          
-     3.1 |                                               ·  ···       ·  ·                
+    10.8 |                                                                                
+         |   ·     ·    ·             ·                                                   
+         |  ·    ·         ·      ·     ·                                                 
+         |      ·  · ···  ········ · ····     ·                                           
+         |·     ·  · ·  ·····  ········· ·· · ·           ·                               
+     8.9 |       · · ························· ···· ·    · ·                              
+         |       ······································  ··       ··                      
+         |         ·· ····· ··································   ·  ·                     
+         |       ·  ·· ·············∘··∘∘∘·∘··∘∘············· ···· ·· ·                   
+         |         · ·· ············∘∘∘·∘∘○·∘∘∘∘∘∘∘···∘··············    ·                
+     6.9 |              · ··········∘∘∘∘∘○○∘∘∘○∘∘∘∘○∘∘∘·∘············  ·    ·             
+         |          ·   · ·············∘∘∘○○○∘○○∘○∘○○○○∘∘∘················ · · ·          
+         |               ·· ··· ········∘∘∘∘∘○○○○○○○∘∘∘∘∘∘∘∘·············· ··  ·          
+         |                 ·  ·············∘∘∘∘○○∘∘○∘∘∘∘○○∘∘∘∘··············· ···         
+         |                   ·  ·············∘···∘∘∘∘∘∘∘∘∘∘∘∘∘··············· ·     ·     
+     4.9 |                       ··  ···················∘····∘················· ··  ·     
+         |                        ·    ····································· · ·     ·    
+         |                              ·  ·· ···························· · ··       ·   
+         |                                      ··  ········ ·· ······· ··   · · ·        
+         |                                        ·   · ··  ·· ·         ·               ·
+     2.9 |                                                                  ·             
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        2.71     2.85     2.99     3.13     3.27     3.41     3.56     3.70     3.84  
+        2.67     2.82     2.96     3.11     3.25     3.40     3.54     3.69     3.83  
 ```
 
 ## Learning More

--- a/docs/tour.md
+++ b/docs/tour.md
@@ -30,7 +30,7 @@ Rainier implements various familiar families of probability distributions like t
 
 ```scala
 scala> val normal: Distribution[Double] = Normal(0,1)
-normal: com.stripe.rainier.core.Distribution[Double] = com.stripe.rainier.core.Injection$$anon$1@793f05aa
+normal: com.stripe.rainier.core.Distribution[Double] = com.stripe.rainier.core.Injection$$anon$1@5c99a14b
 ```
 
 In Rainier, `Distribution` objects play three different roles. `Continuous` distributions (like `Normal`), implement `param`, and all distributions implement `fit` and `generator`. Each of these methods is central to one of the three stages of building a model in Rainier:
@@ -51,43 +51,43 @@ Let's use that same `Normal(0,1)` distribution as a prior for a new parameter:
 
 ```scala
 scala> val x = Normal(0,1).param
-x: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@64674f1f
+x: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@7230afcb
 ```
 
 You can see that the type of `x` is `RandomVariable[Real]`. `RandomVariable` pairs a type of value (in this case, a real number) with some knowledge of the relative probability density of different values of that type. We can use this knowledge to produce a sample of these possible values:
 
 ```scala
 scala> x.sample()
-res0: List[Double] = List(-0.5451549207293471, 0.5421277783120733, -0.5386759590971426, 0.5425977102747024, -0.5432380062242386, 0.5428031270781379, -0.540758488908677, 0.5423203553611833, -0.541275250038389, 0.5419649332970861, -0.5400985831640157, 0.5424864004108134, -0.5426177965822958, 0.5427531873136975, -0.543682215089409, 0.5426446811127528, -0.5430239985865657, 0.5425667388895744, -0.5436428591205954, 0.5421322049718278, -0.5445119908153138, 0.5475045451457676, -0.5477853371358438, 0.5436557495535577, -0.5450719541877482, 0.5436895190545374, -0.5435295588241975, 0.5416791254200879, -0.5422073480199067, 0.5398119449584851, -0.537620094615634, 0.5402375168482485, -0.5424008370245201, 0.5414903293044941, -0.541839959202767, 0.5427210585246793, -0.544094567...
+res0: List[Double] = List(-0.5350756732175771, 0.4095879847940215, -0.48103750803591966, 0.6195772581111134, -0.1881177537347165, 0.5153578542054698, -0.40835882409772284, 0.31110274452483294, 0.48174662765081644, -0.5408499092051309, 0.4172522334231373, -0.14313607661092242, 0.36536408757761807, -0.4915431077636774, 0.39268870034628256, -0.25104249119668204, 0.42524503968352634, -0.7774682430044022, 1.0916362983757233, -0.79307761222504, 0.17955091468343598, 0.2116520724912656, -0.2544159474840291, -0.2544159474840291, 0.6933882180446678, -0.18042154050586623, 0.12743839889299519, -0.5422614153952039, 0.3626523108500808, -0.06231261510660291, 0.05715475723870011, -0.027061013200473716, -0.4245638566089802, -0.15596907820181993, -0.3961564095037544, 0.111219079...
 ```
 
 Each element of the list above represents a single sample from the distribution over `x`. It's easier to understand these if we plot them as a histogram:
 
 ```scala
 scala> plot1D(x.sample())
-     340 |                                                                                
-         |                                     · ·  ∘                                     
-         |                                     ○∘○  ○                                     
-         |                                     ○○○∘○○ ∘                                   
-         |                                   ∘∘○○○○○○○○∘                                  
-     250 |                                ···○○○○○○○○○○○ ○∘                               
-         |                                ○○○○○○○○○○○○○○○○○                               
-         |                             ·  ○○○○○○○○○○○○○○○○○ ∘                             
-         |                             ○∘∘○○○○○○○○○○○○○○○○○∘○                             
-         |                            ∘○○○○○○○○○○○○○○○○○○○○○○∘∘                           
-     170 |                            ○○○○○○○○○○○○○○○○○○○○○○○○○·                          
-         |                          ·○○○○○○○○○○○○○○○○○○○○○○○○○○○∘                         
-         |                       ∘·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○ ○                       
-         |                    ·  ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○ ·                     
-         |                    ○∘∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○                   
-      80 |                    ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○ ○                 
-         |                  ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·○·                
-         |               ··○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○               
-         |             ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○··            
-         |       ··∘·∘∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘··· ∘      
-       0 |·····∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘····
+     400 |                                                                                
+         |                                     ∘ ·                                        
+         |                                     ○ ○                                        
+         |                                    ·○ ○ ∘○∘                                    
+         |                                   ○○○∘○·○○○·                                   
+     300 |                                 ∘·○○○○○○○○○○○∘                                 
+         |                                 ○○○○○○○○○○○○○○○∘                               
+         |                                 ○○○○○○○○○○○○○○○○                               
+         |                             ·∘ ○○○○○○○○○○○○○○○○○○                              
+         |                             ○○∘○○○○○○○○○○○○○○○○○○○ ○                           
+     200 |                             ○○○○○○○○○○○○○○○○○○○○○○ ○                           
+         |                            ○○○○○○○○○○○○○○○○○○○○○○○○○                           
+         |                           ·○○○○○○○○○○○○○○○○○○○○○○○○○∘○                         
+         |                        · ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○·                        
+         |                        ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                       
+     100 |                       ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·○                     
+         |                    ○ ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·                    
+         |                  · ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘                   
+         |                 ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○  ·               
+         |             ··∘∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘·             
+       0 |···· ··∘··∘∘∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·∘···· ····
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-       -3.03    -2.35    -1.68    -1.00    -0.33     0.34     1.02     1.69     2.37  
+       -3.61    -2.81    -2.01    -1.21    -0.41     0.40     1.20     2.00     2.80  
 ```
 
 Since the only information we have about `x` so far is its `Normal` prior, this distribution unsurprisingly looks normal. Later we'll see how to update our beliefs about `x` based on observational data.
@@ -96,102 +96,102 @@ For now, though, let's explore what we can do just with priors. `RandomVariable`
 
 ```scala
 scala> val e_x = x.map(_.exp)
-e_x: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@caf283f
+e_x: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@7ce65611
 
 scala> plot1D(e_x.sample())
-     730 |                                                                                
-         | ∘                                                                              
-         | ○·                                                                             
-         | ○○                                                                             
-         | ○○                                                                             
-     550 | ○○∘   ·∘                                                                       
-         | ○○○  ·○○·                                                                      
-         | ○○○○·○○○○                                                                      
-         | ○○○○○○○○○∘                                                                     
-         | ○○○○○○○○○○                                                                     
-     360 | ○○○○○○○○○○·                                                                    
-         | ○○○○○○○○○○○                                                                    
-         | ○○○○○○○○○○○∘                                                                   
-         | ○○○○○○○○○○○○·                                                                  
-         |·○○○○○○○○○○○○○·                                                                 
-     180 |○○○○○○○○○○○○○○○                                                                 
-         |○○○○○○○○○○○○○○○∘∘∘ ·                                                            
-         |○○○○○○○○○○○○○○○○○○∘○∘∘·                                                         
-         |○○○○○○○○○○○○○○○○○○○○○○○○∘·∘·····                                                
-         |○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘∘∘∘∘∘··∘····                                   
-       0 |○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘∘∘∘·∘···············    ·· ·   ·
+    2400 |                                                                                
+         | ·                                                                              
+         | ○                                                                              
+         | ○                                                                              
+         | ○                                                                              
+    1800 |∘○                                                                              
+         |○○                                                                              
+         |○○·                                                                             
+         |○○○                                                                             
+         |○○○                                                                             
+    1200 |○○○                                                                             
+         |○○○                                                                             
+         |○○○○                                                                            
+         |○○○○                                                                            
+         |○○○○∘                                                                           
+     600 |○○○○○                                                                           
+         |○○○○○·                                                                          
+         |○○○○○○·                                                                         
+         |○○○○○○○∘                                                                        
+         |○○○○○○○○○∘·                                                                     
+       0 |○○○○○○○○○○○○∘∘∘··························  ···     · ··    ·       ·    ·      ·
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        0.13     0.98     1.82     2.67     3.51     4.36     5.21     6.05     6.90  
+        0.0      3.5      7.1      10.6     14.1     17.6     21.1     24.6     28.1  
 ```
 
 Or we can create another `Normal` parameter and zip the two together to produce a 2D gaussian. Since there's nothing relating these two parameters to each other, you can see in the plot that they're completely independent.
 
 ```scala
 scala> val y = Normal(0,1).param
-y: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@254800f7
+y: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@c23a6c4
 
 scala> val xy = x.zip(y)
-xy: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@7bef595
+xy: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@1477366
 
 scala> plot2D(xy.sample())
-     4.0 |                                                                                
-         |                                    ·   ·                                       
-         |               ·     ·  ·                          ·      ·                     
-         |                              ·    · ··   · ··          ·               ·      ·
-         |       ·           ·   ·   ·····  ············ ······      ·                    
-     2.0 |               ··    · · ··········· ···· ···················· · · ·  · ·       
-         |        ·  · · ·······  ····································· ·· · ·   ·        
-         |       · · ·  ···· ··············∘···∘·∘·······∘················ ·· ·  ·        
-         |      · ···· ·· ···········∘··∘·∘∘·∘∘∘··∘∘∘·∘∘∘∘∘∘······················        
-         |  ··· ··  ··· ·············∘·∘∘·∘∘∘∘∘∘·∘∘∘∘∘∘∘∘∘·∘∘∘·∘·∘···················  ·· 
-    -0.0 |      ······················∘∘∘∘∘∘∘∘∘∘○○∘○○∘○∘∘∘∘∘∘∘∘·················· ·· ·    
-         |·       ···· ··············∘∘∘∘∘∘∘○∘∘∘∘∘∘∘∘○∘∘∘○∘∘∘∘∘∘··············· ·  ···· ··
-         |      · ···················∘∘∘∘∘∘∘∘∘∘∘∘∘○∘∘∘○○·····∘·∘·∘···············      ·  
-         |      · ······  ················∘·∘·∘∘∘∘∘·∘∘∘··∘·∘··············· ·· · ··   ·   
-         | ·    ··  ·  ·· ·····················∘·····························    ·  ·     
-    -2.1 |             ··· ··  ··································· · ··· ·  · ·  ·        
-         |     ·      ··   · · ·· ·· ·········· ····  ········ ··  ···    ·  ·            
-         |                   ··  ·   ··  · · ··········  ····   ·             ·   ·       
-         |                                ·   · ·     ·             ·                     
-         |                              ·                      ·                          
-    -4.1 |             ·                               ·                                  
+     3.8 |                                                                                
+         |                              ·                 ·                               
+         |                         ·   ·             ··  ··      ·                        
+         |                                ···· · ·  ······      ·  ·                      
+         |                  · · ·  ·· ··  · ········ ·  ···· ·· ·         ·               
+     2.0 |               ·   ·   ·· ················· ···············   ·     ·   ·       
+         |             · ··· · ·· ······························· · · ·····   ·    ·   ·  
+         |     ·  · · · ··········· ··································· ·      ·  ·       
+         |   ·    ·····  · · ··············∘··∘·∘∘···∘····∘····················· ··      ·
+         |   ·    ···  ··············∘·∘··∘·∘·∘∘∘∘∘∘∘∘∘·∘∘·····∘··············· ·· · ·    
+     0.2 |·      · ··············∘·····∘∘·∘∘∘∘∘∘∘∘∘∘○○∘○∘∘·∘∘∘··············· ···      ·  
+         |      ··  ···················∘∘○∘∘∘○∘∘∘∘○∘∘·∘○∘∘∘∘∘················ ······   ·  
+         |···   ···  ·················∘·∘∘∘∘○∘∘∘∘∘∘∘∘○∘∘∘∘∘∘∘∘·∘·∘·········· ·········    
+         |   ·   · ·  ·····················∘∘·∘∘∘∘∘∘∘∘∘∘∘∘···················· ···  ·    ·
+         |     ···· ·· ·· ·················∘·∘···∘∘∘∘·∘····∘···················  ·  ··    
+    -1.6 |      ·   · · · ······················∘·····∘∘················ ····· ·   ··    ·
+         |            ·· ··········· ··································· ·· ·             
+         |           ·        · ·· · ·· ···················  ····· · ···      ·     ·     
+         |                      ·· · ····· ·  ······ ·· ·  ··· ··· ··           ·         
+         |   ·          ·             ···· ··   ···   ··         · ·                      
+    -3.4 |                       ·           ·    · ·  ··       ·                         
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-       -3.44    -2.68    -1.92    -1.17    -0.41     0.35     1.10     1.86     2.62  
+       -3.57    -2.76    -1.96    -1.16    -0.36     0.44     1.24     2.04     2.84  
 ```
 
 Finally, we can use `flatMap` to create two parameters that *are* related to each other. In particular, we'll create a new parameter `z` that we believe to be very close to `x`: its prior is a `Normal` centered on `x` with a very small standard deviation. We'll then make a 2D plot of `(x,z)` to see the relationship.
 
 ```scala
 scala> val z = x.flatMap{a => Normal(a, 0.1).param}
-z: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@217c6f5c
+z: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@46cf30d1
 
 scala> val xz = x.zip(z)
-xz: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@545be675
+xz: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@7db1d351
 
 scala> plot2D(xz.sample())
-     3.8 |                                                                                
-         |                                                                             ···
-         |                                                                      ·······   
-         |                                                                   ·······      
-         |                                                              ········          
-     1.8 |                                                           ········             
-         |                                                      ·········                 
-         |                                                 ····∘∘····                     
-         |                                              ···∘∘∘···                         
-         |                                          ··∘∘○∘∘···                            
-    -0.2 |                                      ···∘○○∘···                                
-         |                                  ···∘○∘∘···                                    
-         |                             ····∘∘∘∘···                                        
-         |                           ···∘∘····                                            
-         |                      ··········                                                
-    -2.1 |                   ·······                                                      
+     3.9 |                                                                                
+         |                                                                           ·  ··
+         |                                                                      ······    
+         |                                                                  ······        
+         |                                                             ········           
+     1.8 |                                                          ········              
+         |                                                     ··········                 
+         |                                                 ···∘∘∘····                     
+         |                                             ···∘∘∘∘·· ·                        
+         |                                         ···∘○∘∘··                              
+    -0.3 |                                     ···∘○○∘···                                 
+         |                                  ··∘○○∘···                                     
+         |                              ···∘∘∘···                                         
+         |                          ····∘∘···                                             
+         |                       ········                                                 
+    -2.3 |                  ·········                                                     
          |               ········                                                         
          |            ·······                                                             
-         |        ······                                                                  
-         |      ·                                                                         
-    -4.1 |·  ·                                                                            
+         |         ····                                                                   
+         |                                                                                
+    -4.4 |·                                                                               
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-       -4.17    -3.28    -2.39    -1.50    -0.61     0.28     1.17     2.06     2.95  
+        -4.5     -3.6     -2.6     -1.7     -0.7     0.3      1.2      2.2      3.1   
 ```
 
 You can see that although we still sample from the full range of `x` values, for any given sample, `x` and `z` are quite close to each other.
@@ -234,7 +234,7 @@ We can see here that our data is about 3x as likely to have come from a `Poisson
 
 ```scala
 scala> val poisson: RandomVariable[_] = e_x.flatMap{r => Poisson(r).fit(sales)}
-poisson: com.stripe.rainier.core.RandomVariable[_] = com.stripe.rainier.core.RandomVariable@74e8f87
+poisson: com.stripe.rainier.core.RandomVariable[_] = com.stripe.rainier.core.RandomVariable@12c14902
 ```
 
 Reaching under the hood for a second: our `poisson9`'s `density` had no parameters whereas now, our model's density is a function of the parameter value
@@ -254,7 +254,7 @@ scala> val rate = for {
      |     r <- e_x
      |     poisson <- Poisson(r).fit(sales)
      | } yield r
-rate: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@4bf3121d
+rate: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@50f2331
 ```
 
 This is our first "full" model: we have a parameter with a log-normal prior, bundled into the `RandomVariable` named `e_x`; we use that parameter to initialize a `Poisson` noise distribution which we fit to our observations; and at the end, we output the same parameter (referenced by `r`) as the quantity we're interested in sampling from the posterior.
@@ -263,29 +263,29 @@ Let's plot the results!
 
 ```scala
 scala> plot1D(rate.sample())
-     430 |                                                                                
+     370 |                                                                                
          |                                ∘                                               
-         |                               ·○                                               
-         |                              ○○○                                               
-         |                             ○○○○ · ○·                                          
-     320 |                             ○○○○∘○○○○                                          
-         |                         · ○○○○○○○○○○○·∘                                        
-         |                        ·○·○○○○○○○○○○○○○                                        
-         |                        ○○○○○○○○○○○○○○○○∘ ○                                     
-         |                        ○○○○○○○○○○○○○○○○○∘○                                     
-     210 |                       ○○○○○○○○○○○○○○○○○○○○··                                   
-         |                     ○·○○○○○○○○○○○○○○○○○○○○○○                                   
-         |                   ∘·○○○○○○○○○○○○○○○○○○○○○○○○  ∘                                
-         |                   ○○○○○○○○○○○○○○○○○○○○○○○○○○ ∘○                                
-         |                   ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○   ∘                            
-     100 |                · ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○ ∘○                            
-         |               ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·○○                            
-         |             ∘∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○·                         
-         |∘            ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○ ·                       
-         |○      ∘·· ∘ ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○····                   
-       0 |○  ·  ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○○∘∘·· ·····  ··
+         |                             ○  ○○·                                             
+         |                             ○ ∘○○○○∘                                           
+         |                            ○○○○○○○○○                                           
+     280 |                            ○○○○○○○○○  ∘                                        
+         |                         ○∘∘○○○○○○○○○○○○                                        
+         |                       ○·○○○○○○○○○○○○○○○∘·∘                                     
+         |                     ∘ ○○○○○○○○○○○○○○○○○○○○                                     
+         |                     ○○○○○○○○○○○○○○○○○○○○○○∘                                    
+     180 |                     ○○○○○○○○○○○○○○○○○○○○○○○ ∘·                                 
+         |                   ○○○○○○○○○○○○○○○○○○○○○○○○○○○○                                 
+         |                 ··○○○○○○○○○○○○○○○○○○○○○○○○○○○○                                 
+         |                 ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                                
+         |               · ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·∘                              
+      90 |              ·○∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○∘                           
+         |           ··∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○ ·                         
+         |          ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○ ·                      
+         |          ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘                     
+         |     ·· ∘∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘ ∘··              
+       0 |··∘·∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○∘∘··········
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        4.41     5.28     6.15     7.02     7.90     8.77     9.64    10.51    11.38  
+        4.84     5.61     6.37     7.14     7.90     8.67     9.44    10.20    10.97  
 ```
 
 Looks like our daily rate is probably somewhere between 6 and 9, which corresponds well to the steep 3x dropoff we saw before between 9 and 10.
@@ -336,42 +336,42 @@ scala> val prediction = for {
      |     r <- e_x
      |     poisson <- Poisson(r).fit(sales)
      | } yield poisson.generator
-prediction: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@238bfb48
+prediction: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@439eee6c
 ```
 
 This is almost the same model as `rate` above, but instead of taking the real-valued `r` rate parameter as the output, we're producing poisson-distributed integers. The samples look like this:
 
 ```scala
 scala> prediction.sample()
-res9: List[Int] = List(9, 14, 7, 11, 8, 5, 13, 8, 10, 8, 9, 6, 9, 4, 9, 10, 6, 7, 7, 11, 4, 5, 7, 11, 11, 6, 12, 5, 6, 9, 10, 7, 3, 13, 7, 8, 4, 10, 11, 11, 9, 6, 5, 5, 9, 5, 10, 9, 13, 7, 4, 3, 7, 3, 12, 0, 10, 7, 11, 7, 10, 5, 6, 11, 8, 10, 7, 10, 8, 7, 8, 9, 14, 10, 5, 4, 6, 13, 15, 7, 5, 10, 7, 3, 4, 7, 9, 9, 4, 11, 7, 3, 6, 8, 8, 7, 8, 9, 8, 8, 7, 11, 7, 7, 6, 7, 4, 11, 2, 4, 9, 6, 11, 4, 7, 14, 5, 9, 6, 10, 3, 9, 8, 9, 13, 13, 3, 6, 7, 8, 5, 8, 4, 3, 17, 9, 10, 11, 6, 2, 3, 5, 6, 6, 5, 8, 9, 10, 5, 11, 6, 8, 10, 8, 7, 6, 15, 8, 5, 5, 8, 5, 14, 9, 4, 9, 12, 6, 10, 1, 7, 5, 13, 7, 7, 11, 11, 10, 14, 9, 7, 10, 6, 3, 11, 9, 4, 2, 7, 10, 9, 6, 16, 4, 9, 10, 12, 8, 5, 3, 6, 15, 7, 10, 7, 9, 7, 10, 10, 11, 11, 8, 9, 7, 5, 8, 6, 2, 4, 7, 8, 7, 10, 3, 10, 6, 10, 9...
+res9: List[Int] = List(7, 13, 7, 6, 13, 7, 7, 5, 10, 5, 8, 9, 7, 9, 6, 11, 12, 3, 11, 9, 9, 4, 7, 9, 6, 15, 8, 5, 10, 13, 12, 7, 7, 9, 6, 12, 8, 9, 12, 5, 12, 6, 12, 13, 7, 10, 6, 4, 3, 9, 5, 6, 9, 4, 9, 7, 11, 7, 9, 7, 8, 14, 4, 6, 10, 6, 4, 7, 13, 7, 7, 11, 10, 13, 7, 10, 8, 5, 10, 6, 8, 13, 10, 6, 9, 4, 6, 11, 11, 6, 10, 4, 11, 6, 7, 3, 8, 6, 5, 6, 9, 13, 12, 6, 10, 3, 8, 9, 7, 7, 11, 10, 14, 8, 4, 5, 11, 12, 12, 8, 7, 11, 6, 8, 11, 6, 8, 8, 13, 3, 10, 8, 12, 12, 7, 5, 8, 8, 8, 14, 9, 16, 7, 14, 13, 5, 9, 4, 8, 5, 2, 4, 7, 6, 8, 6, 8, 10, 7, 4, 8, 8, 7, 6, 5, 7, 8, 11, 10, 7, 11, 10, 11, 7, 7, 11, 6, 5, 12, 8, 11, 4, 10, 8, 10, 3, 4, 6, 4, 9, 7, 5, 9, 5, 5, 8, 7, 8, 5, 8, 8, 9, 8, 8, 11, 5, 10, 11, 10, 5, 8, 5, 3, 13, 9, 13, 8, 14, 3, 5, 2, 9, 5, 2, 5, 6, 7,...
 ```
 Or, if we plot them, like this:
 
 ```scala
 scala> plot1D(prediction.sample())
-    1390 |                                                                                
-         |                         ○                                                      
-         |                         ○  ∘                                                   
-         |                     ∘   ○  ○                                                   
-         |                     ○   ○  ○                                                   
-    1040 |                     ○   ○  ○   ∘                                               
-         |                  ∘  ○   ○  ○   ○                                               
-         |                  ○  ○   ○  ○   ○                                               
-         |                  ○  ○   ○  ○   ○   ∘                                           
-         |                  ○  ○   ○  ○   ○   ○                                           
-     690 |              ∘   ○  ○   ○  ○   ○   ○                                           
-         |              ○   ○  ○   ○  ○   ○   ○                                           
-         |              ○   ○  ○   ○  ○   ○   ○  ○                                        
-         |              ○   ○  ○   ○  ○   ○   ○  ○                                        
-         |          ·   ○   ○  ○   ○  ○   ○   ○  ○   ∘                                    
-     340 |          ○   ○   ○  ○   ○  ○   ○   ○  ○   ○                                    
-         |          ○   ○   ○  ○   ○  ○   ○   ○  ○   ○                                    
-         |          ○   ○   ○  ○   ○  ○   ○   ○  ○   ○   ○                                
-         |       ∘  ○   ○   ○  ○   ○  ○   ○   ○  ○   ○   ○  ·                             
-         |       ○  ○   ○   ○  ○   ○  ○   ○   ○  ○   ○   ○  ○   ·                         
-       0 |·  ∘   ○  ○   ○   ○  ○   ○  ○   ○   ○  ○   ○   ○  ○   ○  ∘   ·   ·  ·       ·  ·
+    1430 |                                                                                
+         |                          ○                                                     
+         |                          ○                                                     
+         |                      ∘   ○   ∘                                                 
+         |                      ○   ○   ○                                                 
+    1070 |                      ○   ○   ○   ∘                                             
+         |                  ○   ○   ○   ○   ○                                             
+         |                  ○   ○   ○   ○   ○                                             
+         |                  ○   ○   ○   ○   ○                                             
+         |                  ○   ○   ○   ○   ○  ○                                          
+     710 |               ·  ○   ○   ○   ○   ○  ○                                          
+         |               ○  ○   ○   ○   ○   ○  ○                                          
+         |               ○  ○   ○   ○   ○   ○  ○   ∘                                      
+         |               ○  ○   ○   ○   ○   ○  ○   ○                                      
+         |               ○  ○   ○   ○   ○   ○  ○   ○                                      
+     350 |           ∘   ○  ○   ○   ○   ○   ○  ○   ○   ∘                                  
+         |           ○   ○  ○   ○   ○   ○   ○  ○   ○   ○                                  
+         |           ○   ○  ○   ○   ○   ○   ○  ○   ○   ○   ○                              
+         |       ·   ○   ○  ○   ○   ○   ○   ○  ○   ○   ○   ○   ·                          
+         |       ○   ○   ○  ○   ○   ○   ○   ○  ○   ○   ○   ○   ○  ·                       
+       0 |·  ∘   ○   ○   ○  ○   ○   ○   ○   ○  ○   ○   ○   ○   ○  ○   ∘   ∘   ·   ·  ·   ·
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        0.0      2.5      5.0      7.5      9.9      12.4     14.9     17.4     19.9  
+        0.0      2.4      4.7      7.1      9.5      11.9     14.2     16.6     19.0  
 ```
 
 ## `Likelihood` and `Predictor`
@@ -419,7 +419,7 @@ scala> val prior = for {
      |     slope <- LogNormal(0,1).param
      |     intercept <- LogNormal(0,1).param
      |     } yield (slope, intercept)
-prior: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@5657d3c3
+prior: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@50992ee0
 ```
 
 Now, for any given day `i`, we want to check the number of sales against `Poisson(intercept + slope*i)`. We could write some kind of recursive flatMap to build and fit each of these different distribution objects in turn, but this is a common enough pattern that Rainier already has something built in for it: `Predictor`. `Predictor` is not a `Distribution`, but instead wraps a function from `X => Distribution[Y]` for some `(X,Y)`; you can use this any time you have a dependent variable of type `Y` that you're modeling with some independent variables jointly represented as `X`.
@@ -433,7 +433,7 @@ scala> val regr = for {
      |                     Poisson(intercept + slope*i)
      |                 }.fit(data)
      | } yield (slope, intercept)
-regr: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@55dc5bef
+regr: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@56dd6b7e
 ```
 
 As before, we're starting out by just sampling the parameters. By plotting them, we can see that the model's confidence in the intercept, in particular, is pretty low: although it's most likely to be somewhere around 8, it could be anywhere from 3 to 13 or even higher. Second, as you'd hope, the two parameters are anti-correlated:
@@ -441,29 +441,29 @@ a smaller intercept would imply a higher slope, and vice versa.
 
 ```scala
 scala> plot2D(regr.sample())
-    15.2 |                                                                                
-         |·            ·                                                                  
-         |    ·       ·      ·        ·                                                   
-         |    ·   ·   ··  ··  · ·    ·  ·                                                 
-         |·  ·  · ··········· ····· ·      ·                                              
-    12.0 |·    ····················· ··  ·  ·· ·                                          
-         |     ·· · · ························  ··                                        
-         |        ·· ································ ·    ·                              
-         |     · ·  · ·············∘··∘··············  ··  ·                              
-         |         ···············∘·∘∘∘∘∘∘∘∘∘·∘·············· ·                           
-     8.8 |              · ·········∘∘∘∘∘○∘∘∘∘∘∘∘∘·············· · ·                       
-         |           · ·············∘∘∘∘○○○○○○∘○○∘∘∘∘···············                      
-         |                 ···········∘·∘∘∘∘○∘∘○○○○○∘○∘∘·∘·········  ·  ·                 
-         |                    · ···········∘∘∘∘∘∘○○○○∘∘∘∘∘∘········ ·· ····    ·          
-         |                    ·   · ··········∘∘∘∘∘∘∘∘∘∘∘∘∘∘··········· · · ·             
-     5.6 |                          · ···············∘∘················· ···· ·           
-         |                           ·  ·  ·· ·····························     ·         
-         |                                 ·· ·  · · ··················· ·· ·  ····       
-         |                                       ·· · ··  · ·· ·····  ·······   ·         
-         |                                                        ··   ··· ·             ·
-     2.4 |                                                      ·   ·   ·                 
+    15.1 |                                                                                
+         |              ·                                                                 
+         |   ·       ·    ·    · · ·                                                      
+         |    · ······ · · · ····     · ··                                                
+         |·  ·  ·  · ················ ··                                                  
+    12.1 |· ·     ·· ··················· ··· · · ·                                        
+         |     ·  ························· ······  ·                                     
+         |      ····································· ··                                  
+         |  ·      ···············∘························  ··                           
+         |         ·   ··············∘∘∘·∘∘∘∘··∘············ ··   ·                       
+     9.2 |    ·        · ·········∘∘··∘∘∘∘∘∘∘∘∘∘∘∘············ · ·             ·          
+         |        ·    ··· ··········∘∘∘∘∘∘∘∘○○∘∘∘∘○∘···∘·············· · ·               
+         |              · ···········∘∘∘∘∘∘∘∘○∘∘∘○∘∘∘∘∘∘∘∘··∘∘·············   ·           
+         |                 ·   ···········∘∘∘∘∘∘∘○∘○○○○○∘∘∘∘∘∘·∘········· ·· · ·  ·       
+         |                        ·· ·········∘∘∘∘∘∘∘○∘∘∘∘∘∘∘·∘∘············· ·           
+     6.3 |                      ··  ··· ·········∘∘·∘∘∘∘∘∘∘·∘∘∘···∘········  ·· ·   ·     
+         |                            ··· · ·············∘··∘∘∘··∘············  ··   ·    
+         |                                ·   ···················∘············· ·· ·  ·   
+         |                                       ·  ··· ························· ·      ·
+         |                                       ·  ···  ········· ·········· · ··        
+     3.3 |                                                 · ·     · ·   ··            ·  
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        2.44     2.62     2.80     2.98     3.16     3.33     3.51     3.69     3.87  
+        2.45     2.61     2.78     2.94     3.10     3.26     3.43     3.59     3.75  
 ```
 
 Alternatively, as in the earlier example, we could try to predict what will happen tomorrow. This is similar to calling `poisson.generator` before, but this time, we use the `predict` method on `Predictor`, which takes the covariate (the day, in this case), and returns a `Generator` for the dependent variable (the number of sales). Putting it all together, it looks like this:
@@ -476,36 +476,36 @@ scala> val regr2 = for {
      |                     Poisson(intercept + slope*i)
      |                 }.fit(data)
      | } yield predictor.predict(21)
-regr2: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@4ecf3c5c
+regr2: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@e5f3ce1
 ```
 
 Plotting this gives us a prediction which incorporates both the natural noise of a Poisson distribution and our uncertainty about its underlying parameterization.
 
 ```scala
 scala> plot1D(regr2.sample())
-     450 |                                                                                
-         |                              ·∘                                                
-         |                            ·○○○· ·∘                                            
-         |                            ○○○○○○○○                                            
-         |                            ○○○○○○○○∘ ○                                         
-     340 |                         ·· ○○○○○○○○○∘○                                         
-         |                         ○○ ○○○○○○○○○○○                                         
-         |                        ∘○○ ○○○○○○○○○○○○                                        
-         |                       ·○○○ ○○○○○○○○○○○○ ∘                                      
-         |                       ○○○○ ○○○○○○○○○○○○ ○○∘                                    
-     220 |                     ··○○○○ ○○○○○○○○○○○○ ○○○                                    
-         |                    ○○○○○○○ ○○○○○○○○○○○○ ○○○                                    
-         |                   ○○○○○○○○ ○○○○○○○○○○○○ ○○○○○·                                 
-         |                   ○○○○○○○○ ○○○○○○○○○○○○ ○○○○○○                                 
-         |                  ○○○○○○○○○ ○○○○○○○○○○○○ ○○○○○○·                                
-     110 |                 ·○○○○○○○○○ ○○○○○○○○○○○○ ○○○○○○○··                              
-         |               ·○○○○○○○○○○○ ○○○○○○○○○○○○ ○○○○○○○○○ ·                            
-         |               ○○○○○○○○○○○○ ○○○○○○○○○○○○ ○○○○○○○○○∘○                            
-         |              ∘○○○○○○○○○○○○ ○○○○○○○○○○○○ ○○○○○○○○○○○·∘                          
-         |          ·∘∘ ○○○○○○○○○○○○○ ○○○○○○○○○○○○ ○○○○○○○○○○○○○ ○○○                      
-       0 |······∘∘○○○○○ ○○○○○○○○○○○○○ ○○○○○○○○○○○○ ○○○○○○○○○○○○○ ○○○○∘······· · ·· ·· ·  ·
+     470 |                                                                                
+         |                                 · ∘ ∘                                          
+         |                                 ○ ○ ○·                                         
+         |                                 ○ ○○○○· ∘                                      
+         |                              ∘ ○○ ○○○○○·○                                      
+     350 |                              ○·○○ ○○○○○○○                                      
+         |                              ○○○○ ○○○○○○○ ∘                                    
+         |                            · ○○○○ ○○○○○○○∘○∘                                   
+         |                           ·○○○○○○ ○○○○○○○○○○                                   
+         |                           ○○○○○○○ ○○○○○○○○○○  ·                                
+     230 |                         ·○○○○○○○○ ○○○○○○○○○○○ ○                                
+         |                         ○○○○○○○○○ ○○○○○○○○○○○ ○·                               
+         |                        ∘○○○○○○○○○ ○○○○○○○○○○○ ○○                               
+         |                      ○ ○○○○○○○○○○ ○○○○○○○○○○○ ○○○ ·                            
+         |                     ·○ ○○○○○○○○○○ ○○○○○○○○○○○ ○○○ ○                            
+     110 |                     ○○ ○○○○○○○○○○ ○○○○○○○○○○○ ○○○○○                            
+         |                  ∘∘·○○ ○○○○○○○○○○ ○○○○○○○○○○○ ○○○○○∘∘                          
+         |                  ○○○○○ ○○○○○○○○○○ ○○○○○○○○○○○ ○○○○○○○∘○                        
+         |                ·∘○○○○○ ○○○○○○○○○○ ○○○○○○○○○○○ ○○○○○○○○○○ ∘                     
+         |             ··○○○○○○○○ ○○○○○○○○○○ ○○○○○○○○○○○ ○○○○○○○○○○ ○∘○· ·                
+       0 |··· ······∘ ○○○○○○○○○○○ ○○○○○○○○○○ ○○○○○○○○○○○ ○○○○○○○○○○ ○○○○○○·∘··· · ·   ····
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        44.0     52.3     60.7     69.0     77.3     85.7     94.0    102.4    110.7  
+        41.0     49.2     57.4     65.7     73.9     82.1     90.3     98.6    106.8  
 ```
 
 Finally, let's close with a small and somewhat contrived example of a hierarchical model, where we have two separate regressions that share a parameter. For the sake of the example, let's assume that we have a second sales dataset, much like the first, where we know they had the same rate at the start of the observations, but may have grown at different rates - so their intercepts will be equal but their slopes will not. Here's the data:
@@ -525,7 +525,7 @@ scala> val regr3 =  for {
      |     _ <- Predictor.fromInt{ i => Poisson(intercept + slope0 * i) }.fit(data)
      |     _ <- Predictor.fromInt{ i => Poisson(intercept + slope1 * i) }.fit(data2)
      | } yield (slope0, intercept)
-regr3: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@1ceb19c1
+regr3: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@289ee645
 ```
 
 or we can use Rainier's `Lookup` to package the two slopes into a single `RandomVariable` from which we can lookup the one we want. This means that our predictor now has to take both the index of the model to which the data belongs as well as the actual observation as input.
@@ -534,41 +534,41 @@ or we can use Rainier's `Lookup` to package the two slopes into a single `Random
 scala> val allData = data.map{ case (x,y) => ((0, x), y) } ++ data2.map{ case (x, y) => ((1, x), y) }
 allData: List[((Int, Int), Int)] = List(((0,0),8), ((0,1),12), ((0,2),16), ((0,3),20), ((0,4),21), ((0,5),31), ((0,6),23), ((0,7),33), ((0,8),31), ((0,9),33), ((0,10),36), ((0,11),42), ((0,12),39), ((0,13),56), ((0,14),55), ((0,15),63), ((0,16),52), ((0,17),66), ((0,18),52), ((0,19),80), ((0,20),71), ((1,0),9), ((1,1),2), ((1,2),3), ((1,3),17), ((1,4),21), ((1,5),12), ((1,6),21), ((1,7),19), ((1,8),21), ((1,9),18), ((1,10),25), ((1,11),27), ((1,12),33), ((1,13),23), ((1,14),28), ((1,15),45), ((1,16),35), ((1,17),45), ((1,18),47), ((1,19),54), ((1,20),40))
 
-scala> val regLookup = for {
+scala> val regr4 = for {
      |   slopes <- RandomVariable.fill(2)(LogNormal(0,1).param).map(Lookup(_))
      |   intercept <- LogNormal(0,1).param
      |   _ <- Predictor.fromIntPair{ case (index, x) => Poisson(intercept + slopes(index) * x) }.fit(allData)
      | } yield (slopes(0), intercept)
-regLookup: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@14160c76
+regr4: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@32e1f26b
 ```
 
 Plotting slope vs. intercept now, we see that, even though these are two separate regressions, we get tighter bounds than before by letting the new data influence the shared parameter. It makes sense that we'd get more confidence on the intercept, since we have two different time series to learn from now; but because of the anti-correlation, that also leads to somewhat more confidence than before on the `slopes(0)` parameter as well.
 
 ```scala
-scala> plot2D(regLookup.sample())
-    11.7 |                                                                                
-         |                    ·                                                           
+scala> plot2D(regr4.sample())
+    11.9 |                                                                                
+         |                       ·                                                        
          |                                                                                
-         | ·                                                                              
-         |       ·· ··  ·         ·   ·     ··                                            
-     9.5 |           · · ···  · · · ··   ··   ·                                           
-         |· ·   ·· ··· · ········  ·········  ····  ···                                   
-         |      ·· · ······························   ··                                  
-         | ·  ······································· ·   ·· ·                            
-         |·    · ·· ·········································· ·                          
-     7.4 |      ·   ················∘∘∘∘∘∘∘·∘························                     
-         |    ·     · ············∘∘∘∘∘∘∘∘∘∘∘∘∘∘∘∘∘∘···∘··········· ·  ·                  
-         |          ··  ···········∘∘∘∘∘∘○∘∘○∘○∘∘∘∘∘∘∘∘∘∘∘·············· ·                
-         |     ·    · ·· ·············∘∘∘∘∘∘∘○∘○○○∘∘∘○∘∘∘∘·∘············ ····· ·  ·       
-         |             · ··············∘·∘∘∘∘∘∘∘○○∘○○∘○∘∘∘∘∘∘···············   ··   ·  ·  
-     5.3 |                   · ···············∘·∘∘·∘∘∘∘∘∘∘∘·····∘············  ·          
-         |                    · ····· ·················∘···················· ·  ·     ·   
-         |                        ·   ····· ······························ ···  ·    ·    
-         |                     ·       ·   · ··· ··· ·········· ············  ····  ·    ·
-         |                                ·    ·  ·   ··· · · ······· ··   · ·     ·      
-     3.1 |                                                        ···          ·   ·      
+         |           ·                                                                    
+         |   ·        ·  · · ·  ·                                                         
+     9.7 |         ·      · ·· ·     ··                                                   
+         |      ··   · ···· ·· ·  · ····  ··  ··                                          
+         |· ·     ··········· ················· · ·   ·                                   
+         |    ·   ···· ······························· ··  ·  ··                          
+         |      ··  ······································· ··                            
+     7.6 |·     ··················∘∘·∘∘··∘·∘······∘·············· ·                       
+         |        ·················∘·∘∘∘∘∘∘∘∘∘∘∘∘∘∘···················  · ·               
+         |     ·   ···· ············∘∘∘∘∘∘○∘∘○○∘○∘○∘∘∘∘·∘∘··············· ··    ·         
+         |               ···· ······∘∘∘∘∘∘∘○∘○∘○○∘∘∘∘○○∘∘∘∘∘···············    ··· ·      
+         |                 ·· ··········∘∘∘∘∘∘∘∘∘∘∘∘○∘○○∘∘∘∘∘·∘············ ·····   ·     
+     5.4 |                  ···················∘∘∘∘∘∘∘∘∘∘∘∘∘∘·∘∘················ ·· ·     
+         |                        ·  ···············∘····∘···∘··················· ·       
+         |                   · ·· ··    ·································· ·····   ···   ·
+         |                              ·  ··· ···················· ·········· ·    ·     
+         |                                   · ··  ··· ·   · ····· ·······   · ·     ·    
+     3.2 |                                              · ···   ····   ··                 
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        2.73     2.87     3.01     3.15     3.28     3.42     3.56     3.70     3.84  
+        2.73     2.87     3.00     3.13     3.27     3.40     3.54     3.67     3.80  
 ```
 
 ## Learning More

--- a/docs/tour.md
+++ b/docs/tour.md
@@ -30,7 +30,7 @@ Rainier implements various familiar families of probability distributions like t
 
 ```scala
 scala> val normal: Distribution[Double] = Normal(0,1)
-normal: com.stripe.rainier.core.Distribution[Double] = com.stripe.rainier.core.Injection$$anon$1@4d866f1d
+normal: com.stripe.rainier.core.Distribution[Double] = com.stripe.rainier.core.Injection$$anon$1@3af3f2ff
 ```
 
 In Rainier, `Distribution` objects play three different roles. `Continuous` distributions (like `Normal`), implement `param`, and all distributions implement `fit` and `generator`. Each of these methods is central to one of the three stages of building a model in Rainier:
@@ -51,43 +51,43 @@ Let's use that same `Normal(0,1)` distribution as a prior for a new parameter:
 
 ```scala
 scala> val x = Normal(0,1).param
-x: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@54a26e43
+x: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@12923443
 ```
 
 You can see that the type of `x` is `RandomVariable[Real]`. `RandomVariable` pairs a type of value (in this case, a real number) with some knowledge of the relative probability density of different values of that type. We can use this knowledge to produce a sample of these possible values:
 
 ```scala
 scala> x.sample()
-res0: List[Double] = List(0.9243967666974313, -0.8953463619149151, 0.8541474108617475, -0.8847929920172954, 0.8919519160757042, -0.8767043161998334, 0.8831362693802515, -0.8986657844981967, 0.9101965017294977, -0.9552957779102975, 0.9164009430964106, -0.9128573274068298, 0.8850009156385741, -0.8961734369900971, 0.9042945890066733, -0.9372349765314727, 0.9383207775152217, -0.9315598482680789, 0.9241335593645311, -0.930801434635731, 0.9567284143194517, -0.9703843568549142, 0.9878901037863452, -0.9822085326238821, 0.9927913619398661, -1.0249541687625152, 1.0567663525961093, -1.0629516911774224, 1.0307056916054436, -1.0649711710269196, 1.0613546368444922, -1.0453322216049203, 1.0155664913349176, -1.0126309445462787, 1.0044151824493297, -0.9600472066653833, 0.999667...
+res0: List[Double] = List(-0.18335402858821503, 0.12637027213326735, -0.0909145715670816, -0.07166696569046849, 0.07803275896131082, -0.05040464075957829, 0.1897249425715697, -0.330228482917843, 0.29965009657113517, -0.40602332519956974, 0.441077167782878, -0.3949473715507188, 0.45978333367455837, -0.5143347774096683, 0.6465595812782159, -0.6291418113784523, 0.602344765822807, -0.6782438010324159, 0.6017609703237092, -0.5867708084865426, 0.6101485229941813, -0.642168306512582, 0.746102033263268, -0.9605321871082824, 0.8961307642704281, -0.929275238981264, 0.9299583803293722, -0.8849925826546923, 0.864738096148032, -0.89885494150736, 0.8132466530209046, -0.8692849626536547, 0.7123405480709657, -0.7424428425719571, 0.7295653489853273, -0.8074931634378057, 0.90256...
 ```
 
 Each element of the list above represents a single sample from the distribution over `x`. It's easier to understand these if we plot them as a histogram:
 
 ```scala
 scala> plot1D(x.sample())
-     330 |                                                                                
-         |                                    ∘                                           
-         |                                    ○      ·                                    
-         |                                    ○∘   ··○·                                   
-         |                                    ○○∘ ·○○○○                                   
-     250 |                                 ○  ○○○○○○○○○∘∘∘                                
-         |                                ∘○○○○○○○○○○○○○○○∘ ·                             
-         |                              ∘ ○○○○○○○○○○○○○○○○○∘○                             
-         |                             ○○○○○○○○○○○○○○○○○○○○○○                             
-         |                            ·○○○○○○○○○○○○○○○○○○○○○○·                            
-     160 |                          ∘·○○○○○○○○○○○○○○○○○○○○○○○○∘○                          
-         |                          ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                         
-         |                    ∘ ∘  ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○  ∘                      
-         |                    ○ ○∘∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○○○∘∘                   
-         |                  ··○∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘·                 
-      80 |                  ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                 
-         |                ·∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                
-         |              ·∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○              
-         |          · ··○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘ ··          
-         |          ○·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘         
-       0 |· ···∘∘∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○∘∘· ··
+     400 |                                                                                
+         |                                           ∘                                    
+         |                                   ·   ∘   ○                                    
+         |                                   ○ ○○○·○ ○                                    
+         |                                   ○ ○○○○○∘○○∘                                  
+     300 |                                  ○○○○○○○○○○○○·∘                                
+         |                                ○○○○○○○○○○○○○○○○                                
+         |                                ○○○○○○○○○○○○○○○○○·                              
+         |                               ∘○○○○○○○○○○○○○○○○○○·                             
+         |                               ○○○○○○○○○○○○○○○○○○○○                             
+     200 |                             ·∘○○○○○○○○○○○○○○○○○○○○ ∘                           
+         |                            ∘○○○○○○○○○○○○○○○○○○○○○○·○·                          
+         |                          ··○○○○○○○○○○○○○○○○○○○○○○○○○○                          
+         |                          ○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘                         
+         |                          ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·∘                       
+     100 |                       ·○∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○ ·                     
+         |                     ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○··                   
+         |                   ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                   
+         |                  ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                 
+         |               ··∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘∘ ·             
+       0 |·· ·····∘∘∘∘∘∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○∘·∘∘·······
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-       -3.06    -2.38    -1.70    -1.01    -0.33     0.35     1.03     1.72     2.40  
+       -3.92    -3.05    -2.18    -1.31    -0.44     0.43     1.30     2.16     3.03  
 ```
 
 Since the only information we have about `x` so far is its `Normal` prior, this distribution unsurprisingly looks normal. Later we'll see how to update our beliefs about `x` based on observational data.
@@ -96,102 +96,102 @@ For now, though, let's explore what we can do just with priors. `RandomVariable`
 
 ```scala
 scala> val e_x = x.map(_.exp)
-e_x: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@4af803dc
+e_x: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@5282b4d1
 
 scala> plot1D(e_x.sample())
-    1220 |                                                                                
-         |   ○                                                                            
-         |  ∘○                                                                            
-         |· ○○                                                                            
-         |○ ○○                                                                            
-     910 |○ ○○                                                                            
-         |○ ○○                                                                            
-         |○ ○○∘                                                                           
-         |○ ○○○                                                                           
-         |○○○○○ ·                                                                         
-     610 |○○○○○·○·                                                                        
-         |○○○○○○○○                                                                        
-         |○○○○○○○○                                                                        
-         |○○○○○○○○                                                                        
-         |○○○○○○○○○                                                                       
-     300 |○○○○○○○○○∘                                                                      
-         |○○○○○○○○○○∘·                                                                    
-         |○○○○○○○○○○○○                                                                    
-         |○○○○○○○○○○○○∘                                                                   
-         |○○○○○○○○○○○○○○· ·  ··   ·                                                       
-       0 |○○○○○○○○○○○○○○○○○∘○○○○○○○○∘∘∘∘∘·······················∘∘∘∘······················
+     430 |                                                                                
+         |        ∘                                                                       
+         |       ○○                                                                       
+         |   ∘   ○○·                                                                      
+         |   ○   ○○○                                                                      
+     320 | ∘○○   ○○○                                                                      
+         | ○○○   ○○○·                                                                     
+         | ○○○   ○○○○                                                                     
+         | ○○○   ○○○○                                                                     
+         | ○○○  ∘○○○○·                                                                    
+     210 | ○○○  ○○○○○○                                                                    
+         | ○○○  ○○○○○○ ·                                                                  
+         | ○○○··○○○○○○∘○·○·                                                               
+         | ○○○○○○○○○○○○○○○○                       ○·○∘                                    
+         | ○○○○○○○○○○○○○○○○ · ∘ ∘  ∘ · ·      ∘∘·○○○○○○∘                                  
+     100 | ○○○○○○○○○○○○○○○○○○ ○○○  ○ ○○○· ○  ·○○○○○○○○○○○                                 
+         |○○○○○○○○○○○○○○○○○○○ ○○○  ○·○○○○·○○○○○○○○○○○○○○○           ∘  ·                  
+         |○○○○○○○○○○○○○○○○○○○∘○○○○·○○○○○○○○○○○○○○○○○○○○○○∘○· ·      ○○∘○○·∘  ·∘∘          
+         |○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·○ ·∘  ∘○○○○○○○∘○○○○·         
+         |○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○· ∘∘    
+       0 |○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘···
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        0.1      1.7      3.4      5.0      6.7      8.4      10.0     11.7     13.3  
+        0.37     0.63     0.90     1.16     1.42     1.68     1.94     2.21     2.47  
 ```
 
 Or we can create another `Normal` parameter and zip the two together to produce a 2D gaussian. Since there's nothing relating these two parameters to each other, you can see in the plot that they're completely independent.
 
 ```scala
 scala> val y = Normal(0,1).param
-y: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@1fa22dd3
+y: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@63843992
 
 scala> val xy = x.zip(y)
-xy: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@505d257e
+xy: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@469ba2bc
 
 scala> plot2D(xy.sample())
-     4.3 |                                                                                
-         |                                                 ·                              
-         |                                                                                
-         |                          ·     ·  ·        ···      ·     ··                   
-         |                      ·    ··     · ······ ····   · ·· · ·            ·         
-     2.3 |                      ·  ············ ···············  · ·  ··   ··             
-         |             ·     ··· ·· ···································· · ··  · ·        
-         |               ·· ·· ······ ·····································   ···     · · 
-         |           ·  ··························∘····························· ··      ·
-         |·               ···· ················∘∘∘∘·∘∘·····∘·······················       
-     0.3 |                ···················∘∘∘∘∘○○∘∘∘∘∘∘∘∘∘∘∘∘∘················ ·    ·  
-         |           · ··· ············∘··∘∘∘∘∘∘∘∘∘∘∘∘∘∘○∘∘∘∘∘·∘∘∘·············· · · ·  · 
-         |             · ··················∘∘∘∘○∘∘∘∘○∘○∘∘∘∘∘∘∘∘∘∘∘·················    ·  
-         |     ·    ·       ·················∘∘∘∘∘∘∘·∘∘∘∘∘∘∘∘∘∘∘···················    ·  
-         |        ·    ··· ·  ····················∘∘···∘∘··∘···············  ··· ·····    
-    -1.7 |          ·      · ···· · ·········································· ·· ·       
-         |               ·    · ·· ··································  ·· ···             
-         |                 ·    ·   ··· ······· · ········ · ···· ···· ··  ·       ·      
-         |                         ··   ··   · ··· ··· ·· ·  ···· ····  · ·              ·
-         |                             ··     ·      ·    ···           ··                
-    -3.7 |                            ·            ·· ·        ·                          
+     3.7 |                                                                                
+         |                                ·                                               
+         |                                      ·                ·    ·                   
+         |                ·       ·    ·· ·· ··  ··  ··· ··  ·                            
+         |                      ···· · ······· ····· ·· ······ · ··    ··                 
+     1.9 |           ·   ····· ································  ·····  ·                 
+         |            ·· ·· ··········································· · ·  ·            
+         |         ·  · ··· ······································· ···· ·                
+         |        · ·····················∘··∘∘∘∘··∘···∘·······················  ·    ·    
+         |·    ·  ·   ·· ···············∘∘∘·∘∘∘∘∘∘○·∘∘·∘∘·················  ·· ·          
+     0.1 |    ·     · ··············∘·∘∘∘∘∘∘∘∘∘∘∘○∘∘∘∘∘·∘·∘·∘∘···············  ·          
+         |    ·   · ················∘·∘···∘∘∘·∘∘∘∘∘·∘∘∘∘∘∘·∘∘··············· ·  ·        ·
+         |     ·  ·  ················∘·∘∘∘∘∘∘∘∘∘∘∘○∘∘∘·∘∘∘∘··················· ·          
+         |         ···  ··················∘∘∘○∘∘∘·∘∘∘·∘···∘············ ·· · ··  ·        
+         |         ····· ······················∘∘···∘·····∘············    · · ···        
+    -1.7 | ·        ················································· ····  ·  ·          
+         |        ·   ·     ····································· · · ··· ·     ·         
+         |             ·   ·  ·· ································· ·· · ·                 
+         |                       · · ·· ······················ ·· · ··                    
+         |                  ·    ···            · ·  ···    ····· ·                       
+    -3.5 |            ·           ·     · ·     · ·                                       
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-       -4.27    -3.40    -2.53    -1.66    -0.79     0.08     0.95     1.82     2.69  
+       -3.62    -2.78    -1.94    -1.10    -0.26     0.58     1.43     2.27     3.11  
 ```
 
 Finally, we can use `flatMap` to create two parameters that *are* related to each other. In particular, we'll create a new parameter `z` that we believe to be very close to `x`: its prior is a `Normal` centered on `x` with a very small standard deviation. We'll then make a 2D plot of `(x,z)` to see the relationship.
 
 ```scala
 scala> val z = x.flatMap{a => Normal(a, 0.1).param}
-z: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@36bdcf2e
+z: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@24e254c4
 
 scala> val xz = x.zip(z)
-xz: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@42c81358
+xz: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@b448352
 
 scala> plot2D(xz.sample())
-     3.7 |                                                                                
-         |                                                                           ·   ·
-         |                                                                     · ··       
-         |                                                                 ·······        
-         |                                                             ·······            
-     1.9 |                                                        ·········               
-         |                                                    ·········                   
-         |                                                ··········                      
-         |                                           ····∘∘∘····                          
-         |                                        ···∘∘∘···                               
-     0.1 |                                    ···∘○○∘···                                  
-         |                                ···∘∘∘∘···                                      
-         |                           ····∘○○∘···                                          
-         |                         ··∘∘∘∘···                                              
-         |                    ····∘∘∘···                                                  
-    -1.7 |                 ··········                                                     
-         |             ·········                                                          
-         |         ········                                                               
-         |     ·······                                                                    
-         |   ······                                                                       
-    -3.5 |· ··                                                                            
+     4.0 |                                                                                
+         |                                                                               ·
+         |                                                                        · ··    
+         |                                                                    ······      
+         |                                                               ·······          
+     2.1 |                                                           ········             
+         |                                                      ········                  
+         |                                                  ··········                    
+         |                                              ···∘∘∘····                        
+         |                                        ····∘∘∘∘···                             
+     0.2 |                                     ···∘∘∘○∘···                                
+         |                                  ··∘○○○∘···                                    
+         |                             ···∘∘○○∘··                                         
+         |                          ··∘∘∘∘····                                            
+         |                     ····∘∘∘···                                                 
+    -1.8 |                  ·········                                                     
+         |              ·········                                                         
+         |           ········                                                             
+         |        ······                                                                  
+         |     ····                                                                       
+    -3.7 |· ···                                                                           
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-       -3.39    -2.57    -1.75    -0.93    -0.11     0.71     1.53     2.35     3.16  
+       -3.69    -2.83    -1.98    -1.12    -0.27     0.59     1.44     2.29     3.15  
 ```
 
 You can see that although we still sample from the full range of `x` values, for any given sample, `x` and `z` are quite close to each other.
@@ -212,14 +212,11 @@ sales: List[Int] = List(4, 4, 7, 11, 8, 12, 10)
 We can model the number of sales we get on each day as a poisson distribution parameterized by the underlying rate. For example, looking at that data, we might guess that it came from a `Poisson(9)` or `Poisson(10)`. We can test those hypotheses by using the `fit` method available on all `Distribution` objects. Since `Poisson` is a `Distribution[Int]`, its `fit` will accept either `Int` or `Seq[Int]`, and return a `RandomVariable` which encodes the likelihood of the provided data being produced by that distribution. (We're not going to worry right now about what *kind* of `RandomVariable` it is, since we're only really interested in the likelihood).
 
 ```scala
-scala> val poisson9: RandomVariable[_] = Poisson(9).fit(sales)
-poisson9: com.stripe.rainier.core.RandomVariable[_] = com.stripe.rainier.core.RandomVariable@52888ee4
-
-scala> val poisson10: RandomVariable[_] = Poisson(10).fit(sales)
-poisson10: com.stripe.rainier.core.RandomVariable[_] = com.stripe.rainier.core.RandomVariable@3cdfc6fc
+val poisson9: RandomVariable[_] = Poisson(9).fit(sales)
+val poisson10: RandomVariable[_] = Poisson(10).fit(sales)
 ```
 
-Since it is almost never necessary to can reach into a `RandomVariable` and get its current probability `density`, Rainier makes this hard to do. Taking on faith momentarily that
+Since it is almost never necessary to reach into a `RandomVariable` and get its current probability `density`, Rainier makes this hard to do. Taking on faith momentarily that
 
 ```scala
 scala> val poisson9density = -18.03523006575617
@@ -231,15 +228,16 @@ poisson10density: Double = -19.135041188917896
 
 we can find the likelihood ratio of these two hypotheses. Since the density is stored in log space, the best way to do this numerically is to subtract the logs first before exponentiating:
 
-```
-val lr = (poisson9density - poisson10density).exp
+```scala
+scala> val lr = math.exp(poisson9density - poisson10density)
+lr: Double = 3.0035986601488043
 ```
 
 We can see here that our data is about 3x as likely to have come from a `Poisson(9)` as it is to have come from a `Poisson(10)`. We could keep doing this with a large number of values to build up a sense of the rate distribution, but it would be tedious, and we'd be ignoring any prior we had on the rate. Instead, the right way to do this in Rainier is to make the rate a parameter, and let the library do the hard work of exploring the space. Specifically, we can use `flatMap` to chain the creation of the parameter with the creation and fit of the `Poisson` distribution. Since we want our rate to be a positive number, and expect it to be more likely to be on the small side than the large side, the log-normal parameter we created earlier as `e_x` seems like a reasonable choice.
 
 ```scala
 scala> val poisson: RandomVariable[_] = e_x.flatMap{r => Poisson(r).fit(sales)}
-poisson: com.stripe.rainier.core.RandomVariable[_] = com.stripe.rainier.core.RandomVariable@4dd86c3
+poisson: com.stripe.rainier.core.RandomVariable[_] = com.stripe.rainier.core.RandomVariable@3d897c
 ```
 
 By the way: before, when we looked at `poisson9.density`, the model had no parameters and so we got a constant value back. Now, since the model's density is a function of the parameter value, we get something more opaque back. This is why inspecting `density` is not normally useful.
@@ -255,7 +253,7 @@ scala> val rate = for {
      |     r <- e_x
      |     poisson <- Poisson(r).fit(sales)
      | } yield r
-rate: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@7767ed0f
+rate: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@38404e54
 ```
 
 This is our first "full" model: we have a parameter with a log-normal prior, bundled into the `RandomVariable` named `e_x`; we use that parameter to initialize a `Poisson` noise distribution which we fit to our observations; and at the end, we output the same parameter (referenced by `r`) as the quantity we're interested in sampling from the posterior.
@@ -264,29 +262,29 @@ Let's plot the results!
 
 ```scala
 scala> plot1D(rate.sample())
-     470 |                                                                                
-         |                           ∘                                                    
-         |                         · ○   ·                                                
-         |                         ○·○∘○ ○                                                
-         |                         ○○○○○·○                                                
-     350 |                        ○○○○○○○○ ··                                             
-         |                     ·○∘○○○○○○○○ ○○                                             
-         |                     ○○○○○○○○○○○○○○○                                            
-         |                     ○○○○○○○○○○○○○○○                                            
-         |                    ∘○○○○○○○○○○○○○○○                                            
-     230 |                  ∘ ○○○○○○○○○○○○○○○○  ·                                         
-         |                 ·○∘○○○○○○○○○○○○○○○○∘∘○                                         
-         |                ·○○○○○○○○○○○○○○○○○○○○○○∘○                                       
-         |                ○○○○○○○○○○○○○○○○○○○○○○○○○·                                      
-         |             ··○○○○○○○○○○○○○○○○○○○○○○○○○○○·                                     
-     110 |             ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘·                                   
-         |            ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○ ○                                 
-         |            ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○                                 
-         |          ∘∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘·○                             
-         |       ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·○∘                          
-       0 |∘ · ·○∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○·∘∘···· ··  ·          ·
+     450 |                                                                                
+         |                           ∘ ∘                                                  
+         |                          ∘○∘○·∘                                                
+         |                          ○○○○○○                                                
+         |                         ○○○○○○○○·                                              
+     330 |                        ∘○○○○○○○○○                                              
+         |                     ∘ ○○○○○○○○○○○· ·                                           
+         |                    ∘○ ○○○○○○○○○○○○∘○·                                          
+         |                    ○○·○○○○○○○○○○○○○○○·                                         
+         |                    ○○○○○○○○○○○○○○○○○○○                                         
+     220 |                  ··○○○○○○○○○○○○○○○○○○○                                         
+         |                  ○○○○○○○○○○○○○○○○○○○○○∘                                        
+         |                  ○○○○○○○○○○○○○○○○○○○○○○··                                      
+         |               ·○∘○○○○○○○○○○○○○○○○○○○○○○○○                                      
+         |               ○○○○○○○○○○○○○○○○○○○○○○○○○○○∘∘                                    
+     110 |              ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘                                   
+         |              ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○··                                
+         |            ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·                               
+         |          ∘∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘                             
+         |       ·○∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘·∘·                         
+       0 |···∘∘·∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘··········    ·  ·   ·
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        4.6      5.5      6.5      7.5      8.4      9.4      10.4     11.4     12.3  
+        4.6      5.5      6.5      7.4      8.3      9.3      10.2     11.1     12.1  
 ```
 
 Looks like our daily rate is probably somewhere between 6 and 9, which corresponds well to the steep 3x dropoff we saw before between 9 and 10.
@@ -337,42 +335,42 @@ scala> val prediction = for {
      |     r <- e_x
      |     poisson <- Poisson(r).fit(sales)
      | } yield poisson.generator
-prediction: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@3f1572ca
+prediction: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@149239c5
 ```
 
 This is almost the same model as `rate` above, but instead of taking the real-valued `r` rate parameter as the output, we're producing poisson-distributed integers. The samples look like this:
 
 ```scala
 scala> prediction.sample()
-res7: List[Int] = List(10, 17, 6, 4, 9, 1, 12, 4, 8, 4, 10, 7, 7, 4, 13, 6, 6, 3, 9, 1, 10, 5, 8, 8, 14, 9, 7, 3, 6, 5, 7, 10, 7, 5, 4, 10, 5, 10, 6, 8, 5, 8, 7, 4, 9, 6, 7, 9, 8, 7, 12, 6, 5, 11, 6, 7, 5, 8, 11, 9, 14, 6, 7, 4, 16, 5, 4, 11, 6, 9, 7, 10, 9, 9, 3, 9, 6, 6, 8, 7, 12, 12, 7, 8, 8, 5, 14, 9, 6, 10, 7, 13, 7, 9, 6, 4, 15, 6, 7, 10, 8, 8, 10, 2, 7, 8, 10, 6, 7, 13, 7, 6, 9, 8, 10, 15, 9, 8, 8, 8, 4, 9, 9, 15, 6, 5, 9, 8, 6, 8, 7, 8, 7, 4, 9, 7, 6, 6, 6, 8, 5, 5, 8, 11, 3, 7, 12, 2, 7, 6, 11, 9, 8, 6, 9, 8, 4, 11, 10, 5, 13, 9, 12, 7, 5, 5, 4, 12, 5, 11, 11, 7, 11, 6, 12, 8, 6, 18, 4, 9, 6, 7, 11, 5, 4, 7, 8, 14, 6, 8, 10, 7, 12, 10, 6, 7, 8, 6, 7, 7, 8, 7, 9, 5, 6, 7, 10, 8, 2, 6, 6, 6, 7, 9, 8, 6, 4, 9, 9, 12, 11, 7, 6, 5, 7, 9, 9, 3, 7, 4, 10, 5, ...
+res7: List[Int] = List(10, 4, 16, 3, 5, 10, 11, 3, 8, 6, 5, 10, 12, 10, 7, 4, 8, 7, 6, 8, 7, 15, 7, 10, 5, 6, 5, 7, 7, 9, 10, 8, 9, 9, 12, 4, 5, 9, 7, 9, 5, 8, 8, 8, 8, 6, 8, 3, 9, 14, 7, 10, 7, 7, 7, 10, 12, 7, 5, 5, 13, 8, 9, 6, 6, 7, 4, 7, 5, 5, 3, 9, 10, 3, 9, 5, 2, 10, 3, 10, 8, 4, 10, 8, 6, 6, 7, 12, 7, 9, 8, 10, 9, 8, 5, 8, 9, 7, 8, 8, 11, 12, 9, 4, 4, 14, 11, 7, 3, 5, 5, 5, 6, 8, 9, 9, 10, 7, 4, 7, 9, 7, 7, 13, 10, 8, 9, 6, 5, 4, 5, 8, 7, 8, 6, 9, 7, 6, 10, 4, 7, 7, 12, 6, 4, 10, 7, 9, 6, 8, 8, 6, 7, 6, 3, 4, 9, 9, 10, 7, 4, 7, 6, 6, 10, 10, 7, 6, 8, 7, 8, 8, 6, 6, 7, 7, 12, 15, 4, 11, 9, 13, 5, 10, 6, 9, 9, 11, 8, 6, 7, 11, 10, 7, 12, 8, 4, 5, 11, 6, 4, 4, 14, 6, 9, 6, 10, 12, 5, 7, 5, 5, 6, 9, 7, 9, 8, 9, 2, 7, 8, 5, 4, 6, 8, 7, 10, 8, 11, 9, 13, 9, 9...
 ```
 Or, if we plot them, like this:
 
 ```scala
 scala> plot1D(prediction.sample())
-    1400 |                                                                                
-         |                         ○                                                      
-         |                         ○  ∘                                                   
-         |                     ∘   ○  ○                                                   
-         |                     ○   ○  ○                                                   
-    1050 |                     ○   ○  ○   ○                                               
-         |                  ·  ○   ○  ○   ○                                               
-         |                  ○  ○   ○  ○   ○                                               
-         |                  ○  ○   ○  ○   ○   ○                                           
-         |                  ○  ○   ○  ○   ○   ○                                           
-     700 |              ∘   ○  ○   ○  ○   ○   ○                                           
-         |              ○   ○  ○   ○  ○   ○   ○                                           
-         |              ○   ○  ○   ○  ○   ○   ○  ∘                                        
-         |              ○   ○  ○   ○  ○   ○   ○  ○                                        
-         |              ○   ○  ○   ○  ○   ○   ○  ○   ·                                    
-     350 |          ∘   ○   ○  ○   ○  ○   ○   ○  ○   ○                                    
-         |          ○   ○   ○  ○   ○  ○   ○   ○  ○   ○                                    
-         |          ○   ○   ○  ○   ○  ○   ○   ○  ○   ○   ○                                
-         |       ·  ○   ○   ○  ○   ○  ○   ○   ○  ○   ○   ○  ∘                             
-         |       ○  ○   ○   ○  ○   ○  ○   ○   ○  ○   ○   ○  ○   ∘                         
-       0 |·  ○   ○  ○   ○   ○  ○   ○  ○   ○   ○  ○   ○   ○  ○   ○  ∘   ·   ·  ·   ·   ·  ·
+    1410 |                                                                                
+         |                        ○                                                       
+         |                    ∘   ○  ·                                                    
+         |                    ○   ○  ○                                                    
+         |                    ○   ○  ○                                                    
+    1060 |                    ○   ○  ○                                                    
+         |                 ∘  ○   ○  ○   ·                                                
+         |                 ○  ○   ○  ○   ○                                                
+         |                 ○  ○   ○  ○   ○  ·                                             
+         |                 ○  ○   ○  ○   ○  ○                                             
+     700 |             ·   ○  ○   ○  ○   ○  ○                                             
+         |             ○   ○  ○   ○  ○   ○  ○                                             
+         |             ○   ○  ○   ○  ○   ○  ○   ○                                         
+         |             ○   ○  ○   ○  ○   ○  ○   ○                                         
+         |             ○   ○  ○   ○  ○   ○  ○   ○  ·                                      
+     350 |          ∘  ○   ○  ○   ○  ○   ○  ○   ○  ○                                      
+         |          ○  ○   ○  ○   ○  ○   ○  ○   ○  ○                                      
+         |          ○  ○   ○  ○   ○  ○   ○  ○   ○  ○   ○                                  
+         |      ∘   ○  ○   ○  ○   ○  ○   ○  ○   ○  ○   ○  ·                               
+         |      ○   ○  ○   ○  ○   ○  ○   ○  ○   ○  ○   ○  ○  ·                            
+       0 |·  ○  ○   ○  ○   ○  ○   ○  ○   ○  ○   ○  ○   ○  ○  ○   ∘  ·   ·  ·          ·  ·
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        0.0      2.5      5.0      7.5      9.9      12.4     14.9     17.4     19.9  
+        0.0      2.6      5.2      7.8      10.4     13.0     15.6     18.2     20.8  
 ```
 
 ## `Likelihood` and `Predictor`
@@ -420,7 +418,7 @@ scala> val prior = for {
      |     slope <- LogNormal(0,1).param
      |     intercept <- LogNormal(0,1).param
      |     } yield (slope, intercept)
-prior: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@6d007072
+prior: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@25dd0cdc
 ```
 
 Now, for any given day `i`, we want to check the number of sales against `Poisson(intercept + slope*i)`. We could write some kind of recursive flatMap to build and fit each of these different distribution objects in turn, but this is a common enough pattern that Rainier already has something built in for it: `Predictor`. `Predictor` is not a `Distribution`, but instead wraps a function from `X => Distribution[Y]` for some `(X,Y)`; you can use this any time you have a dependent variable of type `Y` that you're modeling with some independent variables jointly represented as `X`.
@@ -434,7 +432,7 @@ scala> val regr = for {
      |                     Poisson(intercept + slope*i)
      |                 }.fit(data)
      | } yield (slope, intercept)
-regr: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@54f3a4ba
+regr: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@79d43dad
 ```
 
 As before, we're starting out by just sampling the parameters. By plotting them, we can see that the model's confidence in the intercept, in particular, is pretty low: although it's most likely to be somewhere around 8, it could be anywhere from 3 to 13 or even higher. Second, as you'd hope, the two parameters are anti-correlated:
@@ -442,29 +440,29 @@ a smaller intercept would imply a higher slope, and vice versa.
 
 ```scala
 scala> plot2D(regr.sample())
-    15.3 |                                                                                
-         |      ·    ·                                                                    
-         |·    ·  ·     ·     ·      ·                                                    
-         |          · · ·   · ·     ·                                                     
-         | ·         ········· ·  ·  ·       ·                                            
-    12.2 |  ·  ··  ·· ·····················                                               
-         |    ··  ·  ·· ·················· ···                                            
-         |   ·  ··  ···························· ····                                     
-         |       · ·· ································  · · ··                            
-         |           ··············∘∘·∘··∘·∘··············· ·                             
-     9.2 |           ··············∘∘∘∘∘∘∘○∘∘∘∘∘····∘·············                        
-         |              ··  ··········∘∘∘∘∘∘∘∘∘∘○∘∘∘∘∘·········· ·· ·      ·              
-         |              ·   ············∘∘∘∘○∘○○○∘○○∘∘∘∘∘·············· ·                 
-         |                 ·    ··········∘∘∘∘∘∘○○∘○○○∘○∘∘∘·∘···········  ·               
-         |                       · ·········∘·∘∘∘∘∘∘∘∘∘∘∘∘∘∘∘∘············· · ·           
-     6.1 |                          ·  ··········∘·∘∘∘∘∘·∘∘∘∘∘∘∘··············· · ·       
-         |                        ·     · ··················∘··············· ·  · ··      
-         |                               ·    ································· ·  ·      
-         |                                       ··   ····················· ·· ···       ·
-         |                                               ·   · ······ ··········          
-     3.0 |                                                    ·        ·    ·  · ·        
+    16.2 |                                                                                
+         |     ·                                                                          
+         |            ·                                                                   
+         |·              ·    ·                                                           
+         |      ··    · ·    ·      ·                                                     
+    12.9 |       · ·  ······ ····· ·· ···    ·                                            
+         |    ···· ·  ······················  ·   ··                                      
+         |      ·  ·· ························· ··     ·                                  
+         |        · ·   ······························ · ··                               
+         |             ··································· · ·· ·                         
+     9.5 |              ··············∘∘∘∘·∘∘∘∘·∘∘·················                       
+         |                  ·············∘∘∘∘∘○∘○∘∘∘∘∘···············      ·              
+         |               ·  ··· ··········∘∘∘○○∘○∘○∘∘○∘∘∘·∘·············                  
+         |                        ··········∘∘∘∘∘○○○○∘○○○∘∘∘∘∘··············· · ·         
+         |                       ·  ············∘∘∘∘∘∘∘∘○○∘∘∘∘∘∘∘············             
+     6.1 |                          ·  ···············∘∘∘∘∘∘∘∘∘·∘∘··········· ··    ·     
+         |                               ··   ·················∘∘············ · ··· · ·   
+         |                                      · ·· ······························· ·  · 
+         |                                          ·  ·· ······················ ··  ·    
+         |                                            ·    ·        ·· ·· ·  ····· ·     ·
+     2.7 |                                                            ·           ·   ·   
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        2.43     2.60     2.77     2.94     3.11     3.28     3.45     3.62     3.79  
+        2.40     2.56     2.73     2.90     3.06     3.23     3.39     3.56     3.73  
 ```
 
 Alternatively, as in the earlier example, we could try to predict what will happen tomorrow. This is similar to calling `poisson.generator` before, but this time, we use the `predict` method on `Predictor`, which takes the covariate (the day, in this case), and returns a `Generator` for the dependent variable (the number of sales). Putting it all together, it looks like this:
@@ -477,7 +475,7 @@ scala> val regr2 = for {
      |                     Poisson(intercept + slope*i)
      |                 }.fit(data)
      | } yield predictor.predict(21)
-regr2: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@1123e42a
+regr2: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@50c2f90b
 ```
 
 Plotting this gives us a prediction which incorporates both the natural noise of a Poisson distribution and our uncertainty about its underlying parameterization.
@@ -485,28 +483,28 @@ Plotting this gives us a prediction which incorporates both the natural noise of
 ```scala
 scala> plot1D(regr2.sample())
      460 |                                                                                
-         |                               ∘                                                
-         |                             ∘ ○ ○∘·                                            
-         |                             ○·○ ○○○○○                                          
-         |                          ∘ ∘○○○ ○○○○○                                          
-     340 |                          ○∘○○○○ ○○○○○○·                                        
-         |                          ○○○○○○ ○○○○○○○○·                                      
-         |                        ·○○○○○○○ ○○○○○○○○○                                      
-         |                        ○○○○○○○○ ○○○○○○○○○                                      
-         |                        ○○○○○○○○ ○○○○○○○○○∘                                     
-     230 |                       ○○○○○○○○○ ○○○○○○○○○○·                                    
-         |                     ·∘○○○○○○○○○ ○○○○○○○○○○○∘                                   
-         |                    ·○○○○○○○○○○○ ○○○○○○○○○○○○○·                                 
-         |                    ○○○○○○○○○○○○ ○○○○○○○○○○○○○○·                                
-         |                   ∘○○○○○○○○○○○○ ○○○○○○○○○○○○○○○                                
-     110 |                  ∘○○○○○○○○○○○○○ ○○○○○○○○○○○○○○○                                
-         |                 ·○○○○○○○○○○○○○○ ○○○○○○○○○○○○○○○ ∘○                             
-         |             · ∘ ○○○○○○○○○○○○○○○ ○○○○○○○○○○○○○○○ ○○○                            
-         |             ○○○ ○○○○○○○○○○○○○○○ ○○○○○○○○○○○○○○○ ○○○○∘○                         
-         |            ·○○○ ○○○○○○○○○○○○○○○ ○○○○○○○○○○○○○○○ ○○○○○○∘∘                       
-       0 |· ····∘·∘∘○○○○○○ ○○○○○○○○○○○○○○○ ○○○○○○○○○○○○○○○ ○○○○○○○○○∘∘∘·∘∘· ······ ·     ·
+         |                               ∘  ∘·  ·                                         
+         |                               ○∘○○○○·○                                         
+         |                               ○○○○○○○○                                         
+         |                             ○ ○○○○○○○○·                                        
+     340 |                             ○ ○○○○○○○○○ ∘                                      
+         |                          · ○○ ○○○○○○○○○ ○                                      
+         |                         ∘○·○○ ○○○○○○○○○ ○∘                                     
+         |                         ○○○○○ ○○○○○○○○○ ○○∘○                                   
+         |                       ··○○○○○ ○○○○○○○○○ ○○○○○                                  
+     230 |                       ○○○○○○○ ○○○○○○○○○ ○○○○○                                  
+         |                       ○○○○○○○ ○○○○○○○○○ ○○○○○ ∘                                
+         |                      ·○○○○○○○ ○○○○○○○○○ ○○○○○∘○∘                               
+         |                      ○○○○○○○○ ○○○○○○○○○ ○○○○○○○○                               
+         |                   · ○○○○○○○○○ ○○○○○○○○○ ○○○○○○○○                               
+     110 |                   ○ ○○○○○○○○○ ○○○○○○○○○ ○○○○○○○○○                              
+         |                ··○○ ○○○○○○○○○ ○○○○○○○○○ ○○○○○○○○○ ○·                           
+         |                ○○○○ ○○○○○○○○○ ○○○○○○○○○ ○○○○○○○○○ ○○○                          
+         |               ○○○○○ ○○○○○○○○○ ○○○○○○○○○ ○○○○○○○○○ ○○○∘∘∘                       
+         |            ∘○○○○○○○ ○○○○○○○○○ ○○○○○○○○○ ○○○○○○○○○ ○○○○○○○○                     
+       0 |······∘∘∘○ ○○○○○○○○○ ○○○○○○○○○ ○○○○○○○○○ ○○○○○○○○○ ○○○○○○○○○ ○∘·∘∘···  · ·     ·
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        43.0     51.4     59.9     68.3     76.8     85.2     93.7    102.1    110.6  
+        43.0     51.1     59.2     67.3     75.4     83.6     91.7     99.8    107.9  
 ```
 
 Finally, let's close with a small and somewhat contrived example of a hierarchical model, where we have two separate regressions that share a parameter. For the sake of the example, let's assume that we have a second sales dataset, much like the first, where we know they had the same rate at the start of the observations, but may have grown at different rates - so their intercepts will be equal but their slopes will not. Here's the data:
@@ -526,7 +524,7 @@ scala> val regr3 =  for {
      |     _ <- Predictor.fromInt{ i => Poisson(intercept + slope0 * i) }.fit(data)
      |     _ <- Predictor.fromInt{ i => Poisson(intercept + slope1 * i) }.fit(data2)
      | } yield (slope0, intercept)
-regr3: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@78b3707d
+regr3: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@6b79045
 ```
 
 or we can use Rainier's `Lookup` to package the two slopes into a single `RandomVariable` from which we can lookup the one we want. This means that our predictor now has to take both the index of the model to which the data belongs as well as the actual observation as input.
@@ -540,36 +538,36 @@ scala> val regLookup = for {
      |   intercept <- LogNormal(0,1).param
      |   _ <- Predictor.fromIntPair{ case (index, x) => Poisson(intercept + slopes(index) * x) }.fit(allData)
      | } yield (slopes(0), intercept)
-regLookup: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@56a03f06
+regLookup: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@62dd0be
 ```
 
 Plotting slope vs. intercept now, we see that, even though these are two separate regressions, we get tighter bounds than before by letting the new data influence the shared parameter. It makes sense that we'd get more confidence on the intercept, since we have two different time series to learn from now; but because of the anti-correlation, that also leads to somewhat more confidence than before on the `slopes(0)` parameter as well.
 
 ```scala
 scala> plot2D(regLookup.sample())
-    10.9 |                                                                                
-         |     · ·                                                                        
-         |               ·       · ·     ·                                                
-         |            · ·· ·· ·· ·         ·                                              
-         |    ·  · · ·· ···· ··· · ·· ··  ·     ·                                         
-     9.0 |·  ···························· · ··                                            
-         |   ··································  · ·    ·              ·                  
-         |·  ········································   · ·   ·                           
-         |    ·············································   ·      ·                    
-         |·     ··················∘··∘∘∘∘·∘················ ···· ··        ·              
-     7.1 |     ··   ·············∘∘∘∘∘∘∘∘∘∘∘∘·∘∘∘∘····················      ·             
-         |     ·  ·   ···········∘∘·∘∘∘∘∘○∘∘∘∘∘∘∘∘○·∘················  ··                 
-         |          ················∘∘∘∘∘○○∘∘○∘○○∘○∘∘∘∘∘·····················             
-         |     ·     · ··· ············∘∘∘∘○∘∘∘∘○∘∘∘○∘∘∘∘···∘·················    ·       
-         |          ·   ·· ············∘∘···∘∘∘∘∘∘∘○∘∘∘∘∘∘∘∘∘············· ·  ·· ·        
-     5.2 |                   ···················∘∘∘∘∘∘∘∘∘∘·∘∘·················    ··      
-         |                     · ···························∘···················          
-         |                     ··    ············································ ··     ·
-         |                             · ··· ······ ···················· ·····  ··        
-         |                                ·    · · ···· ··  ·· ···· · ·  ·· ·    · ·      
-     3.3 |                                             ··· ·  ·  ·        ··  ·   ·       
+    11.0 |                                                                                
+         |·               ·           ·                                                   
+         |                    ··   ·                                                      
+         |      · ·      ···· · ··   ··                ·                                  
+         |      ·  ·· ·· ··  ·······   · ······  · ·  ·                                   
+     9.1 | ·   ·  ··   ········ · ··········· ··  ···                                     
+         |  · ···  ··· ··························· ·  ··  ·                               
+         |    · ·· ······································· ··                             
+         |        ·   ·············∘·····∘····················· ·                         
+         |        · ·  ·············∘·∘∘·∘∘∘∘∘∘∘∘················   · ·                   
+     7.1 |       ·   ··············∘·∘∘∘∘∘∘∘∘∘∘∘∘∘∘··················· ·                  
+         |      ··   ·  ··············∘∘∘∘∘∘∘∘○∘∘∘○∘∘∘∘··∘··············  ·               
+         |             · · ··········∘·∘∘∘○∘∘∘○∘○○∘○○∘∘∘∘∘∘∘··········· ··                
+         |               ·  ············∘∘∘∘∘∘∘○○∘∘○∘○○○∘∘∘∘∘∘··············   ·    ·     
+         |               ·  ·  ·············∘∘∘∘∘∘∘○○∘∘∘∘∘∘∘∘∘··········· · ·····   ·     
+     5.2 |                     ················∘∘∘∘∘∘∘∘∘∘∘·∘·················   ···       
+         |                     ·   ··  ···············∘·······∘··············      ·  ·   
+         |                             ·  ·································  · ·          
+         |                               ·· ······ ················ ········ · ·     ·  · 
+         |                                     ·  · · ··········· · ··· ·  · ·           ·
+     3.3 |                                              ·  ·····  · ··     ··             
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        2.77     2.91     3.04     3.17     3.30     3.44     3.57     3.70     3.83  
+        2.68     2.83     2.97     3.12     3.26     3.41     3.55     3.70     3.85  
 ```
 
 ## Learning More

--- a/docs/tour.md
+++ b/docs/tour.md
@@ -30,7 +30,7 @@ Rainier implements various familiar families of probability distributions like t
 
 ```scala
 scala> val normal: Distribution[Double] = Normal(0,1)
-normal: com.stripe.rainier.core.Distribution[Double] = com.stripe.rainier.core.Injection$$anon$1@3b6830b7
+normal: com.stripe.rainier.core.Distribution[Double] = com.stripe.rainier.core.Injection$$anon$1@4d866f1d
 ```
 
 In Rainier, `Distribution` objects play three different roles. `Continuous` distributions (like `Normal`), implement `param`, and all distributions implement `fit` and `generator`. Each of these methods is central to one of the three stages of building a model in Rainier:
@@ -51,43 +51,43 @@ Let's use that same `Normal(0,1)` distribution as a prior for a new parameter:
 
 ```scala
 scala> val x = Normal(0,1).param
-x: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@37da90f9
+x: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@54a26e43
 ```
 
 You can see that the type of `x` is `RandomVariable[Real]`. `RandomVariable` pairs a type of value (in this case, a real number) with some knowledge of the relative probability density of different values of that type. We can use this knowledge to produce a sample of these possible values:
 
 ```scala
 scala> x.sample()
-res0: List[Double] = List(-0.35220846848274046, 0.5858005436586071, -1.2621642960996353, 1.725652319545246, -1.31900274208508, 0.23857488725666265, -0.4906905385717083, 0.1471117947718792, -0.5754910098351603, 0.9032656551750851, -0.1211261014093421, 0.02994936266575221, 0.18948263017233014, 0.08789582956110431, 0.3529053921650007, 0.20363459646390325, -0.7585765027673335, 0.9136150273090323, -1.6869496668527377, 1.363460590284482, -1.0440452946097523, 1.1748327160355092, -0.7889109373128986, 0.6862335881593147, -1.6139490728424328, 1.0983574998917889, 1.0983574998917889, -0.9405507597977106, 0.7201410639868797, -0.24054182865453977, -0.24054182865453977, 0.5987389539152949, -0.14376701926065283, 0.3670848849572113, 0.3670848849572113, 0.18505125535008626, -0.2...
+res0: List[Double] = List(0.9243967666974313, -0.8953463619149151, 0.8541474108617475, -0.8847929920172954, 0.8919519160757042, -0.8767043161998334, 0.8831362693802515, -0.8986657844981967, 0.9101965017294977, -0.9552957779102975, 0.9164009430964106, -0.9128573274068298, 0.8850009156385741, -0.8961734369900971, 0.9042945890066733, -0.9372349765314727, 0.9383207775152217, -0.9315598482680789, 0.9241335593645311, -0.930801434635731, 0.9567284143194517, -0.9703843568549142, 0.9878901037863452, -0.9822085326238821, 0.9927913619398661, -1.0249541687625152, 1.0567663525961093, -1.0629516911774224, 1.0307056916054436, -1.0649711710269196, 1.0613546368444922, -1.0453322216049203, 1.0155664913349176, -1.0126309445462787, 1.0044151824493297, -0.9600472066653833, 0.999667...
 ```
 
 Each element of the list above represents a single sample from the distribution over `x`. It's easier to understand these if we plot them as a histogram:
 
 ```scala
 scala> plot1D(x.sample())
-     460 |                                                                                
-         |                                    ∘ ∘∘                                        
-         |                                    ○ ○○○·                                      
-         |                                    ○○○○○○                                      
-         |                                  ○○○○○○○○∘                                     
-     340 |                                 ·○○○○○○○○○∘                                    
-         |                               ∘∘○○○○○○○○○○○○∘                                  
-         |                               ○○○○○○○○○○○○○○○ ·                                
-         |                               ○○○○○○○○○○○○○○○○○                                
-         |                              ○○○○○○○○○○○○○○○○○○                                
-     230 |                             ·○○○○○○○○○○○○○○○○○○∘·                              
-         |                            ∘○○○○○○○○○○○○○○○○○○○○○                              
-         |                          ∘·○○○○○○○○○○○○○○○○○○○○○○ ·                            
-         |                          ○○○○○○○○○○○○○○○○○○○○○○○○·○                            
-         |                         ∘○○○○○○○○○○○○○○○○○○○○○○○○○○·                           
-     110 |                        ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘                          
-         |                      · ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·                         
-         |                     ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘                       
-         |                   ∘·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘                      
-         |                · ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘·                   
-       0 |·   ········∘∘∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○∘∘·······  ·    ·
+     330 |                                                                                
+         |                                    ∘                                           
+         |                                    ○      ·                                    
+         |                                    ○∘   ··○·                                   
+         |                                    ○○∘ ·○○○○                                   
+     250 |                                 ○  ○○○○○○○○○∘∘∘                                
+         |                                ∘○○○○○○○○○○○○○○○∘ ·                             
+         |                              ∘ ○○○○○○○○○○○○○○○○○∘○                             
+         |                             ○○○○○○○○○○○○○○○○○○○○○○                             
+         |                            ·○○○○○○○○○○○○○○○○○○○○○○·                            
+     160 |                          ∘·○○○○○○○○○○○○○○○○○○○○○○○○∘○                          
+         |                          ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                         
+         |                    ∘ ∘  ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○  ∘                      
+         |                    ○ ○∘∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○○○∘∘                   
+         |                  ··○∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘·                 
+      80 |                  ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                 
+         |                ·∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                
+         |              ·∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○              
+         |          · ··○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘ ··          
+         |          ○·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘         
+       0 |· ···∘∘∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○∘∘· ··
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        -4.0     -3.0     -2.1     -1.2     -0.3     0.6      1.5      2.5      3.4   
+       -3.06    -2.38    -1.70    -1.01    -0.33     0.35     1.03     1.72     2.40  
 ```
 
 Since the only information we have about `x` so far is its `Normal` prior, this distribution unsurprisingly looks normal. Later we'll see how to update our beliefs about `x` based on observational data.
@@ -96,102 +96,102 @@ For now, though, let's explore what we can do just with priors. `RandomVariable`
 
 ```scala
 scala> val e_x = x.map(_.exp)
-e_x: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@d91cd79
+e_x: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@4af803dc
 
 scala> plot1D(e_x.sample())
-    3200 |                                                                                
-         |∘                                                                               
-         |○                                                                               
-         |○                                                                               
-         |○∘                                                                              
-    2400 |○○                                                                              
-         |○○                                                                              
-         |○○                                                                              
-         |○○                                                                              
-         |○○                                                                              
-    1600 |○○                                                                              
-         |○○·                                                                             
-         |○○○                                                                             
-         |○○○                                                                             
-         |○○○                                                                             
-     800 |○○○∘                                                                            
-         |○○○○                                                                            
-         |○○○○                                                                            
-         |○○○○○·                                                                          
-         |○○○○○○∘                                                                         
-       0 |○○○○○○○○∘∘···················· ·  · · · ·           ··       ·  ·              ·
+    1220 |                                                                                
+         |   ○                                                                            
+         |  ∘○                                                                            
+         |· ○○                                                                            
+         |○ ○○                                                                            
+     910 |○ ○○                                                                            
+         |○ ○○                                                                            
+         |○ ○○∘                                                                           
+         |○ ○○○                                                                           
+         |○○○○○ ·                                                                         
+     610 |○○○○○·○·                                                                        
+         |○○○○○○○○                                                                        
+         |○○○○○○○○                                                                        
+         |○○○○○○○○                                                                        
+         |○○○○○○○○○                                                                       
+     300 |○○○○○○○○○∘                                                                      
+         |○○○○○○○○○○∘·                                                                    
+         |○○○○○○○○○○○○                                                                    
+         |○○○○○○○○○○○○∘                                                                   
+         |○○○○○○○○○○○○○○· ·  ··   ·                                                       
+       0 |○○○○○○○○○○○○○○○○○∘○○○○○○○○∘∘∘∘∘·······················∘∘∘∘······················
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        0.0      5.6      11.1     16.7     22.2     27.8     33.3     38.9     44.4  
+        0.1      1.7      3.4      5.0      6.7      8.4      10.0     11.7     13.3  
 ```
 
 Or we can create another `Normal` parameter and zip the two together to produce a 2D gaussian. Since there's nothing relating these two parameters to each other, you can see in the plot that they're completely independent.
 
 ```scala
 scala> val y = Normal(0,1).param
-y: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@80b236e
+y: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@1fa22dd3
 
 scala> val xy = x.zip(y)
-xy: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@1e8ee235
+xy: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@505d257e
 
 scala> plot2D(xy.sample())
-     4.4 |                                                                                
-         |                                   ·                                            
+     4.3 |                                                                                
+         |                                                 ·                              
          |                                                                                
-         |                    ·            ·                ·                             
-         |                          ·  ·· · ·  ·····  · ·· ···       ·                    
-     2.4 |             · ·     · ······· ··········· ·······   ·                          
-         |           · · ·· ················· ·················· · ··   ··                
-         |   ·    · · ··················································· ·     ·         
-         |     ·· · ··· ············································ · ·  · ···           
-         |   ·   ····················∘·∘∘····∘∘··∘····∘················· ·· ·  ··         
-     0.4 |  ·  ····· ··················∘∘·∘∘∘∘∘∘∘∘∘∘···∘···················· ·            
-         |    ·  ··· ·················∘∘∘·∘∘○○∘∘○∘∘∘∘∘··∘∘··∘··················  ·   ·    
-         |   ···  ·····················∘∘∘∘∘○○∘∘○∘○○∘∘∘∘··∘·········· · ··   ···   · ·   ·
-         |·· ······ ·············∘···∘∘·∘∘∘∘∘∘∘∘·∘·∘∘∘∘∘················· ·· ·· ··        
-         | ·   ·  ·   ················∘∘·∘·····∘∘···∘·················· ··· · ··· ·       
-    -1.5 |·  ····  ·······················································  ·  ·          
-         |    · ··  · ····· ······································ ·  ··   ·  ·           
-         |   · ·      ·  ·  ·································  ·· · ····    ·  ·          
-         |          ·     ··   ·  ·· · ··················   ·· ··  ·                      
-         |             ·  ·· ·  ···  · ···· ·   ··       ·  · ·· ·   ·          ·         
-    -3.5 |                    ·        ··           ·   ·   ·           ·                 
+         |                          ·     ·  ·        ···      ·     ··                   
+         |                      ·    ··     · ······ ····   · ·· · ·            ·         
+     2.3 |                      ·  ············ ···············  · ·  ··   ··             
+         |             ·     ··· ·· ···································· · ··  · ·        
+         |               ·· ·· ······ ·····································   ···     · · 
+         |           ·  ··························∘····························· ··      ·
+         |·               ···· ················∘∘∘∘·∘∘·····∘·······················       
+     0.3 |                ···················∘∘∘∘∘○○∘∘∘∘∘∘∘∘∘∘∘∘∘················ ·    ·  
+         |           · ··· ············∘··∘∘∘∘∘∘∘∘∘∘∘∘∘∘○∘∘∘∘∘·∘∘∘·············· · · ·  · 
+         |             · ··················∘∘∘∘○∘∘∘∘○∘○∘∘∘∘∘∘∘∘∘∘∘·················    ·  
+         |     ·    ·       ·················∘∘∘∘∘∘∘·∘∘∘∘∘∘∘∘∘∘∘···················    ·  
+         |        ·    ··· ·  ····················∘∘···∘∘··∘···············  ··· ·····    
+    -1.7 |          ·      · ···· · ·········································· ·· ·       
+         |               ·    · ·· ··································  ·· ···             
+         |                 ·    ·   ··· ······· · ········ · ···· ···· ··  ·       ·      
+         |                         ··   ··   · ··· ··· ·· ·  ···· ····  · ·              ·
+         |                             ··     ·      ·    ···           ··                
+    -3.7 |                            ·            ·· ·        ·                          
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-       -3.34    -2.51    -1.69    -0.86    -0.04     0.79     1.61     2.44     3.26  
+       -4.27    -3.40    -2.53    -1.66    -0.79     0.08     0.95     1.82     2.69  
 ```
 
 Finally, we can use `flatMap` to create two parameters that *are* related to each other. In particular, we'll create a new parameter `z` that we believe to be very close to `x`: its prior is a `Normal` centered on `x` with a very small standard deviation. We'll then make a 2D plot of `(x,z)` to see the relationship.
 
 ```scala
 scala> val z = x.flatMap{a => Normal(a, 0.1).param}
-z: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@34cb64bc
+z: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@36bdcf2e
 
 scala> val xz = x.zip(z)
-xz: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@3aa567c
+xz: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@42c81358
 
 scala> plot2D(xz.sample())
-     3.9 |                                                                                
-         |                                                                              ··
-         |                                                                         ····   
-         |                                                                  ·· ····       
-         |                                                               ·······          
-     2.0 |                                                           ·······              
-         |                                                      ·········                 
-         |                                                 ···········                    
-         |                                              ···∘∘∘···                         
-         |                                         ···∘∘∘∘····                            
-     0.1 |                                     ···∘○∘∘∘···                                
-         |                                  ··∘○○∘∘···                                    
-         |                              ··∘∘∘∘∘··                                         
-         |                         ····∘∘∘···                                             
-         |                     ·····∘····                                                 
-    -1.8 |                 ··········                                                     
-         |              ·········                                                         
-         |        · ·········                                                             
-         |       ·······                                                                  
-         |    ·····                                                                       
-    -3.7 |···                                                                             
+     3.7 |                                                                                
+         |                                                                           ·   ·
+         |                                                                     · ··       
+         |                                                                 ·······        
+         |                                                             ·······            
+     1.9 |                                                        ·········               
+         |                                                    ·········                   
+         |                                                ··········                      
+         |                                           ····∘∘∘····                          
+         |                                        ···∘∘∘···                               
+     0.1 |                                    ···∘○○∘···                                  
+         |                                ···∘∘∘∘···                                      
+         |                           ····∘○○∘···                                          
+         |                         ··∘∘∘∘···                                              
+         |                    ····∘∘∘···                                                  
+    -1.7 |                 ··········                                                     
+         |             ·········                                                          
+         |         ········                                                               
+         |     ·······                                                                    
+         |   ······                                                                       
+    -3.5 |· ··                                                                            
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-       -3.64    -2.81    -1.97    -1.14    -0.31     0.53     1.36     2.20     3.03  
+       -3.39    -2.57    -1.75    -0.93    -0.11     0.71     1.53     2.35     3.16  
 ```
 
 You can see that although we still sample from the full range of `x` values, for any given sample, `x` and `z` are quite close to each other.
@@ -205,52 +205,91 @@ Just like every Rainier model has one more more parameters with priors, every Ra
 Let's say that we have some data that represents the last week's worth of sales on a website, at (we believe) a constant daily rate, and we'd like to know how many sales we might get tomorrow. Here's our data:
 
 ```scala
-val sales = List(4, 4, 7, 11, 8, 12, 10)
+scala> val sales = List(4, 4, 7, 11, 8, 12, 10)
+sales: List[Int] = List(4, 4, 7, 11, 8, 12, 10)
 ```
 
-We can model the number of sales we get on each day as a Poisson distribution parameterized by the underlying rate. Looking at the data, we might guess that it came from a `Poisson(9)` or `Poisson(10)`. In Rainier, we define our model and it fit to the observed data. Since we want our rate to be a positive number, and expect it to be more likely to be on the small side than the large side, the log-normal parameter we created earlier as `e_x` seems like a reasonable choice. We use `flatMap` to chain the creation of the parameter with the creation and fit of the `Poisson` distribution. Although we _can_ do this with explicit `flatMaps` and `maps`, it's much neater with `for{...}` syntax.
+We can model the number of sales we get on each day as a poisson distribution parameterized by the underlying rate. For example, looking at that data, we might guess that it came from a `Poisson(9)` or `Poisson(10)`. We can test those hypotheses by using the `fit` method available on all `Distribution` objects. Since `Poisson` is a `Distribution[Int]`, its `fit` will accept either `Int` or `Seq[Int]`, and return a `RandomVariable` which encodes the likelihood of the provided data being produced by that distribution. (We're not going to worry right now about what *kind* of `RandomVariable` it is, since we're only really interested in the likelihood).
+
+```scala
+scala> val poisson9: RandomVariable[_] = Poisson(9).fit(sales)
+poisson9: com.stripe.rainier.core.RandomVariable[_] = com.stripe.rainier.core.RandomVariable@52888ee4
+
+scala> val poisson10: RandomVariable[_] = Poisson(10).fit(sales)
+poisson10: com.stripe.rainier.core.RandomVariable[_] = com.stripe.rainier.core.RandomVariable@3cdfc6fc
+```
+
+Since it is almost never necessary to can reach into a `RandomVariable` and get its current probability `density`, Rainier makes this hard to do. Taking on faith momentarily that
+
+```scala
+scala> val poisson9density = -18.03523006575617
+poisson9density: Double = -18.03523006575617
+
+scala> val poisson10density = -19.135041188917896
+poisson10density: Double = -19.135041188917896
+```
+
+we can find the likelihood ratio of these two hypotheses. Since the density is stored in log space, the best way to do this numerically is to subtract the logs first before exponentiating:
+
+```
+val lr = (poisson9density - poisson10density).exp
+```
+
+We can see here that our data is about 3x as likely to have come from a `Poisson(9)` as it is to have come from a `Poisson(10)`. We could keep doing this with a large number of values to build up a sense of the rate distribution, but it would be tedious, and we'd be ignoring any prior we had on the rate. Instead, the right way to do this in Rainier is to make the rate a parameter, and let the library do the hard work of exploring the space. Specifically, we can use `flatMap` to chain the creation of the parameter with the creation and fit of the `Poisson` distribution. Since we want our rate to be a positive number, and expect it to be more likely to be on the small side than the large side, the log-normal parameter we created earlier as `e_x` seems like a reasonable choice.
+
+```scala
+scala> val poisson: RandomVariable[_] = e_x.flatMap{r => Poisson(r).fit(sales)}
+poisson: com.stripe.rainier.core.RandomVariable[_] = com.stripe.rainier.core.RandomVariable@4dd86c3
+```
+
+By the way: before, when we looked at `poisson9.density`, the model had no parameters and so we got a constant value back. Now, since the model's density is a function of the parameter value, we get something more opaque back. This is why inspecting `density` is not normally useful.
+
+```
+poisson.density
+```
+
+Instead, we can sample the quantity we're actually interested in. To start with, let's try to sample the rate parameter of the Poisson, conditioned by our observed data. Here's almost the same thing we had above, recreated with the slightly friendlier `for` syntax, and yielding the `r` parameter at the end:
 
 ```scala
 scala> val rate = for {
      |     r <- e_x
      |     poisson <- Poisson(r).fit(sales)
      | } yield r
-rate: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@d2b15bc
+rate: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@7767ed0f
 ```
 
-This is our first "full" model: we have a parameter with a log-normal prior bundled into the `RandomVariable` named `e_x`; we use that parameter to initialize a `Poisson` noise distribution which we fit to our observations; and at the end, we output the same parameter (referenced by `r`) as the quantity we're interested in sampling from the posterior.
+This is our first "full" model: we have a parameter with a log-normal prior, bundled into the `RandomVariable` named `e_x`; we use that parameter to initialize a `Poisson` noise distribution which we fit to our observations; and at the end, we output the same parameter (referenced by `r`) as the quantity we're interested in sampling from the posterior.
 
 Let's plot the results!
 
 ```scala
 scala> plot1D(rate.sample())
-     430 |                                                                                
-         |                           ·  ∘                                                 
-         |                           ○·○○                                                 
-         |                        · ·○○○○                                                 
-         |                      · ○ ○○○○○··○                                              
-     320 |                      ○ ○∘○○○○○○○○·∘                                            
-         |                     ·○∘○○○○○○○○○○○○                                            
-         |                    ·○○○○○○○○○○○○○○○   ·                                        
-         |                    ○○○○○○○○○○○○○○○○○∘∘○                                        
-         |                   ·○○○○○○○○○○○○○○○○○○○○                                        
-     210 |                  ·○○○○○○○○○○○○○○○○○○○○○∘                                       
-         |                  ○○○○○○○○○○○○○○○○○○○○○○○·                                      
-         |                ∘ ○○○○○○○○○○○○○○○○○○○○○○○○○                                     
-         |                ○ ○○○○○○○○○○○○○○○○○○○○○○○○○∘·                                   
-         |               ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                                   
-     100 |              ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘                                  
-         |             ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                                 
-         |          ∘ ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·                              
-         |          ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘                             
-         |      ··∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘∘∘ ·· ·                     
-       0 |·····○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○·∘∘∘······ · ··     ·
+     470 |                                                                                
+         |                           ∘                                                    
+         |                         · ○   ·                                                
+         |                         ○·○∘○ ○                                                
+         |                         ○○○○○·○                                                
+     350 |                        ○○○○○○○○ ··                                             
+         |                     ·○∘○○○○○○○○ ○○                                             
+         |                     ○○○○○○○○○○○○○○○                                            
+         |                     ○○○○○○○○○○○○○○○                                            
+         |                    ∘○○○○○○○○○○○○○○○                                            
+     230 |                  ∘ ○○○○○○○○○○○○○○○○  ·                                         
+         |                 ·○∘○○○○○○○○○○○○○○○○∘∘○                                         
+         |                ·○○○○○○○○○○○○○○○○○○○○○○∘○                                       
+         |                ○○○○○○○○○○○○○○○○○○○○○○○○○·                                      
+         |             ··○○○○○○○○○○○○○○○○○○○○○○○○○○○·                                     
+     110 |             ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘·                                   
+         |            ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○ ○                                 
+         |            ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○                                 
+         |          ∘∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘·○                             
+         |       ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·○∘                          
+       0 |∘ · ·○∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○·∘∘···· ··  ·          ·
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        4.68     5.58     6.47     7.37     8.26     9.16    10.05    10.95    11.84  
+        4.6      5.5      6.5      7.5      8.4      9.4      10.4     11.4     12.3  
 ```
 
-Looks like our daily rate is probably somewhere between 6 and 9, and is in fact much more likely to be around 9 than 10.
-
+Looks like our daily rate is probably somewhere between 6 and 9, which corresponds well to the steep 3x dropoff we saw before between 9 and 10.
 ## A mathematical digression
 
 Please feel free to skip this section if it's not helping you.
@@ -298,42 +337,42 @@ scala> val prediction = for {
      |     r <- e_x
      |     poisson <- Poisson(r).fit(sales)
      | } yield poisson.generator
-prediction: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@1734d8bf
+prediction: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@3f1572ca
 ```
 
 This is almost the same model as `rate` above, but instead of taking the real-valued `r` rate parameter as the output, we're producing poisson-distributed integers. The samples look like this:
 
 ```scala
 scala> prediction.sample()
-res7: List[Int] = List(13, 10, 9, 10, 5, 10, 5, 7, 2, 6, 6, 10, 11, 7, 11, 3, 14, 9, 11, 4, 10, 8, 6, 7, 5, 8, 5, 10, 14, 5, 8, 14, 12, 9, 10, 13, 3, 7, 9, 2, 6, 7, 8, 10, 9, 5, 14, 4, 7, 4, 10, 5, 8, 5, 7, 5, 9, 5, 9, 7, 10, 9, 4, 9, 9, 9, 8, 7, 11, 10, 12, 8, 7, 6, 5, 7, 5, 8, 9, 9, 6, 12, 4, 11, 9, 10, 6, 9, 7, 6, 8, 8, 6, 3, 8, 3, 9, 9, 12, 5, 5, 10, 7, 4, 11, 9, 7, 4, 9, 2, 10, 0, 8, 8, 15, 6, 8, 7, 4, 8, 16, 6, 7, 5, 6, 15, 8, 5, 5, 7, 13, 8, 5, 8, 12, 10, 4, 5, 8, 6, 6, 9, 9, 3, 11, 5, 6, 6, 8, 8, 8, 10, 8, 6, 7, 9, 4, 8, 6, 4, 16, 6, 6, 7, 9, 6, 3, 6, 13, 15, 6, 12, 7, 11, 3, 6, 11, 4, 6, 8, 4, 2, 12, 10, 6, 8, 3, 10, 7, 7, 10, 4, 4, 15, 10, 4, 10, 7, 9, 9, 2, 10, 11, 8, 8, 16, 6, 9, 7, 4, 5, 6, 4, 6, 14, 8, 12, 5, 10, 6, 11, 9, 4, 8, 9, 10, 6, 12, 6, 9...
+res7: List[Int] = List(10, 17, 6, 4, 9, 1, 12, 4, 8, 4, 10, 7, 7, 4, 13, 6, 6, 3, 9, 1, 10, 5, 8, 8, 14, 9, 7, 3, 6, 5, 7, 10, 7, 5, 4, 10, 5, 10, 6, 8, 5, 8, 7, 4, 9, 6, 7, 9, 8, 7, 12, 6, 5, 11, 6, 7, 5, 8, 11, 9, 14, 6, 7, 4, 16, 5, 4, 11, 6, 9, 7, 10, 9, 9, 3, 9, 6, 6, 8, 7, 12, 12, 7, 8, 8, 5, 14, 9, 6, 10, 7, 13, 7, 9, 6, 4, 15, 6, 7, 10, 8, 8, 10, 2, 7, 8, 10, 6, 7, 13, 7, 6, 9, 8, 10, 15, 9, 8, 8, 8, 4, 9, 9, 15, 6, 5, 9, 8, 6, 8, 7, 8, 7, 4, 9, 7, 6, 6, 6, 8, 5, 5, 8, 11, 3, 7, 12, 2, 7, 6, 11, 9, 8, 6, 9, 8, 4, 11, 10, 5, 13, 9, 12, 7, 5, 5, 4, 12, 5, 11, 11, 7, 11, 6, 12, 8, 6, 18, 4, 9, 6, 7, 11, 5, 4, 7, 8, 14, 6, 8, 10, 7, 12, 10, 6, 7, 8, 6, 7, 7, 8, 7, 9, 5, 6, 7, 10, 8, 2, 6, 6, 6, 7, 9, 8, 6, 4, 9, 9, 12, 11, 7, 6, 5, 7, 9, 9, 3, 7, 4, 10, 5, ...
 ```
 Or, if we plot them, like this:
 
 ```scala
 scala> plot1D(prediction.sample())
-    1350 |                                                                                
-         |                        ○                                                       
-         |                    ○   ○  ○                                                    
-         |                    ○   ○  ○                                                    
-         |                    ○   ○  ○   ∘                                                
-    1010 |                 ○  ○   ○  ○   ○                                                
-         |                 ○  ○   ○  ○   ○                                                
-         |                 ○  ○   ○  ○   ○                                                
-         |                 ○  ○   ○  ○   ○  ∘                                             
-         |                 ○  ○   ○  ○   ○  ○                                             
-     670 |             ○   ○  ○   ○  ○   ○  ○                                             
-         |             ○   ○  ○   ○  ○   ○  ○   ∘                                         
-         |             ○   ○  ○   ○  ○   ○  ○   ○                                         
-         |             ○   ○  ○   ○  ○   ○  ○   ○                                         
-         |          ·  ○   ○  ○   ○  ○   ○  ○   ○                                         
-     330 |          ○  ○   ○  ○   ○  ○   ○  ○   ○  ∘                                      
-         |          ○  ○   ○  ○   ○  ○   ○  ○   ○  ○   ·                                  
-         |          ○  ○   ○  ○   ○  ○   ○  ○   ○  ○   ○                                  
-         |      ·   ○  ○   ○  ○   ○  ○   ○  ○   ○  ○   ○  ·                               
-         |      ○   ○  ○   ○  ○   ○  ○   ○  ○   ○  ○   ○  ○  ·                            
-       0 |·  ○  ○   ○  ○   ○  ○   ○  ○   ○  ○   ○  ○   ○  ○  ○   ∘  ·   ·  ·   ·      ·  ·
+    1400 |                                                                                
+         |                         ○                                                      
+         |                         ○  ∘                                                   
+         |                     ∘   ○  ○                                                   
+         |                     ○   ○  ○                                                   
+    1050 |                     ○   ○  ○   ○                                               
+         |                  ·  ○   ○  ○   ○                                               
+         |                  ○  ○   ○  ○   ○                                               
+         |                  ○  ○   ○  ○   ○   ○                                           
+         |                  ○  ○   ○  ○   ○   ○                                           
+     700 |              ∘   ○  ○   ○  ○   ○   ○                                           
+         |              ○   ○  ○   ○  ○   ○   ○                                           
+         |              ○   ○  ○   ○  ○   ○   ○  ∘                                        
+         |              ○   ○  ○   ○  ○   ○   ○  ○                                        
+         |              ○   ○  ○   ○  ○   ○   ○  ○   ·                                    
+     350 |          ∘   ○   ○  ○   ○  ○   ○   ○  ○   ○                                    
+         |          ○   ○   ○  ○   ○  ○   ○   ○  ○   ○                                    
+         |          ○   ○   ○  ○   ○  ○   ○   ○  ○   ○   ○                                
+         |       ·  ○   ○   ○  ○   ○  ○   ○   ○  ○   ○   ○  ∘                             
+         |       ○  ○   ○   ○  ○   ○  ○   ○   ○  ○   ○   ○  ○   ∘                         
+       0 |·  ○   ○  ○   ○   ○  ○   ○  ○   ○   ○  ○   ○   ○  ○   ○  ∘   ·   ·  ·   ·   ·  ·
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        0.0      2.6      5.2      7.8      10.4     13.0     15.6     18.2     20.8  
+        0.0      2.5      5.0      7.5      9.9      12.4     14.9     17.4     19.9  
 ```
 
 ## `Likelihood` and `Predictor`
@@ -381,7 +420,7 @@ scala> val prior = for {
      |     slope <- LogNormal(0,1).param
      |     intercept <- LogNormal(0,1).param
      |     } yield (slope, intercept)
-prior: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@53997e37
+prior: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@6d007072
 ```
 
 Now, for any given day `i`, we want to check the number of sales against `Poisson(intercept + slope*i)`. We could write some kind of recursive flatMap to build and fit each of these different distribution objects in turn, but this is a common enough pattern that Rainier already has something built in for it: `Predictor`. `Predictor` is not a `Distribution`, but instead wraps a function from `X => Distribution[Y]` for some `(X,Y)`; you can use this any time you have a dependent variable of type `Y` that you're modeling with some independent variables jointly represented as `X`.
@@ -395,7 +434,7 @@ scala> val regr = for {
      |                     Poisson(intercept + slope*i)
      |                 }.fit(data)
      | } yield (slope, intercept)
-regr: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@4b9bc4b9
+regr: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@54f3a4ba
 ```
 
 As before, we're starting out by just sampling the parameters. By plotting them, we can see that the model's confidence in the intercept, in particular, is pretty low: although it's most likely to be somewhere around 8, it could be anywhere from 3 to 13 or even higher. Second, as you'd hope, the two parameters are anti-correlated:
@@ -403,29 +442,29 @@ a smaller intercept would imply a higher slope, and vice versa.
 
 ```scala
 scala> plot2D(regr.sample())
-    15.4 |                                                                                
-         |     ·  ·                                                                       
-         |   ·                    · ·                                                     
-         |· ·    ·  ···· · ··    ·        ·                                               
-         | ·     ·  ·············  ····    ·                                              
-    12.2 |   ·   ·  · ······················· ·    ·                                      
-         |     ·  · ························· ·· ·    ·                                   
-         |          ····························· ···· ·  ·                               
-         |        ··· ·  ······························ ····  ·                           
-         |        ·    ·  ··········∘∘·∘∘∘·∘∘∘∘···············  ·                         
-     8.9 |             ·· ···········∘∘·∘∘∘∘∘∘∘∘∘∘··∘·············                        
-         |                  ···········∘∘∘∘∘∘∘∘∘○○∘∘∘∘○∘∘∘·∘········· · ··                
-         |                       ···········∘∘∘∘○○○○○○○○∘∘∘∘∘∘·············               
-         |                        · ·········∘·∘∘∘∘○∘○∘○○○∘○∘∘···············             
-         |                             ············∘∘∘∘∘∘∘∘∘∘∘·····∘···········   ·       
-     5.7 |                                ·················∘·∘··∘··∘·········· · ···   ·  
-         |                                     ································· ··   ·  ·
-         |                                       · ··· ························· ·   ·    
-         |                                            ···    ············· ········   ·  ·
-         |                                                        ·  ···· ···  ·   · ·    
-     2.5 |                                                                   ··     ·     
+    15.3 |                                                                                
+         |      ·    ·                                                                    
+         |·    ·  ·     ·     ·      ·                                                    
+         |          · · ·   · ·     ·                                                     
+         | ·         ········· ·  ·  ·       ·                                            
+    12.2 |  ·  ··  ·· ·····················                                               
+         |    ··  ·  ·· ·················· ···                                            
+         |   ·  ··  ···························· ····                                     
+         |       · ·· ································  · · ··                            
+         |           ··············∘∘·∘··∘·∘··············· ·                             
+     9.2 |           ··············∘∘∘∘∘∘∘○∘∘∘∘∘····∘·············                        
+         |              ··  ··········∘∘∘∘∘∘∘∘∘∘○∘∘∘∘∘·········· ·· ·      ·              
+         |              ·   ············∘∘∘∘○∘○○○∘○○∘∘∘∘∘·············· ·                 
+         |                 ·    ··········∘∘∘∘∘∘○○∘○○○∘○∘∘∘·∘···········  ·               
+         |                       · ·········∘·∘∘∘∘∘∘∘∘∘∘∘∘∘∘∘∘············· · ·           
+     6.1 |                          ·  ··········∘·∘∘∘∘∘·∘∘∘∘∘∘∘··············· · ·       
+         |                        ·     · ··················∘··············· ·  · ··      
+         |                               ·    ································· ·  ·      
+         |                                       ··   ····················· ·· ···       ·
+         |                                               ·   · ······ ··········          
+     3.0 |                                                    ·        ·    ·  · ·        
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        2.40     2.57     2.74     2.90     3.07     3.23     3.40     3.57     3.73  
+        2.43     2.60     2.77     2.94     3.11     3.28     3.45     3.62     3.79  
 ```
 
 Alternatively, as in the earlier example, we could try to predict what will happen tomorrow. This is similar to calling `poisson.generator` before, but this time, we use the `predict` method on `Predictor`, which takes the covariate (the day, in this case), and returns a `Generator` for the dependent variable (the number of sales). Putting it all together, it looks like this:
@@ -438,36 +477,36 @@ scala> val regr2 = for {
      |                     Poisson(intercept + slope*i)
      |                 }.fit(data)
      | } yield predictor.predict(21)
-regr2: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@3ebe0336
+regr2: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@1123e42a
 ```
 
 Plotting this gives us a prediction which incorporates both the natural noise of a Poisson distribution and our uncertainty about its underlying parameterization.
 
 ```scala
 scala> plot1D(regr2.sample())
-     450 |                                                                                
-         |                                     ·   ∘                                      
-         |                                   ·○○ ∘ ○                                      
-         |                               ○ ∘ ○○○∘○ ○·                                     
-         |                               ○·○ ○○○○○ ○○∘                                    
-     340 |                               ○○○ ○○○○○ ○○○·                                   
-         |                             ∘ ○○○ ○○○○○ ○○○○∘                                  
-         |                           · ○ ○○○ ○○○○○ ○○○○○ ○                                
-         |                           ○ ○○○○○ ○○○○○ ○○○○○ ○                                
-         |                           ○ ○○○○○ ○○○○○ ○○○○○ ○                                
-     220 |                         ∘ ○ ○○○○○ ○○○○○ ○○○○○ ○·○·                             
-         |                        ○○∘○ ○○○○○ ○○○○○ ○○○○○ ○○○○ ·                           
-         |                      · ○○○○ ○○○○○ ○○○○○ ○○○○○ ○○○○ ○                           
-         |                      ○ ○○○○ ○○○○○ ○○○○○ ○○○○○ ○○○○ ○∘                          
-         |                     ∘○ ○○○○ ○○○○○ ○○○○○ ○○○○○ ○○○○ ○○                          
-     110 |                    ∘○○ ○○○○ ○○○○○ ○○○○○ ○○○○○ ○○○○ ○○∘○                        
-         |                   ∘○○○ ○○○○ ○○○○○ ○○○○○ ○○○○○ ○○○○ ○○○○○ ∘                     
-         |                  ∘○○○○ ○○○○ ○○○○○ ○○○○○ ○○○○○ ○○○○ ○○○○○ ○·                    
-         |               ○∘ ○○○○○ ○○○○ ○○○○○ ○○○○○ ○○○○○ ○○○○ ○○○○○ ○○·                   
-         |             ·○○○ ○○○○○ ○○○○ ○○○○○ ○○○○○ ○○○○○ ○○○○ ○○○○○ ○○○○○ ∘· ·            
-       0 |··  · ··∘∘○ ○○○○○ ○○○○○ ○○○○ ○○○○○ ○○○○○ ○○○○○ ○○○○ ○○○○○ ○○○○○ ○○○○∘ ∘∘·· ··· ·
+     460 |                                                                                
+         |                               ∘                                                
+         |                             ∘ ○ ○∘·                                            
+         |                             ○·○ ○○○○○                                          
+         |                          ∘ ∘○○○ ○○○○○                                          
+     340 |                          ○∘○○○○ ○○○○○○·                                        
+         |                          ○○○○○○ ○○○○○○○○·                                      
+         |                        ·○○○○○○○ ○○○○○○○○○                                      
+         |                        ○○○○○○○○ ○○○○○○○○○                                      
+         |                        ○○○○○○○○ ○○○○○○○○○∘                                     
+     230 |                       ○○○○○○○○○ ○○○○○○○○○○·                                    
+         |                     ·∘○○○○○○○○○ ○○○○○○○○○○○∘                                   
+         |                    ·○○○○○○○○○○○ ○○○○○○○○○○○○○·                                 
+         |                    ○○○○○○○○○○○○ ○○○○○○○○○○○○○○·                                
+         |                   ∘○○○○○○○○○○○○ ○○○○○○○○○○○○○○○                                
+     110 |                  ∘○○○○○○○○○○○○○ ○○○○○○○○○○○○○○○                                
+         |                 ·○○○○○○○○○○○○○○ ○○○○○○○○○○○○○○○ ∘○                             
+         |             · ∘ ○○○○○○○○○○○○○○○ ○○○○○○○○○○○○○○○ ○○○                            
+         |             ○○○ ○○○○○○○○○○○○○○○ ○○○○○○○○○○○○○○○ ○○○○∘○                         
+         |            ·○○○ ○○○○○○○○○○○○○○○ ○○○○○○○○○○○○○○○ ○○○○○○∘∘                       
+       0 |· ····∘·∘∘○○○○○○ ○○○○○○○○○○○○○○○ ○○○○○○○○○○○○○○○ ○○○○○○○○○∘∘∘·∘∘· ······ ·     ·
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        43.0     50.4     57.9     65.3     72.7     80.2     87.6     95.1    102.5  
+        43.0     51.4     59.9     68.3     76.8     85.2     93.7    102.1    110.6  
 ```
 
 Finally, let's close with a small and somewhat contrived example of a hierarchical model, where we have two separate regressions that share a parameter. For the sake of the example, let's assume that we have a second sales dataset, much like the first, where we know they had the same rate at the start of the observations, but may have grown at different rates - so their intercepts will be equal but their slopes will not. Here's the data:
@@ -487,7 +526,7 @@ scala> val regr3 =  for {
      |     _ <- Predictor.fromInt{ i => Poisson(intercept + slope0 * i) }.fit(data)
      |     _ <- Predictor.fromInt{ i => Poisson(intercept + slope1 * i) }.fit(data2)
      | } yield (slope0, intercept)
-regr3: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@28f54f1b
+regr3: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@78b3707d
 ```
 
 or we can use Rainier's `Lookup` to package the two slopes into a single `RandomVariable` from which we can lookup the one we want. This means that our predictor now has to take both the index of the model to which the data belongs as well as the actual observation as input.
@@ -501,36 +540,36 @@ scala> val regLookup = for {
      |   intercept <- LogNormal(0,1).param
      |   _ <- Predictor.fromIntPair{ case (index, x) => Poisson(intercept + slopes(index) * x) }.fit(allData)
      | } yield (slopes(0), intercept)
-regLookup: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@3c9c790c
+regLookup: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@56a03f06
 ```
 
 Plotting slope vs. intercept now, we see that, even though these are two separate regressions, we get tighter bounds than before by letting the new data influence the shared parameter. It makes sense that we'd get more confidence on the intercept, since we have two different time series to learn from now; but because of the anti-correlation, that also leads to somewhat more confidence than before on the `slopes(0)` parameter as well.
 
 ```scala
 scala> plot2D(regLookup.sample())
-    11.4 |                                                                                
-         |     ·                   ·                                                      
-         |                   ·            ·                                               
-         |              ·· ··  ··                                                         
-         |       ·  ·· ·· ·  ·   · · ·                                                    
-     9.3 |· ·  ·  · · ···  ··· ····· ······       ·                                       
-         |      · ·· ····················· ····· ····     ·                               
-         |  ·    ································ ······ ·· ·                             
-         |     · ··  ········································· · · ·   ·                  
-         |      · ··················∘··∘∘···∘·∘················· ·· · ·                   
-     7.2 | ·  · · ················∘·∘∘·∘∘∘∘∘∘∘∘∘∘∘∘∘················ ··· ·                
-         |    ·       ·············∘·∘∘∘∘∘○∘∘∘○○○∘∘∘○∘∘∘···∘···············               
-         |           · · ···········∘∘∘∘∘∘∘∘∘○○∘○○○○∘○○∘∘∘∘·∘∘·············  · ·          
-         |             ··  ·············∘∘∘∘∘○∘∘∘○∘○∘○○○∘∘∘∘∘·∘·············  ·  ··      ·
-         |               ·   ············∘∘··∘∘∘∘∘∘∘∘∘∘∘∘∘∘∘∘·∘∘···∘········· ·····    ·  
-     5.1 |                    · ·· ··············∘·∘∘∘∘·∘·∘·∘∘··∘··············· ···     ·
-         |                     ·  · ··· ········································· ·   · · 
-         |                            ··········· ···························· · ·  ··    
-         |                                    · ·· ·· ···············  ··  ·· · · ···     
-         |                                      ·   ·   · · · ·  ·········            ·   
-     3.0 |                                      ·             ·                           
+    10.9 |                                                                                
+         |     · ·                                                                        
+         |               ·       · ·     ·                                                
+         |            · ·· ·· ·· ·         ·                                              
+         |    ·  · · ·· ···· ··· · ·· ··  ·     ·                                         
+     9.0 |·  ···························· · ··                                            
+         |   ··································  · ·    ·              ·                  
+         |·  ········································   · ·   ·                           
+         |    ·············································   ·      ·                    
+         |·     ··················∘··∘∘∘∘·∘················ ···· ··        ·              
+     7.1 |     ··   ·············∘∘∘∘∘∘∘∘∘∘∘∘·∘∘∘∘····················      ·             
+         |     ·  ·   ···········∘∘·∘∘∘∘∘○∘∘∘∘∘∘∘∘○·∘················  ··                 
+         |          ················∘∘∘∘∘○○∘∘○∘○○∘○∘∘∘∘∘·····················             
+         |     ·     · ··· ············∘∘∘∘○∘∘∘∘○∘∘∘○∘∘∘∘···∘·················    ·       
+         |          ·   ·· ············∘∘···∘∘∘∘∘∘∘○∘∘∘∘∘∘∘∘∘············· ·  ·· ·        
+     5.2 |                   ···················∘∘∘∘∘∘∘∘∘∘·∘∘·················    ··      
+         |                     · ···························∘···················          
+         |                     ··    ············································ ··     ·
+         |                             · ··· ······ ···················· ·····  ··        
+         |                                ·    · · ···· ··  ·· ···· · ·  ·· ·    · ·      
+     3.3 |                                             ··· ·  ·  ·        ··  ·   ·       
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        2.73     2.86     2.99     3.13     3.26     3.39     3.53     3.66     3.79  
+        2.77     2.91     3.04     3.17     3.30     3.44     3.57     3.70     3.83  
 ```
 
 ## Learning More

--- a/docs/tour.md
+++ b/docs/tour.md
@@ -1,10 +1,8 @@
 # A Tour of Rainier's Core
 
-Hello! This document will provide a quick tour through the most important parts of Rainier's core.
-If you'd like to follow along with this tour, `sbt "project rainierCore" console` will get you to a Scala REPL.
+Hello! This document will provide a quick tour through the most important parts of Rainier's core. If you'd like to follow along with this tour, `sbt "project rainierCore" console` will get you to a Scala REPL.
 
-The `rainier.core` package defines some key traits like `Distribution`, `RandomVariable`, `Likelihood`, and `Predictor`.
-Let's import it, along with a `repl` package that gives us some useful utilities.
+The `rainier.core` package defines some key traits like `Distribution`, `RandomVariable`, `Likelihood`, and `Predictor`. Let's import it, along with a `repl` package that gives us some useful utilities.
 
 ```scala
 import com.stripe.rainier.core._
@@ -12,10 +10,8 @@ import com.stripe.rainier.repl._
 import com.stripe.rainier.compute._
 ```
 
-Together, those traits let you define Bayesian models in Rainier.
-To throw you a little bit into the deep end, here's a simple linear regression that we'll return to later.
-This probably won't entirely make sense yet. That's ok.
-Hopefully it will serve as a bit of a roadmap that put the rest of the tour in context as we build up to it.
+Together, those traits let you define Bayesian models in Rainier. To throw you a little bit into the deep end, here's a simple linear regression that we'll return to later.
+This probably won't entirely make sense yet. That's ok. Hopefully it will serve as a bit of a roadmap that put the rest of the tour in context as we build up to it.
 
 ```scala
 scala> val data =  List((0,8), (1,12), (2,16), (3,20), (4,21), (5,31), (6,23), (7,33), (8,31), (9,33), (10,36), (11,42), (12,39), (13,56), (14,55), (15,63), (16,52), (17,66), (18,52), (19,80), (20,71))
@@ -26,36 +22,26 @@ scala> val model = for {
      |   intercept <- LogNormal(0,1).param
      |   regression <- Predictor.fromInt{x => Poisson(x*slope + intercept)}.fit(data)
      | } yield regression.predict(21)
-model: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@1af49208
+model: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@3922d4e5
 
 scala> model.sample(10)
-res0: List[Int] = List(69, 73, 74, 87, 72, 78, 68, 73, 100, 74)
+res0: List[Int] = List(71, 73, 68, 76, 73, 74, 96, 71, 77, 83)
 ```
 
 ## Distribution
 
-The starting point for almost any work in Rainier will be some object that implements
-`rainier.core.Distribution[T]`.
+The starting point for almost any work in Rainier will be some object that implements `rainier.core.Distribution[T]`.
 
-Rainier implements various familiar families of probability distributions like
-the [Normal](https://en.wikipedia.org/wiki/Normal_distribution) distribution,
-the [Uniform][UC] distribution,
-and the [Poisson](https://en.wikipedia.org/wiki/Poisson_distribution) distribution.
-You will find these three in [Continuous.scala](/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala)
-and [Discrete.scala](/rainier-core/src/main/scala/com/stripe/rainier/core/Discrete.scala) -
-along with a few more, and we'll keep adding them as the need arises.
-
-You construct a distribution from its parameters, usually with the `apply` method on the object representing its family.
-So for example, this is a normal distribution with a mean of 0 and a standard deviation of 1:
+Rainier implements various familiar families of probability distributions like the [Normal](https://en.wikipedia.org/wiki/Normal_distribution) distribution,
+the [Uniform][UC] distribution, and the [Poisson](https://en.wikipedia.org/wiki/Poisson_distribution) distribution.
+You will find these three in [Continuous.scala](/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala) and [Discrete.scala](/rainier-core/src/main/scala/com/stripe/rainier/core/Discrete.scala) - along with a few more, and we'll keep adding them as the need arises. You construct a distribution from its parameters, usually with the `apply` method on the object representing its family. So for example, this is a normal distribution with a mean of 0 and a standard deviation of 1:
 
 ```scala
 scala> val normal: Distribution[Double] = Normal(0,1)
-normal: com.stripe.rainier.core.Distribution[Double] = com.stripe.rainier.core.Injection$$anon$1@24bd441f
+normal: com.stripe.rainier.core.Distribution[Double] = com.stripe.rainier.core.Injection$$anon$1@2d29c75b
 ```
 
-In Rainier, `Distribution` objects play three different roles.
-`Continuous` distributions (like `Normal`), implement `param`, and all distributions implement `fit` and `generator`.
-Each of these methods is central to one of the three stages of building a model in Rainier:
+In Rainier, `Distribution` objects play three different roles. `Continuous` distributions (like `Normal`), implement `param`, and all distributions implement `fit` and `generator`. Each of these methods is central to one of the three stages of building a model in Rainier:
 
 * defining your parameters and their priors
 * fitting the parameters to some observed data and
@@ -65,284 +51,226 @@ We'll start by exploring each of these in turn.
 
 ## `param` and `RandomVariable`
 
-Every model in Rainier has some parameters whose values are unknown
-(if that's not true for your model, you don't need an inference library!).
+Every model in Rainier has some parameters whose values are unknown (if that's not true for your model, you don't need an inference library!).
 The first step in constructing a model is to set up these parameters.
 
-You create a parameter by calling `param` on the distribution that represents
-the prior for that parameter. `param` is only implemented for continuous distributions
-(which extend `Continuous`, which extends `Distribution[Double]`).
-As you might be able to tell from those types:
-in Rainier, all parameters are continuous real scalar values.
-There's no support for discrete model parameters, and there's no support (or need)
-for explicit vectorization.
+You create a parameter by calling `param` on the distribution that represents the prior for that parameter. `param` is only implemented for continuous distributions
+(which extend `Continuous`, which extends `Distribution[Double]`). As you might be able to tell from those types:
+in Rainier, all parameters are continuous real scalar values. There's no support for discrete model parameters, and there's no support (or need) for explicit vectorization.
 
 Let's use that same `Normal(0,1)` distribution as a prior for a new parameter:
 
 ```scala
 scala> val x = Normal(0,1).param
-x: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@3b5cb97f
+x: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@2041c4b2
 ```
 
-You can see that the type of `x` is `RandomVariable[Real]`.
-`RandomVariable` pairs a type of value (in this case, a real number)
-with some knowledge of the relative probability density of different values of that type.
-We can use this knowledge to produce a sample of these possible values:
+You can see that the type of `x` is `RandomVariable[Real]`. `RandomVariable` pairs a type of value (in this case, a real number) with some knowledge of the relative probability density of different values of that type. We can use this knowledge to produce a sample of these possible values:
 
 ```scala
 scala> x.sample()
-res1: List[Double] = List(0.08945741219217429, -0.08572103782740581, 0.08096740348353304, -0.06942170310697804, 0.03769808860633095, -0.056337565447439175, 0.08286122392158468, -0.07049380254126869, 0.0964505900183994, -0.08994844607337066, 0.0681015347459415, -0.07075948263299364, 0.0747424482459611, -0.09179821815027656, 0.11372979045788867, -0.13055617861536195, 0.13606559329183548, -0.13553342637211643, 0.12085681266491866, -0.1253478378893762, 0.08819446794761276, -0.06586789070823107, 0.03648060095499428, -0.0556970493083373, 0.05379641551584552, -0.07823773960888425, 0.06610020346817047, -0.05584664287136165, 0.07824428971547004, -0.09127833667902208, 0.1058097878681088, -0.09282603839528669, 0.10660612074837217, -0.0902395210197997, 0.09211392168009319,...
+res1: List[Double] = List(0.851042860312551, -0.10115873972819678, -0.2019818396177493, -0.06242326870305881, 0.07910315689936297, -0.47486515373676363, -0.12473499286691347, 0.43937959443822083, -0.0412165163852396, -0.04709140333485806, -0.1727825589365133, 0.3641927622782447, -0.47435955497055354, -0.7322526805211682, 1.1363419190428985, -1.4240714809931854, 1.516408582936893, 1.516408582936893, -1.667909084512874, 2.2296258626092333, -2.642251012149351, 1.7095348500648408, -1.2344294260603343, -1.2344294260603343, -1.2344294260603343, 0.9447687726348758, -1.1958229468003794, 1.864051158609457, -1.9420776453364645, 0.6826358066473812, 0.6826358066473812, -0.03210524538600579, -0.6123508762216829, 0.11795503664366258, -0.35659498252364596, 0.3904674386910485,...
 ```
 
-Each element of the list above represents a single sample from the distribution over `x`.
-It's easier to understand these if we plot them as a histogram:
+Each element of the list above represents a single sample from the distribution over `x`. It's easier to understand these if we plot them as a histogram:
 
 ```scala
 scala> plot1D(x.sample())
-     370 |                                                                                
-         |                                       ·∘                                       
-         |                                 ∘ ·∘ ∘○○·  ○                                   
-         |                                 ○ ○○ ○○○○∘ ○○·                                 
-         |                                 ○○○○ ○○○○○∘○○○○                                
-     270 |                               ∘∘○○○○○○○○○○○○○○○○                               
-         |                              ○○○○○○○○○○○○○○○○○○○                               
-         |                              ○○○○○○○○○○○○○○○○○○○·○                             
-         |                             ○○○○○○○○○○○○○○○○○○○○○○                             
-         |                             ○○○○○○○○○○○○○○○○○○○○○○○                            
-     180 |                            ○○○○○○○○○○○○○○○○○○○○○○○○                            
-         |                            ○○○○○○○○○○○○○○○○○○○○○○○○                            
-         |                          ·○○○○○○○○○○○○○○○○○○○○○○○○○∘∘                          
-         |                          ○○○○○○○○○○○○○○○○○○○○○○○○○○○○                          
-         |                         ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○·  ·                      
-      90 |                      ∘∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                      
-         |                   ∘∘∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○··                    
-         |                   ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘·                  
-         |                 ○·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○··                
-         |        ∘·····○∘∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○∘·  ·∘·       
-       0 |···∘∘·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○·····
+     430 |                                                                                
+         |                                        · ∘                                     
+         |                                      · ○ ○                                     
+         |                                    ∘○○∘○∘○                                     
+         |                                    ○○○○○○○∘ ·                                  
+     320 |                                  ○○○○○○○○○○○○                                  
+         |                                ○∘○○○○○○○○○○○○·                                 
+         |                               ∘○○○○○○○○○○○○○○○○                                
+         |                               ○○○○○○○○○○○○○○○○○                                
+         |                              ·○○○○○○○○○○○○○○○○○ ○                              
+     210 |                             ∘○○○○○○○○○○○○○○○○○○○○                              
+         |                            ∘○○○○○○○○○○○○○○○○○○○○○∘·                            
+         |                           ∘○○○○○○○○○○○○○○○○○○○○○○○○                            
+         |                          ○○○○○○○○○○○○○○○○○○○○○○○○○○∘                           
+         |                          ○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘                         
+     100 |                        ○·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                         
+         |                      ··○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                        
+         |                    ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘·∘                    
+         |                  ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘·                  
+         |              ∘∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘∘·               
+       0 |·····  ····∘∘∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘············
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-       -3.72    -2.89    -2.05    -1.21    -0.38     0.46     1.29     2.13     2.96  
+       -3.76    -2.91    -2.05    -1.20    -0.35     0.50     1.35     2.20     3.05  
 ```
 
-Since the only information we have about `x` so far is its `Normal` prior, this distribution unsurprisingly looks  normal.
-Later we'll see how to update our beliefs about `x` based on observational data.
+Since the only information we have about `x` so far is its `Normal` prior, this distribution unsurprisingly looks normal. Later we'll see how to update our beliefs about `x` based on observational data.
 
-For now, though, let's explore what we can do just with priors.
-`RandomVariable` has more than just `sample`:
-you can use the familiar collection methods like `map`, `flatMap`, and `zip`
-to transform and combine the parameters you create.
-For example, we can create a log-normal distribution just by mapping over `e^x`:
+For now, though, let's explore what we can do just with priors. `RandomVariable` has more than just `sample`: you can use the familiar collection methods like `map`, `flatMap`, and `zip` to transform and combine the parameters you create. For example, we can create a log-normal distribution just by mapping over `e^x`:
 
 ```scala
 scala> val e_x = x.map(_.exp)
-e_x: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@494de68b
+e_x: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@135c8934
 
 scala> plot1D(e_x.sample())
-    2300 |                                                                                
-         | ·                                                                              
-         | ○                                                                              
-         | ○                                                                              
-         | ○                                                                              
-    1700 |·○                                                                              
+    3300 |                                                                                
+         |∘                                                                               
+         |○                                                                               
+         |○                                                                               
          |○○                                                                              
+    2400 |○○                                                                              
+         |○○                                                                              
+         |○○                                                                              
+         |○○                                                                              
+         |○○                                                                              
+    1600 |○○                                                                              
+         |○○                                                                              
+         |○○∘                                                                             
          |○○○                                                                             
          |○○○                                                                             
-         |○○○                                                                             
-    1100 |○○○                                                                             
-         |○○○∘                                                                            
+     800 |○○○·                                                                            
          |○○○○                                                                            
-         |○○○○                                                                            
-         |○○○○∘                                                                           
-     500 |○○○○○·                                                                          
-         |○○○○○○                                                                          
-         |○○○○○○○                                                                         
-         |○○○○○○○··                                                                       
-         |○○○○○○○○○∘·                                                                     
-       0 |○○○○○○○○○○○○○○∘∘································· ·  · ···         ··  · ·     ·
+         |○○○○·                                                                           
+         |○○○○○·                                                                          
+         |○○○○○○·                                                                         
+       0 |○○○○○○○○○∘∘················ ·  ·  ····  ··      ·                        ·     ·
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        0.0      3.4      6.7      10.1     13.5     16.8     20.2     23.5     26.9  
+        0.0      5.6      11.2     16.9     22.5     28.1     33.7     39.3     44.9  
 ```
 
-Or we can create another `Normal` parameter and zip the two together to produce a 2D gaussian.
-Since there's nothing relating these two parameters to each other, you can see in the plot that they're completely independent.
+Or we can create another `Normal` parameter and zip the two together to produce a 2D gaussian. Since there's nothing relating these two parameters to each other, you can see in the plot that they're completely independent.
 
 ```scala
 scala> val y = Normal(0,1).param
-y: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@ab08a1a
+y: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@30394309
 
 scala> val xy = x.zip(y)
-xy: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@47ec801b
+xy: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@555c3f2c
 
 scala> plot2D(xy.sample())
-     3.5 |                                                                                
-         |                             ·              ·                                   
-         |                 ·        ···            ·  ·  · ··          ·                  
-         |                        · ··   · ····· · · ·· ··· · ·· · ··  ·                  
-         |                   · ···· ······························ · · ··  ·              
-     1.7 |          ·          · ·· · ···························· ·· ···   · ·       ·   
-         |            ·   ···· ··  ····································· ·  · ·  ··       
-         |       ·    · · ·  ···· ··············∘··∘······∘············· ·  ··            
-         |     ·  ·   ··   ···················∘∘·∘∘∘○∘∘∘∘∘∘················· · ··        ·
-         |        · ·  ···················∘∘∘∘∘∘∘∘∘∘∘○∘∘∘∘∘∘∘∘·∘··············         · ·
-    -0.0 |·           ·· ···············∘·∘∘∘○·○∘∘∘∘∘∘∘∘∘∘·∘∘∘∘·················          
-         |  ·            ··············∘∘∘··∘∘○∘∘∘∘∘∘∘○∘○∘∘∘∘∘∘··············· ··         
-         |   · ·   ·· ·  ··  ············∘·∘··∘∘∘∘∘∘○∘∘∘·∘∘·∘·∘·············· ··      · · 
-         |             · ····················∘∘∘·∘∘∘∘∘·∘∘∘·∘············ ··· ···  · ·     
-         |          ··  · ·  ···················∘··∘∘·∘∘··················· ··· ·         
-    -1.8 |                  ··· ······ ··································· ·  ·          ·
-         |                       ·································· ····  ··              
-         |                   ·  · ·  ··· ··········· ····· ············     ·   ·         
-         |                     ·     · ·· · ··  ·  ······  · · ··  ·                      
-         |                          ·          ··           · ·                           
-    -3.5 |                           ·           ··     ·              ·                  
+     3.6 |                                                                                
+         |                               ·  ·            ·                                
+         |                           ····    · ·   ·       ··  ··                         
+         |         ·             ·  · ··· ·· ··· ··  ·  ···       ··                      
+         |          · ·     ··  ·  ····· ············· · ·· ···      ·          ·         
+     1.9 |             ··   · ··································  · · ·· ·                
+         |            ·· ·   ·········································· ·    ·    ·       
+         |         ·  · ·· ········································ ·· ·  ·               
+         |  · ·    ·· ···················∘·∘····∘∘······················ · ··            ·
+         |         · · ················∘·····∘∘○∘∘∘·∘∘·∘····················              
+     0.1 |     · ··· ·· ···········∘···∘∘∘∘∘·∘∘∘○∘∘∘∘∘∘·∘∘·∘············· ·····  ·    ·   
+         |       ·  · ················∘∘∘∘∘∘∘∘∘∘○∘∘∘∘∘∘∘∘················  ·              
+         |    ·   ····················∘∘∘∘∘∘∘∘∘∘∘∘··∘∘∘∘······················     ·     ·
+         |         ···················∘·∘∘∘∘∘∘∘∘∘∘∘∘··∘·∘················ ··· ··          
+         |·       ························∘··∘·∘·∘······················ · ·              
+    -1.6 |      ·    · ···· ··············································· · ·           
+         |               · · ···································· ···· ·· ··              
+         |               ·   ···  ···· ························ ···  ·  ···               
+         |             ·    ····  · ·· ······· ·······  · ·· · ·  ·                       
+         |             · ·        ···  ·      ·· ·····  ··    ·    ·    ·                 
+    -3.3 |                          ·   ·    ·   ·     ·                                  
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        -4.2     -3.3     -2.4     -1.5     -0.6     0.3      1.2      2.1      3.0   
+       -3.71    -2.82    -1.93    -1.04    -0.15     0.74     1.63     2.52     3.41  
 ```
 
-Finally, we can use `flatMap` to create two parameters that *are* related to each other.
-In particular, we'll create a new parameter `z` that we believe to be very close to `x`:
-its prior is a `Normal` centered on `x` with a very small standard deviation.
-We'll then make a 2D plot of `(x,z)` to see the relationship.
+Finally, we can use `flatMap` to create two parameters that *are* related to each other. In particular, we'll create a new parameter `z` that we believe to be very close to `x`: its prior is a `Normal` centered on `x` with a very small standard deviation. We'll then make a 2D plot of `(x,z)` to see the relationship.
 
 ```scala
 scala> val z = x.flatMap{a => Normal(a, 0.1).param}
-z: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@3fc07927
+z: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@37cb600f
 
 scala> val xz = x.zip(z)
-xz: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@34d0e441
+xz: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@3dad549f
 
 scala> plot2D(xz.sample())
-     4.2 |                                                                                
+     4.1 |                                                                                
          |                                                                             · ·
-         |                                                                        ·       
-         |                                                                   ····         
-         |                                                              ······            
-     2.0 |                                                          ········              
-         |                                                      ········                  
-         |                                                · ·········                     
-         |                                             ···∘∘∘····                         
-         |                                         ···∘○∘∘···                             
-    -0.1 |                                     ···○○∘∘···                                 
-         |                               · ···∘○○∘···                                     
-         |                             ···∘∘∘∘···                                         
-         |                          ···∘∘····                                             
-         |                      ·········                                                 
-    -2.3 |                  ········                                                      
-         |               ········                                                         
-         |            ······                                                              
-         |          · ·                                                                   
-         |                                                                                
-    -4.5 |·                                                                               
+         |                                                                         ··     
+         |                                                                     ·····      
+         |                                                              ·········         
+     2.1 |                                                           ·········            
+         |                                                      ·········                 
+         |                                                 · ········                     
+         |                                             ····∘∘∘···                         
+         |                                          ··∘∘∘∘····                            
+     0.1 |                                      ··∘○○∘∘···                                
+         |                                 ···∘○○∘∘···                                    
+         |                             ···∘○○∘···                                         
+         |                          ···∘∘∘···                                             
+         |                      ··········                                                
+    -1.9 |                 ··········                                                     
+         |              ········                                                          
+         |          ·······                                                               
+         |       ······                                                                   
+         |   ··  ··                                                                       
+    -3.9 |···                                                                             
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        -4.5     -3.5     -2.5     -1.5     -0.6     0.4      1.4      2.4      3.3   
+       -3.79    -2.93    -2.06    -1.19    -0.32     0.54     1.41     2.28     3.15  
 ```
 
-You can see that although we still sample from the full range of `x` values,
-for any given sample, `x` and `z` are quite close to each other.
+You can see that although we still sample from the full range of `x` values, for any given sample, `x` and `z` are quite close to each other.
 
-A note about the `Real` type: you may have noticed that, for example,
-`x` is a `RandomVariable[Real]` or that `normal.mean` was a `Real`. What's that?
-`Real` is a special numeric type used by Rainier to represent your model's parameter values,
-and any values derived from those parameters (if you do arithmetic on a `Real`, you get back another `Real`).
-It's also the type that all the distribution objects like `Normal` expect to be parameterized with,
-so that you can chain things together like we did for `z` -
-though you can also use regular `Int` or `Double` values here and they'll get wrapped automatically.
-`Real` is, by design, an extremely restricted type:
-it only supports the 4 basic arithmetic operations, `log`, and `exp`.
-Restricting it in this way helps keep Rainier models as efficient to perform inference on as possible.
-At sampling time, however, any `Real` outputs are converted to `Double` so that you can work with them from there.
+A note about the `Real` type: you may have noticed that, for example, `x` is a `RandomVariable[Real]` or that `normal.mean` was a `Real`. What's that? `Real` is a special numeric type used by Rainier to represent your model's parameter values, and any values derived from those parameters (if you do arithmetic on a `Real`, you get back another `Real`). It's also the type that all the distribution objects like `Normal` expect to be parameterized with, so that you can chain things together like we did for `z` - though you can also use regular `Int` or `Double` values here and they'll get wrapped automatically. `Real` is, by design, an extremely restricted type: it only supports the 4 basic arithmetic operations, `log`, and `exp`. Restricting it in this way helps keep Rainier models as efficient to perform inference on as possible. At sampling time, however, any `Real` outputs are converted to `Double` so that you can work with them from there.
 
 ## `fit`
 
-Just like every Rainier model has one more more parameters with priors,
-every Rainier model uses some observational data to update our belief about
-the values of those parameters (again, if your model doesn't have this, you're probably using the wrong library).
+Just like every Rainier model has one more more parameters with priors, every Rainier model uses some observational data to update our belief about the values of those parameters (again, if your model doesn't have this, you're probably using the wrong library).
 
-Let's say that we have some data that represents the last week's worth of sales
-on a website, at (we believe) a constant daily rate, and we'd like to know
-how many sales we might get tomorrow.
-Here's our data:
+Let's say that we have some data that represents the last week's worth of sales on a website, at (we believe) a constant daily rate, and we'd like to know how many sales we might get tomorrow. Here's our data:
 
 ```scala
 val sales = List(4, 4, 7, 11, 8, 12, 10)
 ```
 
-We can model the number of sales we get on each day as a Poisson distribution
-parameterized by the underlying rate.
-Looking at the data, we might guess that it came from a `Poisson(9)` or `Poisson(10)`.
-In Rainier, we define our model and it fit to the observed data.
-Since we want our rate to be a positive number,
-and expect it to be more likely to be on the small side than the large side,
-the log-normal parameter we created earlier as `e_x` seems like a reasonable choice.
-We use `flatMap` to chain the creation of the parameter with the creation and
-fit of the `Poisson` distribution.
-Although we _can_ do this with explicit `flatMaps` and `maps`,
-it's much neater with `for{...}` syntax.
+We can model the number of sales we get on each day as a Poisson distribution parameterized by the underlying rate. Looking at the data, we might guess that it came from a `Poisson(9)` or `Poisson(10)`. In Rainier, we define our model and it fit to the observed data. Since we want our rate to be a positive number, and expect it to be more likely to be on the small side than the large side, the log-normal parameter we created earlier as `e_x` seems like a reasonable choice. We use `flatMap` to chain the creation of the parameter with the creation and fit of the `Poisson` distribution. Although we _can_ do this with explicit `flatMaps` and `maps`, it's much neater with `for{...}` syntax.
 
 ```scala
 scala> val rate = for {
      |     r <- e_x
      |     poisson <- Poisson(r).fit(sales)
      | } yield r
-rate: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@3086889e
+rate: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@51d5e4b2
 ```
 
-This is our first "full" model: we have a parameter with a log-normal prior bundled into the `RandomVariable` named `e_x`;
-we use that parameter to initialize a `Poisson` noise distribution which we fit to our observations;
-and at the end, we output the same parameter (referenced by `r`) as the quantity we're interested in sampling from the posterior.
+This is our first "full" model: we have a parameter with a log-normal prior bundled into the `RandomVariable` named `e_x`; we use that parameter to initialize a `Poisson` noise distribution which we fit to our observations; and at the end, we output the same parameter (referenced by `r`) as the quantity we're interested in sampling from the posterior.
 
 Let's plot the results!
 
 ```scala
 scala> plot1D(rate.sample())
-     350 |                                                                                
-         |                        ∘      ·                                                
-         |                       ·○· ·   ○   ·                                            
-         |                       ○○○○○··∘○ ○ ○                                            
-         |                      ○○○○○○○○○○○○∘○ ∘                                          
-     260 |                     ·○○○○○○○○○○○○○○ ○·                                         
-         |                    ·○○○○○○○○○○○○○○○ ○○·                                        
-         |                  · ○○○○○○○○○○○○○○○○ ○○○                                        
-         |                  ○·○○○○○○○○○○○○○○○○○○○○·                                       
-         |                 ·○○○○○○○○○○○○○○○○○○○○○○○○                                      
-     170 |               ○ ○○○○○○○○○○○○○○○○○○○○○○○○○                                      
-         |              ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                                     
-         |              ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                                   
-         |              ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○ ·                                 
-         |            ··○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○·                                
-      80 |          · ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○· ·                             
-         |         ○○∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○ ○                           
-         |       ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○·∘                         
-         |   · ··○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○ ∘·                      
-         |  ·○·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○○∘∘··  ∘               
-       0 |∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘∘···∘· ····· ·
+     420 |                                                                                
+         |                               ∘  ∘                                             
+         |                          ∘   ○○  ○                                             
+         |                         ·○∘  ○○·∘○                                             
+         |                         ○○○○∘○○○○○                                             
+     320 |                         ○○○○○○○○○○○○                                           
+         |                      ·  ○○○○○○○○○○○○                                           
+         |                      ○  ○○○○○○○○○○○○ ∘∘                                        
+         |                     ○○○○○○○○○○○○○○○○○○○·                                       
+         |                    ○○○○○○○○○○○○○○○○○○○○○                                       
+     210 |                    ○○○○○○○○○○○○○○○○○○○○○·                                      
+         |                  ·∘○○○○○○○○○○○○○○○○○○○○○○·                                     
+         |                  ○○○○○○○○○○○○○○○○○○○○○○○○○∘                                    
+         |                 ∘○○○○○○○○○○○○○○○○○○○○○○○○○○                                    
+         |                 ○○○○○○○○○○○○○○○○○○○○○○○○○○○○                                   
+     100 |               ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘∘                               
+         |              ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○ ·                             
+         |             ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                             
+         |          ···○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·                           
+         |   ·     ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘∘·∘                       
+       0 |∘ ·○∘∘○∘∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○○··∘···· · · ···  · ·
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        5.03     5.82     6.60     7.39     8.17     8.96     9.74    10.53    11.31  
+        4.4      5.3      6.3      7.2      8.2      9.1      10.0     11.0     11.9  
 ```
 
-Looks like our daily rate is probably somewhere between 6 and 9,
-and is in fact much more likely to be around 9 than 10.
+Looks like our daily rate is probably somewhere between 6 and 9, and is in fact much more likely to be around 9 than 10.
 
 ## A mathematical digression
 
 Please feel free to skip this section if it's not helping you.
 
-One thing that sometimes confuses people at this stage is,
-what is the line with `fit` actually doing?
-It seems to return some value `poisson` that we just ignore.
-(That object, by the way, is just the `Poisson(r)` distribution object that we used
-to do the `fit`.)
-And yet the line is clearly doing something, because sampling from `rate` gives quite different results from just sampling directly from `e_x`.
+One thing that sometimes confuses people at this stage is, what is the line with `fit` actually doing? It seems to return some value `poisson` that we just ignore. (That object, by the way, is just the `Poisson(r)` distribution object that we used to do the `fit`.) And yet the line is clearly doing something, because sampling from `rate` gives quite different results from just sampling directly from `e_x`.
 
-The key is to remember that a `RandomVariable` has two parts: a `value` and a `density`.
-Mathematically, you should think of these as two different *functions* of the same latent parameter space `Q`.
-That is, you should think of `value` as being some deterministic function `f = F(q)`,
-and `density` as being the (unnormalized) probability function `P(Q=q)`.
+The key is to remember that a `RandomVariable` has two parts: a `value` and a `density`. Mathematically, you should think of these as two different *functions* of the same latent parameter space `Q`. That is, you should think of `value` as being some deterministic function `f = F(q)`, and `density` as being the (unnormalized) probability function `P(Q=q)`.
 
-When we `map` or `flatMap` a `RandomVariable` (whether explicitly or inside a `for` construct),
-the object we see and work with (like, the `r` above) is the `value` object.
-And we can see in the definition of `rate` that it's just passing that value object through to the end;
-it should end up with the same `value` function as the prior, `e_x`. And indeed, it does:
+When we `map` or `flatMap` a `RandomVariable` (whether explicitly or inside a `for` construct), the object we see and work with (like, the `r` above) is the `value` object. And we can see in the definition of `rate` that it's just passing that value object through to the end; it should end up with the same `value` function as the prior, `e_x`. And indeed, it does:
 
 ```scala
 scala> e_x.value == rate.value
@@ -351,33 +279,18 @@ res7: Boolean = true
 
 So, for the same input in the latent parameter space, `e_x` and `rate` will produce the same output.
 
-However, when we `flatMap`, behind the scenes we're also working with the `density` object.
-Specifically, when we start with one `RandomVariable` (like `e_x`),
-and use `flatMap` to flatten another `RandomVariable` into it (like the result of `fit`),
-the resulting `RandomVariable` (like `rate`) will have a `density` that *combines*
-the densities of the other two `RandomVariable`s.
-Put another way, `flatMap` is the Bayesian update operation:
-you're putting in a prior, coming up with a likelihood, and getting back the posterior.
-That's what the `fit` line is doing: constructing a likelihood function that we can incorporate into our posterior density.
-And if we look at the densities, we'll see that they are indeed different:
+However, when we `flatMap`, behind the scenes we're also working with the `density` object. Specifically, when we start with one `RandomVariable` (like `e_x`), and use `flatMap` to flatten another `RandomVariable` into it (like the result of `fit`), the resulting `RandomVariable` (like `rate`) will have a `density` that *combines* the densities of the other two `RandomVariable`s. Put another way, `flatMap` is the Bayesian update operation: you're putting in a prior, coming up with a likelihood, and getting back the posterior. That's what the `fit` line is doing: constructing a likelihood function that we can incorporate into our posterior density. And if we look at the densities, we'll see that they are indeed different:
 
 ```scala
 scala> e_x.density == rate.density
 res8: Boolean = false
 ```
 
-So although `F(q)` has not changed, `P(Q=q)` *has* changed;
-which means that `P(F(q)=f)` has also changed, and it's that change which we're observing
-when we see that sampling values of `F` produces different results in the two cases.
+So although `F(q)` has not changed, `P(Q=q)` *has* changed; which means that `P(F(q)=f)` has also changed, and it's that change which we're observing when we see that sampling values of `F` produces different results in the two cases.
 
 ## `generator` and `Generator`
 
-Sampling from the rate parameter is nice, but what we originally said is that
-we wanted to predict how many sales to expect tomorrow.
-As we just discussed in the digression, we got a `poisson` value back from `fit` but didn't do anything with it.
-This value is just the distribution we used for the `fit`, that is, `Poisson(r)`.
-Now, instead of fitting data *to* that distribution, we want to generate data *from* that distribution.
-One idea might be to do that with `param`, that is, with something like this:
+Sampling from the rate parameter is nice, but what we originally said is that we wanted to predict how many sales to expect tomorrow. As we just discussed in the digression, we got a `poisson` value back from `fit` but didn't do anything with it. This value is just the distribution we used for the `fit`, that is, `Poisson(r)`. Now, instead of fitting data *to* that distribution, we want to generate data *from* that distribution. One idea might be to do that with `param`, that is, with something like this:
 
 ```scala
 //This code won't compile
@@ -388,18 +301,10 @@ for {
 } yield prediction
 ```
 
-This has a couple of problems.
-First, it seems conceptually wrong to think of a prediction as a parameter:
-there is no true value of "how many sales will we have tomorrow" for us to infer,
-and we have no observational data that can influence our belief about its value;
-once we've derived the rate parameter, the prediction is purely generative.
-Second, as a practical matter, Rainier only supports continuous parameters,and
-here we need to generate discrete values, so `poisson.param` won't, in fact, compile.
+This has a couple of problems. First, it seems conceptually wrong to think of a prediction as a parameter: there is no true value of "how many sales will we have tomorrow" for us to infer, and we have no observational data that can influence our belief about its value; once we've derived the rate parameter, the prediction is purely generative.
+Second, as a practical matter, Rainier only supports continuous parameters,and here we need to generate discrete values, so `poisson.param` won't, in fact, compile.
 
-Luckily, all distributions, continious or discrete, implement `generator`,
-which gives us what we need: a way to randomly generate new values from a distribution as part of the sampling process.
-Every `Distribution[T]` can give us a `Generator[T]`, and if we sample from a `RandomVariable[Generator[T]]`,
-we will get values of type `T`.
+Luckily, all distributions, continious or discrete, implement `generator`, which gives us what we need: a way to randomly generate new values from a distribution as part of the sampling process. Every `Distribution[T]` can give us a `Generator[T]`, and if we sample from a `RandomVariable[Generator[T]]`, we will get values of type `T`.
 (You can think of `Real` as being a special case that acts in this sense like a `Generator[Double]`).
 
 Here's one way we could implement what we're looking for:
@@ -409,53 +314,47 @@ scala> val prediction = for {
      |     r <- e_x
      |     poisson <- Poisson(r).fit(sales)
      | } yield poisson.generator
-prediction: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@2c7c57f8
+prediction: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@62a7b39a
 ```
 
-This is almost the same model as `rate` above,
-but instead of taking the real-valued `r` rate parameter as the output,
-we're producing poisson-distributed integers.
-The samples look like this:
+This is almost the same model as `rate` above, but instead of taking the real-valued `r` rate parameter as the output, we're producing poisson-distributed integers. The samples look like this:
 
 ```scala
 scala> prediction.sample()
-res9: List[Int] = List(12, 6, 7, 7, 8, 8, 4, 6, 10, 5, 8, 17, 10, 8, 5, 5, 10, 10, 6, 5, 12, 7, 7, 6, 6, 8, 9, 15, 10, 6, 10, 4, 9, 6, 11, 12, 8, 9, 6, 5, 6, 10, 1, 10, 8, 4, 12, 8, 6, 3, 6, 10, 4, 10, 9, 15, 6, 4, 8, 8, 11, 6, 6, 5, 6, 5, 6, 7, 10, 3, 9, 6, 10, 8, 14, 7, 10, 4, 6, 7, 6, 10, 5, 7, 7, 10, 10, 8, 7, 8, 11, 9, 6, 9, 7, 10, 14, 8, 3, 2, 15, 8, 10, 11, 10, 7, 13, 2, 7, 10, 12, 9, 10, 6, 11, 14, 7, 10, 7, 7, 11, 7, 10, 7, 3, 7, 5, 7, 6, 12, 9, 10, 7, 10, 7, 6, 10, 7, 7, 9, 9, 4, 5, 9, 7, 6, 6, 5, 9, 7, 5, 7, 5, 9, 6, 9, 4, 8, 8, 7, 7, 7, 6, 9, 5, 13, 6, 5, 12, 10, 3, 5, 9, 9, 5, 15, 9, 8, 5, 10, 4, 8, 7, 9, 6, 8, 9, 7, 6, 9, 4, 9, 7, 6, 10, 5, 15, 12, 6, 4, 6, 8, 13, 5, 12, 9, 7, 7, 9, 7, 8, 8, 10, 8, 11, 7, 7, 8, 13, 6, 5, 12, 9, 5, 7, 8, 6, 6, 4, 4...
+res9: List[Int] = List(6, 3, 9, 5, 6, 9, 13, 7, 4, 12, 7, 9, 1, 8, 12, 10, 6, 13, 9, 12, 12, 6, 8, 9, 8, 8, 5, 4, 15, 11, 10, 10, 6, 5, 15, 9, 9, 6, 13, 8, 13, 4, 5, 3, 6, 14, 14, 11, 16, 14, 9, 9, 8, 7, 10, 7, 10, 9, 5, 4, 8, 8, 9, 11, 7, 6, 13, 9, 6, 8, 8, 4, 7, 8, 7, 18, 10, 6, 3, 6, 1, 5, 7, 6, 6, 8, 6, 9, 12, 7, 8, 4, 9, 8, 10, 9, 10, 5, 10, 6, 10, 5, 10, 7, 7, 7, 4, 10, 9, 13, 14, 7, 8, 8, 5, 5, 4, 4, 9, 7, 7, 9, 8, 9, 10, 11, 8, 10, 9, 5, 13, 7, 10, 7, 10, 5, 11, 7, 8, 7, 5, 5, 5, 6, 15, 5, 13, 7, 6, 4, 6, 12, 7, 11, 5, 9, 6, 11, 10, 6, 5, 11, 4, 5, 5, 8, 5, 7, 6, 4, 5, 7, 8, 7, 14, 12, 10, 7, 6, 9, 4, 10, 4, 11, 7, 9, 5, 4, 9, 7, 10, 11, 8, 7, 8, 15, 8, 4, 4, 7, 12, 7, 5, 7, 8, 6, 9, 4, 2, 13, 8, 12, 4, 12, 11, 11, 4, 5, 3, 6, 7, 9, 17, 4, 3, 8, 6, 9, 5...
 ```
 Or, if we plot them, like this:
 
 ```scala
 scala> plot1D(prediction.sample())
-    1380 |                                                                                
-         |                         ○                                                      
-         |                     ∘   ○  ∘                                                   
-         |                     ○   ○  ○                                                   
-         |                     ○   ○  ○   ·                                               
-    1040 |                     ○   ○  ○   ○                                               
-         |                  ∘  ○   ○  ○   ○                                               
-         |                  ○  ○   ○  ○   ○                                               
-         |                  ○  ○   ○  ○   ○   ○                                           
-         |                  ○  ○   ○  ○   ○   ○                                           
-     690 |              ○   ○  ○   ○  ○   ○   ○                                           
-         |              ○   ○  ○   ○  ○   ○   ○                                           
-         |              ○   ○  ○   ○  ○   ○   ○  ○                                        
-         |              ○   ○  ○   ○  ○   ○   ○  ○                                        
-         |              ○   ○  ○   ○  ○   ○   ○  ○                                        
-     340 |          ·   ○   ○  ○   ○  ○   ○   ○  ○   ○                                    
-         |          ○   ○   ○  ○   ○  ○   ○   ○  ○   ○                                    
-         |          ○   ○   ○  ○   ○  ○   ○   ○  ○   ○   ○                                
-         |       ·  ○   ○   ○  ○   ○  ○   ○   ○  ○   ○   ○  ∘                             
-         |       ○  ○   ○   ○  ○   ○  ○   ○   ○  ○   ○   ○  ○   ∘                         
-       0 |·  ∘   ○  ○   ○   ○  ○   ○  ○   ○   ○  ○   ○   ○  ○   ○  ∘   ·   ·  ·   ·   ·  ·
+    1300 |                                                                                
+         |                   ∘  ○  ·                                                      
+         |                   ○  ○  ○                                                      
+         |                   ○  ○  ○  ·                                                   
+         |               ○   ○  ○  ○  ○                                                   
+     970 |               ○   ○  ○  ○  ○                                                   
+         |               ○   ○  ○  ○  ○                                                   
+         |               ○   ○  ○  ○  ○  ·                                                
+         |               ○   ○  ○  ○  ○  ○                                                
+         |               ○   ○  ○  ○  ○  ○                                                
+     650 |            ∘  ○   ○  ○  ○  ○  ○   ○                                            
+         |            ○  ○   ○  ○  ○  ○  ○   ○                                            
+         |            ○  ○   ○  ○  ○  ○  ○   ○                                            
+         |            ○  ○   ○  ○  ○  ○  ○   ○                                            
+         |         ·  ○  ○   ○  ○  ○  ○  ○   ○  ·                                         
+     320 |         ○  ○  ○   ○  ○  ○  ○  ○   ○  ○                                         
+         |         ○  ○  ○   ○  ○  ○  ○  ○   ○  ○  ·                                      
+         |         ○  ○  ○   ○  ○  ○  ○  ○   ○  ○  ○  ·                                   
+         |      ○  ○  ○  ○   ○  ○  ○  ○  ○   ○  ○  ○  ○                                   
+         |      ○  ○  ○  ○   ○  ○  ○  ○  ○   ○  ○  ○  ○  ∘                                
+       0 |·  ○  ○  ○  ○  ○   ○  ○  ○  ○  ○   ○  ○  ○  ○  ○  ∘   ·  ·  ·  ·               ·
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        0.0      2.5      5.0      7.5      9.9      12.4     14.9     17.4     19.9  
+        0.0      2.8      5.6      8.5      11.3     14.1     16.9     19.8     22.6  
 ```
 
 ## `Likelihood` and `Predictor`
 
-What if, instead of assuming that our website's sales are constant over time,
-we assume that they're growing at a constant rate?
-We might have data like the following, organized in (day, sales) pairs.
-(You may recognize this data from the start of the tour.)
+What if, instead of assuming that our website's sales are constant over time, we assume that they're growing at a constant rate? We might have data like the following, organized in (day, sales) pairs. (You may recognize this data from the start of the tour.)
 
 ```scala
 scala> val data =  List((0,8), (1,12), (2,16), (3,20), (4,21), (5,31), (6,23), (7,33), (8,31), (9,33), (10,36), (11,42), (12,39), (13,56), (14,55), (15,63), (16,52), (17,66), (18,52), (19,80), (20,71))
@@ -491,25 +390,17 @@ scala> plot2D(data)
         0.0      2.3      4.5      6.8      9.0      11.3     13.6     15.8     18.1  
 ```
 
-How should we model this? We'll need to know what the rate was on day 0 (the intercept),
-as well as how fast the rate increases each day (the slope).
-We know they're both positive and not too large, so let's keep using log-normal priors.
-(This time we can just use the builtin `LogNormal` instead of deriving it ourselves).
+How should we model this? We'll need to know what the rate was on day 0 (the intercept), as well as how fast the rate increases each day (the slope). We know they're both positive and not too large, so let's keep using log-normal priors. (This time we can just use the builtin `LogNormal` instead of deriving it ourselves).
 
 ```scala
 scala> val prior = for {
      |     slope <- LogNormal(0,1).param
      |     intercept <- LogNormal(0,1).param
      |     } yield (slope, intercept)
-prior: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@13217c9e
+prior: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@396cbb56
 ```
 
-Now, for any given day `i`, we want to check the number of sales against `Poisson(intercept + slope*i)`.
-We could write some kind of recursive flatMap to build and fit each of these different distribution objects in turn,
-but this is a common enough pattern that Rainier already has something built in for it: `Predictor`.
-`Predictor` is not a `Distribution`, but instead wraps a function from `X => Distribution[Y]` for some `(X,Y)`;
-you can use this any time you have a dependent variable of type `Y` that you're modeling
-with some independent variables jointly represented as `X`.
+Now, for any given day `i`, we want to check the number of sales against `Poisson(intercept + slope*i)`. We could write some kind of recursive flatMap to build and fit each of these different distribution objects in turn, but this is a common enough pattern that Rainier already has something built in for it: `Predictor`. `Predictor` is not a `Distribution`, but instead wraps a function from `X => Distribution[Y]` for some `(X,Y)`; you can use this any time you have a dependent variable of type `Y` that you're modeling with some independent variables jointly represented as `X`.
 
 Like `Distribution`, `Predictor` implements `fit` (in fact, they both extend the `Likelihood` trait which provides that method). So we can extend the previous model to create and use a `Predictor` like this:
 
@@ -520,46 +411,40 @@ scala> val regr = for {
      |                     Poisson(intercept + slope*i)
      |                 }.fit(data)
      | } yield (slope, intercept)
-regr: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@14b8a978
+regr: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@7c232f2
 ```
 
-As before, we're starting out by just sampling the parameters.
-By plotting them, we can see that the model's confidence in the intercept, in particular, is pretty low:
-although it's most likely to be somewhere around 8, it could be anywhere from 3 to 13 or even higher.
-Second, as you'd hope, the two parameters are anti-correlated:
+As before, we're starting out by just sampling the parameters. By plotting them, we can see that the model's confidence in the intercept, in particular, is pretty low: although it's most likely to be somewhere around 8, it could be anywhere from 3 to 13 or even higher. Second, as you'd hope, the two parameters are anti-correlated:
 a smaller intercept would imply a higher slope, and vice versa.
 
 ```scala
 scala> plot2D(regr.sample())
-    15.2 |                                                                                
-         |        ·      · ·                                                              
-         |·  · ·   ·    ·   ·· ··                                                         
-         |             ·   ·········   · ··                                               
-         |            · ·············· · ·· ··· ·    ·                                    
-    12.2 |             · ·· ················· ·  ·   ·                                    
-         |         · ·  ···························· ·    ·                               
-         |               ·······························  ···                             
-         |        ·      · ···················∘············· ··                           
-         |              ·   ···········∘·····∘∘∘∘∘·∘∘··········· ··   ·  ·                
-     9.1 |           ·        ············∘·∘∘∘∘∘∘∘∘∘∘∘∘·············· ·                  
-         |                      · ··········∘∘∘∘∘∘○○○∘∘∘∘∘∘············ ·· ··             
-         |                            ·········∘∘∘∘○○○∘∘∘○○∘∘··∘········· ···· ·  ·       
-         |                          ·· ·········∘·∘∘∘∘○○○○○○○∘∘∘∘∘············ ·· ·       
-         |                             ··············∘∘∘∘○·○○∘○○○∘·∘·∘············       ·
-     6.1 |                                  ·  ···········∘∘∘∘∘∘∘∘·∘∘·∘···········  ·· ·  
-         |                                    ··  ··············∘···················· ·   
-         |                                         ··· ··· ····················· ······· ·
-         |                                      ·     ··    ························  ··· 
-         |                                                ·  ··· ·   ·· ······ ·· ··· ·   
-     3.0 |                                                             ·  · ·  ·     ··   
+    16.0 |                                                                                
+         |     ·            ·                                                             
+         |·             ·            ·                                                    
+         |      ··   ·  ·     ·  ·                                                        
+         |      ··  ··     ·   · ·  ·· ·                                                  
+    12.6 |  ·   · ·· ·  ············· ·   ·                                               
+         |·   ···  · ··················· ·····  · ··                                      
+         |          ·· ···························· ··                                    
+         |         ·  ································· ·    ··   ·                       
+         |      ·    ···· ·············∘·∘·∘···················· ·  ·                     
+     9.3 |          ·  ·· ············∘∘∘∘∘∘∘∘·∘∘·∘∘··············· ·····                 
+         |               · ··············∘∘∘∘○∘∘∘∘∘∘∘∘∘∘··············· ····              
+         |              · ·  ·············∘∘∘∘∘○○○○○○∘○∘∘∘∘∘··············· · ·· ·        
+         |                       · ··········∘·∘∘∘○∘○○∘∘○○∘∘∘∘∘·············  · ··        
+         |                          ··············∘∘∘∘∘∘∘∘∘∘∘○∘∘∘∘············ ··  ·      
+     5.9 |                         · · ··· ············∘∘·∘∘∘∘∘∘∘∘················ ·     ·
+         |                          ·     ·· ·   ······························· ··· ·    
+         |                                   ·      ································· · · 
+         |                                               ·· ···· ················· ·· ·  ·
+         |                                                   ·  ····  ·    ····     ···  ·
+     2.5 |                                                                 ··       ·     
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        2.31     2.48     2.65     2.82     2.99     3.16     3.32     3.49     3.66  
+        2.42     2.58     2.74     2.90     3.06     3.22     3.38     3.55     3.71  
 ```
 
-Alternatively, as in the earlier example, we could try to predict what will happen tomorrow.
-This is similar to calling `poisson.generator` before, but this time, we use the `predict` method on `Predictor`,
-which takes the covariate (the day, in this case), and returns a `Generator` for the dependent variable (the number of sales).
-Putting it all together, it looks like this:
+Alternatively, as in the earlier example, we could try to predict what will happen tomorrow. This is similar to calling `poisson.generator` before, but this time, we use the `predict` method on `Predictor`, which takes the covariate (the day, in this case), and returns a `Generator` for the dependent variable (the number of sales). Putting it all together, it looks like this:
 
 ```scala
 scala> val regr2 = for {
@@ -569,57 +454,46 @@ scala> val regr2 = for {
      |                     Poisson(intercept + slope*i)
      |                 }.fit(data)
      | } yield predictor.predict(21)
-regr2: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@6e07d752
+regr2: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@6eb4c88b
 ```
 
-Plotting this gives us a prediction which incorporates both the natural noise of a Poisson distribution
-and our uncertainty about its underlying parameterization.
+Plotting this gives us a prediction which incorporates both the natural noise of a Poisson distribution and our uncertainty about its underlying parameterization.
 
 ```scala
 scala> plot1D(regr2.sample())
      440 |                                                                                
-         |                                  ·∘ ∘ · ·                                      
-         |                                  ○○·○○○ ○·                                     
-         |                               ∘  ○○○○○○ ○○·                                    
-         |                               ○ ○○○○○○○ ○○○∘                                   
-     330 |                             · ○ ○○○○○○○ ○○○○                                   
-         |                             ○○○ ○○○○○○○ ○○○○○                                  
-         |                             ○○○ ○○○○○○○ ○○○○○○                                 
-         |                           ∘·○○○ ○○○○○○○ ○○○○○○·                                
-         |                          ·○○○○○ ○○○○○○○ ○○○○○○○ ·                              
-     220 |                          ○○○○○○ ○○○○○○○ ○○○○○○○ ○·                             
-         |                         ∘○○○○○○ ○○○○○○○ ○○○○○○○ ○○                             
-         |                       ∘ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○                             
-         |                       ○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○∘○                           
-         |                      ∘○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○∘                         
-     110 |                     ·○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○                         
-         |                    ∘○○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○∘ ·                      
-         |                   ○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○·                     
-         |               · ·○○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○∘·                   
-         |             ∘∘○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○○○∘∘                 
-       0 |·  ····  ·∘∘∘○○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○∘○∘··· ·  · ··
+         |                                 ∘∘∘   ·                                        
+         |                               ·○○○○ ○○○                                        
+         |                               ○○○○○ ○○○ ·∘                                     
+         |                              ∘○○○○○ ○○○∘○○                                     
+     330 |                            ∘ ○○○○○○ ○○○○○○                                     
+         |                            ○ ○○○○○○ ○○○○○○                                     
+         |                          ∘∘○ ○○○○○○ ○○○○○○○ ·                                  
+         |                         ·○○○ ○○○○○○ ○○○○○○○ ○∘∘                                
+         |                         ○○○○ ○○○○○○ ○○○○○○○ ○○○                                
+     220 |                        ·○○○○ ○○○○○○ ○○○○○○○ ○○○                                
+         |                       ○○○○○○ ○○○○○○ ○○○○○○○ ○○○○                               
+         |                     · ○○○○○○ ○○○○○○ ○○○○○○○ ○○○○ ∘                             
+         |                     ○ ○○○○○○ ○○○○○○ ○○○○○○○ ○○○○○○                             
+         |                    ∘○ ○○○○○○ ○○○○○○ ○○○○○○○ ○○○○○○ ∘                           
+     110 |                    ○○ ○○○○○○ ○○○○○○ ○○○○○○○ ○○○○○○ ○○·                         
+         |                 ·∘○○○ ○○○○○○ ○○○○○○ ○○○○○○○ ○○○○○○ ○○○                         
+         |                 ○○○○○ ○○○○○○ ○○○○○○ ○○○○○○○ ○○○○○○ ○○○○··                      
+         |               ○○○○○○○ ○○○○○○ ○○○○○○ ○○○○○○○ ○○○○○○ ○○○○○○ ○                    
+         |           ··∘ ○○○○○○○ ○○○○○○ ○○○○○○ ○○○○○○○ ○○○○○○ ○○○○○○ ○○·∘                 
+       0 |······· ∘∘○○○○ ○○○○○○○ ○○○○○○ ○○○○○○ ○○○○○○○ ○○○○○○ ○○○○○○ ○○○○○○∘ ·∘··∘·   ····
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        41.0     48.9     56.8     64.7     72.5     80.4     88.3     96.2    104.1  
+        43.0     50.8     58.5     66.3     74.1     81.9     89.6     97.4    105.2  
 ```
 
-Finally, let's close with a small and somewhat contrived example of a hierarchical model,
-where we have two separate regressions that share a parameter.
-For the sake of the example, let's assume that we have a second sales dataset,
-much like the first, where we know they had the same rate at the start of the observations,
-but may have grown at different rates - so their intercepts will be equal but their slopes will not.
-Here's the data:
+Finally, let's close with a small and somewhat contrived example of a hierarchical model, where we have two separate regressions that share a parameter. For the sake of the example, let's assume that we have a second sales dataset, much like the first, where we know they had the same rate at the start of the observations, but may have grown at different rates - so their intercepts will be equal but their slopes will not. Here's the data:
 
 ```scala
 scala> val data2 = List((0,9), (1,2), (2,3), (3,17), (4,21), (5,12), (6,21), (7,19), (8,21), (9,18), (10,25), (11,27), (12,33), (13,23), (14,28), (15,45), (16,35), (17,45), (18,47), (19,54), (20,40))
 data2: List[(Int, Int)] = List((0,9), (1,2), (2,3), (3,17), (4,21), (5,12), (6,21), (7,19), (8,21), (9,18), (10,25), (11,27), (12,33), (13,23), (14,28), (15,45), (16,35), (17,45), (18,47), (19,54), (20,40))
 ```
 
-It's straightforward to set up two separate slopes, two separate predictors,
-but the same interecept.
-We'll still just sample the first slope so we can compare to the previous model.
-We _could_ write out the parameters of the models separately and fit each one
-to its respective data, but this is a bit tedious,
-so we can use Rainier's `Lookup` to do it more succinctly.
+It's straightforward to set up two separate slopes, two separate predictors, but the same interecept. We'll still just sample the first slope so we can compare to the previous model. We _could_ write out the parameters of the models separately and fit each one to its respective data, but this is a bit tedious, so we can use Rainier's `Lookup` to do it more succinctly.
 
 ```scala
 scala> val allData = data.map{ case (x,y) => ((0, x), y) } ++ data2.map{ case (x, y) => ((1, x), y) }
@@ -630,55 +504,40 @@ scala> val regr3 = for {
      |   intercept <- LogNormal(0,1).param
      |   _ <- Predictor.from[(Int, Int), Int, (Real, Real), Real]{ case (i,x) => Poisson(intercept + slopes(i) * x) }.fit(allData)
      | } yield (slopes(0), intercept)
-regr3: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@6fa66fd
+regr3: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@765ec043
 ```
-Here, `i` indexes the model and `x` is the x-value of the observation.
-Plotting slope vs intercept now, we can see that,
-even though these are two separate regressions,
-we get tighter bounds than before by letting the new data influence the shared parameter.
-It makes sense that we'd get more confidence on the intercept,
-since we have two different time series to learn from now;
-but because of the anti-correlation, that also leads to somewhat more confidence
-than before on the `slope1` parameter as well.
+Here, `i` indexes the model and `x` is the x-value of the observation. Plotting slope vs intercept now, we can see that, even though these are two separate regressions, we get tighter bounds than before by letting the new data influence the shared parameter. It makes sense that we'd get more confidence on the intercept, since we have two different time series to learn from now; but because of the anti-correlation, that also leads to somewhat more confidence than before on the `slope1` parameter as well.
 
 ```scala
 scala> plot2D(regr3.sample())
-    11.5 |                                                                                
-         |                    ·                                                           
-         |                             ·                                                  
-         |        · ··    ·    ·          ·                                               
-         |     ·  · ·   ·· ·   ·  ··   ·  ·                                               
-     9.4 |·    ·    ·  ··· ···········   · ·  ···        ·                                
-         |   ·     · · ·····················   ··  ··   ·  ··  ·                          
-         |       ···································· ··· ·                               
-         |         ····  ·····································   ·  ·                     
-         |       ··   ··················∘∘∘···∘∘·∘················   ·                    
-     7.3 |          ··············∘···∘∘∘∘∘∘∘∘∘∘∘∘·∘·∘∘∘·············· ··                 
-         |            ·  ·········∘··∘∘∘∘○∘○∘∘○∘○○○∘∘∘∘∘·∘···················             
-         |             ·················∘∘∘∘∘○○○○○○∘○∘∘∘○∘∘∘·∘∘·············· · ·         
-         |               ····· ·········∘·∘∘○∘∘∘○∘○○○○∘∘○○○∘∘∘∘∘∘∘∘··········· ·· · ·     
-         |                     · ·············∘∘∘∘∘○○∘○∘○○∘∘○∘∘∘∘∘∘·················      
-     5.2 |                      ·  ················∘∘∘∘·∘∘∘∘∘∘∘∘·∘·∘·∘·············· · ·  
-         |                         · ·· ····················∘·∘∘····················· ·  ·
-         |                            ···  · ··· ·························· ···· ··  ·    
-         |                                   ·      ·· ····················· · ····  · ·· 
-         |                                 ·          ··· · · ······· ·  · · ·· ·         
-     3.1 |                                                      ·   ·   ·                 
+    11.3 |                                                                                
+         |        ·                                                                       
+         |·                                                                               
+         |         ·        ··  ··                                                        
+         |  · ·    · ·· · ···   ··· · ·· ·    ··                                          
+     9.2 |   ··  ··· · ·······················    ··   ·                                  
+         |      ····· ··· ··················· ····· ·      ·   ·                          
+         |    · ·· ································ ·      ·  ··                          
+         |     ·  ··································· ····· ·       ·                     
+         |        ·   ···············∘·∘∘·∘·∘···················    · ·                   
+     7.2 |        · ···············∘·∘∘∘∘∘∘∘∘∘∘∘·∘···∘···············                     
+         |             ··············∘∘∘∘∘○∘∘∘∘∘○∘∘∘∘················· ·   ·              
+         |          ···· ·· ·········∘·∘∘∘∘∘○∘∘○∘∘∘∘∘∘∘∘∘∘∘∘··············    · ·         
+         |           ·    · ·············∘∘∘∘∘∘∘○○∘∘∘○∘∘∘∘∘∘··············  ·             
+         |               ·  ················∘·∘·∘∘∘∘∘∘∘·∘∘∘∘∘················ ·           
+     5.1 |                ·  ·   ·············∘·····∘···∘∘······················          
+         |                     ·    · ······································ ····  ··    ·
+         |                       ·    ·  · ·· ······························ ··  ·        
+         |                                   · ·· ··················· ·  · ·  · ··  ·     
+         |                                               ··  · ·      ·        ·          
+     3.1 |                                               ·  ···       ·  ·                
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        2.72     2.85     2.97     3.10     3.23     3.36     3.49     3.62     3.75  
+        2.71     2.85     2.99     3.13     3.27     3.41     3.56     3.70     3.84  
 ```
 
 ## Learning More
 
-This tour has focused on the high-level API.
-If you want to understand more about what's going on under the hood,
-you might enjoy reading about [Real](real.md) or checking out some
-[implementation notes](impl.md).
-If you want to learn more about Bayesian modeling in general,
-[Cam Davidson Pilon's book][CDP] is an excellent resource - the examples are in Python,
-but porting them to Rainier is a good learning exercise.
-Over time, we hope to add more Rainier-specific documentation and community resources;
-for now, feel free to file a [GitHub issue][GISSUES] with any questions or problems.
+This tour has focused on the high-level API. If you want to understand more about what's going on under the hood, you might enjoy reading about [Real](real.md) or checking out some [implementation notes](impl.md). If you want to learn more about Bayesian modeling in general, [Cam Davidson Pilon's book][CDP] is an excellent resource - the examples are in Python, but porting them to Rainier is a good learning exercise. Over time, we hope to add more Rainier-specific documentation and community resources; for now, feel free to file a [GitHub issue][GISSUES] with any questions or problems.
 
 [CDP]: http://camdavidsonpilon.github.io/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers/
 [GISSUES]: https://github.com/stripe/rainier/issues

--- a/docs/tour.md
+++ b/docs/tour.md
@@ -1,24 +1,35 @@
 # A Tour of Rainier's Core
 
-Hello! This document will provide a quick tour through the most important parts of Rainier's core. If you'd like to follow along with this tour, `sbt "project rainierCore" console` will get you to a Scala REPL.
+Hello! This document will provide a quick tour through the most important parts of Rainier's core.
+If you'd like to follow along with this tour, `sbt "project rainierCore" console` will get you to a Scala REPL.
 
-The `rainier.core` package defines some key traits like `Distribution`, `RandomVariable`, `Likelihood`, and `Predictor`. Let's import it, along with a `repl` package that gives us some useful utilities.
+The `rainier.core` package defines some key traits like `Distribution`, `RandomVariable`, `Likelihood`, and `Predictor`.
+Let's import it, along with a `repl` package that gives us some useful utilities.
 
 ```scala
 import com.stripe.rainier.core._
 import com.stripe.rainier.repl._
+import com.stripe.rainier.compute._
 ```
 
-Together, those traits let you define bayesian models in Rainier. To throw you a little bit into the deep end, here's a simple linear regression that we'll return to later. This probably won't entirely make sense yet. That's ok. Hopefully it will serve as a bit of a roadmap that put the rest of the tour in context as we build up to it. 
+Together, those traits let you define Bayesian models in Rainier.
+To throw you a little bit into the deep end, here's a simple linear regression that we'll return to later.
+This probably won't entirely make sense yet. That's ok.
+Hopefully it will serve as a bit of a roadmap that put the rest of the tour in context as we build up to it.
 
 ```scala
-val data =  List((0,8), (1,12), (2,16), (3,20), (4,21), (5,31), (6,23), (7,33), (8,31), (9,33), (10,36), (11,42), (12,39), (13,56), (14,55), (15,63), (16,52), (17,66), (18,52), (19,80), (20,71))
+scala> val data =  List((0,8), (1,12), (2,16), (3,20), (4,21), (5,31), (6,23), (7,33), (8,31), (9,33), (10,36), (11,42), (12,39), (13,56), (14,55), (15,63), (16,52), (17,66), (18,52), (19,80), (20,71))
+data: List[(Int, Int)] = List((0,8), (1,12), (2,16), (3,20), (4,21), (5,31), (6,23), (7,33), (8,31), (9,33), (10,36), (11,42), (12,39), (13,56), (14,55), (15,63), (16,52), (17,66), (18,52), (19,80), (20,71))
 
-val model = for {
-    slope <- LogNormal(0,1).param
-    intercept <- LogNormal(0,1).param
-    regression <- Predictor.from{x: Int => Poisson(x*slope + intercept)}.fit(data)
-} yield regression.predict(21)
+scala> val model = for {
+     |   slope <- LogNormal(0,1).param
+     |   intercept <- LogNormal(0,1).param
+     |   regression <- Predictor.fromInt{x => Poisson(x*slope + intercept)}.fit(data)
+     | } yield regression.predict(21)
+model: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@1af49208
+
+scala> model.sample(10)
+res0: List[Int] = List(69, 73, 74, 87, 72, 78, 68, 73, 100, 74)
 ```
 
 ## Distribution
@@ -26,75 +37,105 @@ val model = for {
 The starting point for almost any work in Rainier will be some object that implements
 `rainier.core.Distribution[T]`.
 
-Rainier implements various familiar families of probability distributions like the [Normal](https://en.wikipedia.org/wiki/Normal_distribution) distribution,
-the [Uniform](https://en.wikipedia.org/wiki/Uniform_distribution_(continuous)) distribution, and the [Poisson](https://en.wikipedia.org/wiki/Poisson_distribution) distribution. You will find these three in [Continuous.scala](/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala) and [Discrete.scala](/rainier-core/src/main/scala/com/stripe/rainier/core/Discrete.scala) - along with a few more, and we'll keep adding them as the need arises.
+Rainier implements various familiar families of probability distributions like
+the [Normal](https://en.wikipedia.org/wiki/Normal_distribution) distribution,
+the [Uniform][UC] distribution,
+and the [Poisson](https://en.wikipedia.org/wiki/Poisson_distribution) distribution.
+You will find these three in [Continuous.scala](/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala)
+and [Discrete.scala](/rainier-core/src/main/scala/com/stripe/rainier/core/Discrete.scala) -
+along with a few more, and we'll keep adding them as the need arises.
 
-You construct a distribution from its parameters, usually with the `apply` method on the object representing its family. So for example, this is a normal distribution with a mean of 0 and a standard deviation of 1:
+You construct a distribution from its parameters, usually with the `apply` method on the object representing its family.
+So for example, this is a normal distribution with a mean of 0 and a standard deviation of 1:
 
 ```scala
 scala> val normal: Distribution[Double] = Normal(0,1)
-normal: com.stripe.rainier.core.Distribution[Double] = com.stripe.rainier.core.Injection$$anon$1@4ce0cc1a
+normal: com.stripe.rainier.core.Distribution[Double] = com.stripe.rainier.core.Injection$$anon$1@24bd441f
 ```
 
-In Rainier, `Distribution` objects play three different roles. `Continuous` distributions (like `Normal`), implement `param`, and all distributions implement `fit` and `generator`. Each of these methods is central to one of the three stages of building a model in Rainier: defining your parameters and their priors; fitting the parameters to some observed data; and using the fit parameters to generate samples of some posterior distribution of interest. We'll start by exploring each of these in turn.
+In Rainier, `Distribution` objects play three different roles.
+`Continuous` distributions (like `Normal`), implement `param`, and all distributions implement `fit` and `generator`.
+Each of these methods is central to one of the three stages of building a model in Rainier:
+
+* defining your parameters and their priors
+* fitting the parameters to some observed data and
+* using the fit parameters to generate samples of some posterior distribution of interest.
+
+We'll start by exploring each of these in turn.
 
 ## `param` and `RandomVariable`
 
-Every model in Rainier has some parameters whose values are unknown (if that's not true for your model, you don't need an inference library!).  The first step in constructing a model is to set up these parameters. 
+Every model in Rainier has some parameters whose values are unknown
+(if that's not true for your model, you don't need an inference library!).
+The first step in constructing a model is to set up these parameters.
 
-You create a parameter by calling `param` on the distribution that represents the prior for that parameter. `param` is only implemented for continuous distributions (which extend `Continuous`, which extends `Distribution[Double]`). As you might be able to tell from those types: in Rainier, all parameters are continuous real scalar values. There's no support for discrete model parameters, and there's no support (or need) for explicit vectorization.
+You create a parameter by calling `param` on the distribution that represents
+the prior for that parameter. `param` is only implemented for continuous distributions
+(which extend `Continuous`, which extends `Distribution[Double]`).
+As you might be able to tell from those types:
+in Rainier, all parameters are continuous real scalar values.
+There's no support for discrete model parameters, and there's no support (or need)
+for explicit vectorization.
 
 Let's use that same `Normal(0,1)` distribution as a prior for a new parameter:
 
 ```scala
 scala> val x = Normal(0,1).param
-x: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@232e5b21
+x: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@3b5cb97f
 ```
 
-You can see that the type of `x` is `RandomVariable[Real]`. `RandomVariable` pairs a type of value (in this case, a real number) with some knowledge of the relative probability density of different values of that type. We can use this knowledge to produce a sample of these possible values:
+You can see that the type of `x` is `RandomVariable[Real]`.
+`RandomVariable` pairs a type of value (in this case, a real number)
+with some knowledge of the relative probability density of different values of that type.
+We can use this knowledge to produce a sample of these possible values:
 
 ```scala
 scala> x.sample()
-Initializing RNG with seed 1528607621103
-res0: List[Double] = List(0.2668925806558562, 0.2668925806558562, 0.2668925806558562, 0.2668925806558562, 0.2668925806558562, 0.2668925806558562, 0.2668925806558562, 0.08308255891110272, -0.7507410928137115, -0.7507410928137115, -0.7509669096148541, 2.0631314152983418, 1.3249273912534498, 0.03555138311217787, 0.03555138311217787, -0.6955898234740514, -0.0837806333999056, -0.9274366321774818, -0.9274366321774818, 0.8318328769519683, 0.25325404344233426, 0.28406288209268826, 0.28406288209268826, 0.28406288209268826, 0.28406288209268826, 0.6742861222712562, -0.3570215030919299, -0.5400233157792773, -0.5400233157792773, 1.5672412873474744, 1.73802462004861, -0.16635438290570548, -0.16635438290570548, -0.16635438290570548, -0.16635438290570548, 0.7579880774045454, -...
+res1: List[Double] = List(0.08945741219217429, -0.08572103782740581, 0.08096740348353304, -0.06942170310697804, 0.03769808860633095, -0.056337565447439175, 0.08286122392158468, -0.07049380254126869, 0.0964505900183994, -0.08994844607337066, 0.0681015347459415, -0.07075948263299364, 0.0747424482459611, -0.09179821815027656, 0.11372979045788867, -0.13055617861536195, 0.13606559329183548, -0.13553342637211643, 0.12085681266491866, -0.1253478378893762, 0.08819446794761276, -0.06586789070823107, 0.03648060095499428, -0.0556970493083373, 0.05379641551584552, -0.07823773960888425, 0.06610020346817047, -0.05584664287136165, 0.07824428971547004, -0.09127833667902208, 0.1058097878681088, -0.09282603839528669, 0.10660612074837217, -0.0902395210197997, 0.09211392168009319,...
 ```
 
-Each element of the list above represents a single sample from the distribution over `x`. It's easier to understand these if we plot them as a histogram:
+Each element of the list above represents a single sample from the distribution over `x`.
+It's easier to understand these if we plot them as a histogram:
 
 ```scala
 scala> plot1D(x.sample())
-     500 |                                                                                
-         |                                         ∘                                      
-         |                                         ○                                      
-         |                                         ○                                      
-         |                                         ○ ∘○ ○                                 
-     370 |                                         ○ ○○ ○∘                                
-         |                                        ○○○○○·○○                                
-         |                                      ○○○○○○○○○○  ○                             
-         |                                  ·  ○○○○○○○○○○○ ∘○·                            
-         |                                 ·○ ·○○○○○○○○○○○○○○○                            
-     250 |                                 ○○○○○○○○○○○○○○○○○○○∘∘                          
-         |                                 ○○○○○○○○○○○○○○○○○○○○○∘                         
-         |                               ·○○○○○○○○○○○○○○○○○○○○○○○                         
-         |                               ○○○○○○○○○○○○○○○○○○○○○○○○∘                        
-         |                              ∘○○○○○○○○○○○○○○○○○○○○○○○○○                        
-     120 |                            ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○                     
-         |                           ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·                   
-         |                          ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·                  
-         |                        ∘·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘·                
-         |                     ··○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·              
-       0 |·       · ····∘··∘○∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘∘∘······· ··
+     370 |                                                                                
+         |                                       ·∘                                       
+         |                                 ∘ ·∘ ∘○○·  ○                                   
+         |                                 ○ ○○ ○○○○∘ ○○·                                 
+         |                                 ○○○○ ○○○○○∘○○○○                                
+     270 |                               ∘∘○○○○○○○○○○○○○○○○                               
+         |                              ○○○○○○○○○○○○○○○○○○○                               
+         |                              ○○○○○○○○○○○○○○○○○○○·○                             
+         |                             ○○○○○○○○○○○○○○○○○○○○○○                             
+         |                             ○○○○○○○○○○○○○○○○○○○○○○○                            
+     180 |                            ○○○○○○○○○○○○○○○○○○○○○○○○                            
+         |                            ○○○○○○○○○○○○○○○○○○○○○○○○                            
+         |                          ·○○○○○○○○○○○○○○○○○○○○○○○○○∘∘                          
+         |                          ○○○○○○○○○○○○○○○○○○○○○○○○○○○○                          
+         |                         ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○·  ·                      
+      90 |                      ∘∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                      
+         |                   ∘∘∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○··                    
+         |                   ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘·                  
+         |                 ○·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○··                
+         |        ∘·····○∘∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○∘·  ·∘·       
+       0 |···∘∘·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○·····
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        -4.5     -3.6     -2.7     -1.7     -0.8     0.1      1.1      2.0      2.9   
+       -3.72    -2.89    -2.05    -1.21    -0.38     0.46     1.29     2.13     2.96  
 ```
 
-Since the only information we have about `x` so far is its `Normal` prior, this distribution unsurprisingly looks  normal. Later we'll see how to update our beliefs about `x` based on observational data.
+Since the only information we have about `x` so far is its `Normal` prior, this distribution unsurprisingly looks  normal.
+Later we'll see how to update our beliefs about `x` based on observational data.
 
-For now, though, let's explore what we can do just with priors. `RandomVariable` has more than just `sample`: you can use the familiar collection methods like `map`, `flatMap`, and `zip` to transform and combine the parameters you create. For example, we can create a log-normal distribution just by mapping over `e^x`:
+For now, though, let's explore what we can do just with priors.
+`RandomVariable` has more than just `sample`:
+you can use the familiar collection methods like `map`, `flatMap`, and `zip`
+to transform and combine the parameters you create.
+For example, we can create a log-normal distribution just by mapping over `e^x`:
 
 ```scala
 scala> val e_x = x.map(_.exp)
-e_x: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@325063a0
+e_x: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@494de68b
 
 scala> plot1D(e_x.sample())
     2300 |                                                                                
@@ -102,221 +143,241 @@ scala> plot1D(e_x.sample())
          | ○                                                                              
          | ○                                                                              
          | ○                                                                              
-    1700 | ○                                                                              
+    1700 |·○                                                                              
          |○○                                                                              
-         |○○                                                                              
-         |○○∘                                                                             
+         |○○○                                                                             
+         |○○○                                                                             
          |○○○                                                                             
     1100 |○○○                                                                             
-         |○○○                                                                             
          |○○○∘                                                                            
-         |○○○○·                                                                           
-         |○○○○○                                                                           
-     500 |○○○○○                                                                           
-         |○○○○○∘                                                                          
-         |○○○○○○·                                                                         
-         |○○○○○○○∘·                                                                       
-         |○○○○○○○○○∘··                                                                    
-       0 |○○○○○○○○○○○○○∘∘∘······················ ···· ·· ·· ·    · ·· · ·       ·   ·    ·
+         |○○○○                                                                            
+         |○○○○                                                                            
+         |○○○○∘                                                                           
+     500 |○○○○○·                                                                          
+         |○○○○○○                                                                          
+         |○○○○○○○                                                                         
+         |○○○○○○○··                                                                       
+         |○○○○○○○○○∘·                                                                     
+       0 |○○○○○○○○○○○○○○∘∘································· ·  · ···         ··  · ·     ·
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        0.0      3.5      7.0      10.6     14.1     17.6     21.1     24.6     28.1  
+        0.0      3.4      6.7      10.1     13.5     16.8     20.2     23.5     26.9  
 ```
 
-Or we can create another `Normal` parameter and zip the two together to produce a 2D gaussian. Since there's nothing relating these two parameters to each other, you can see in the plot that they're completely independent.
+Or we can create another `Normal` parameter and zip the two together to produce a 2D gaussian.
+Since there's nothing relating these two parameters to each other, you can see in the plot that they're completely independent.
 
 ```scala
 scala> val y = Normal(0,1).param
-y: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@7dba9d23
+y: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@ab08a1a
 
 scala> val xy = x.zip(y)
-xy: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@5efebe61
+xy: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@47ec801b
 
 scala> plot2D(xy.sample())
-     3.9 |                                                                                
-         |                                        ·                                       
-         |                                         ·  ·      ··      ·                    
-         |                    ·       ·   ·  ·   · ·  ·     ··    ··                      
-         |                · · · ·· ·· ·· ·· ······· ····· ·  · · ···                      
-     2.0 |       ·     ·     ·· ···· ·· ··· ·················· ··  ·                      
-         |               · · ······································      ··  ·            
-         |    ·  ··  ··  · · ······································ ··· ·  ·      ·       
-         |         ························∘····∘·∘····∘················· ····  ·   ·    ·
-         |     ·   ·  ················∘·∘··∘∘∘∘·∘∘∘∘··∘·∘················· · · ·· ··      
-     0.1 |   ·  ··· ·· ············∘····∘∘∘∘∘·∘∘∘∘∘∘∘∘∘∘··∘·∘·············· ···  ·        
-         |      ·   ··················∘·∘∘∘∘∘·∘∘○○∘∘∘∘∘∘∘∘···∘················· ··        
-         |      · · ·  ···············∘∘∘··∘∘∘∘∘∘∘∘∘∘·∘∘∘∘∘················· ···          
-         |·     ·  ····················∘·∘·∘·∘∘·∘·∘∘∘∘∘·····∘················  ·     ·    
-         |    · · ·   ···· ···························∘················· ·        ·       
-    -1.7 |    ·        ·  ·· ········································ ·······             
-         |           · ··   ·· ····································· · ··                 
-         |      ·         · ·· ····  ······· ·············· · ··    ·     ·   ·           
-         |                    ·  ·····   ··· ······· ·· ·   · ·      ·                    
-         |                          ·      ·  ·    ··                                     
-    -3.6 |                               ·     ·         ·     ·                          
+     3.5 |                                                                                
+         |                             ·              ·                                   
+         |                 ·        ···            ·  ·  · ··          ·                  
+         |                        · ··   · ····· · · ·· ··· · ·· · ··  ·                  
+         |                   · ···· ······························ · · ··  ·              
+     1.7 |          ·          · ·· · ···························· ·· ···   · ·       ·   
+         |            ·   ···· ··  ····································· ·  · ·  ··       
+         |       ·    · · ·  ···· ··············∘··∘······∘············· ·  ··            
+         |     ·  ·   ··   ···················∘∘·∘∘∘○∘∘∘∘∘∘················· · ··        ·
+         |        · ·  ···················∘∘∘∘∘∘∘∘∘∘∘○∘∘∘∘∘∘∘∘·∘··············         · ·
+    -0.0 |·           ·· ···············∘·∘∘∘○·○∘∘∘∘∘∘∘∘∘∘·∘∘∘∘·················          
+         |  ·            ··············∘∘∘··∘∘○∘∘∘∘∘∘∘○∘○∘∘∘∘∘∘··············· ··         
+         |   · ·   ·· ·  ··  ············∘·∘··∘∘∘∘∘∘○∘∘∘·∘∘·∘·∘·············· ··      · · 
+         |             · ····················∘∘∘·∘∘∘∘∘·∘∘∘·∘············ ··· ···  · ·     
+         |          ··  · ·  ···················∘··∘∘·∘∘··················· ··· ·         
+    -1.8 |                  ··· ······ ··································· ·  ·          ·
+         |                       ·································· ····  ··              
+         |                   ·  · ·  ··· ··········· ····· ············     ·   ·         
+         |                     ·     · ·· · ··  ·  ······  · · ··  ·                      
+         |                          ·          ··           · ·                           
+    -3.5 |                           ·           ··     ·              ·                  
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-       -3.64    -2.80    -1.96    -1.12    -0.28     0.56     1.40     2.24     3.08  
+        -4.2     -3.3     -2.4     -1.5     -0.6     0.3      1.2      2.1      3.0   
 ```
 
-Finally, we can use `flatMap` to create two parameters that *are* related to each other. In particular, we'll create a new parameter `z` that we believe to be very close to `x`: its prior is a `Normal` centered on `x` with a very small standard deviation. We'll then make a 2D plot of `(x,z)` to see the relationship.
+Finally, we can use `flatMap` to create two parameters that *are* related to each other.
+In particular, we'll create a new parameter `z` that we believe to be very close to `x`:
+its prior is a `Normal` centered on `x` with a very small standard deviation.
+We'll then make a 2D plot of `(x,z)` to see the relationship.
 
 ```scala
 scala> val z = x.flatMap{a => Normal(a, 0.1).param}
-z: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@40fb6c3c
+z: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@3fc07927
 
 scala> val xz = x.zip(z)
-xz: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@2d8e1a86
+xz: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@34d0e441
 
 scala> plot2D(xz.sample())
-     3.7 |                                                                                
-         |                                                                               ·
-         |                                                                         · ··   
-         |                                                                  ········      
-         |                                                               ·······          
-     2.0 |                                                          ········ ·            
-         |                                                      ·········                 
-         |                                                  ·········                     
-         |                                              ····∘∘····                        
-         |                                          ···∘∘∘∘···                            
-     0.2 |                                     ···∘∘∘∘∘····                               
-         |                                 ····∘∘∘∘···                                    
-         |                             ····∘○○∘···                                        
-         |                          ···∘∘∘∘···                                            
-         |                     ····∘∘∘·····                                               
-    -1.5 |                  ··········                                                    
-         |              ·········                                                         
-         |          ··········                                                            
-         |       ·········                                                                
-         |    ····· ·                                                                     
-    -3.3 |·  ···                                                                          
+     4.2 |                                                                                
+         |                                                                             · ·
+         |                                                                        ·       
+         |                                                                   ····         
+         |                                                              ······            
+     2.0 |                                                          ········              
+         |                                                      ········                  
+         |                                                · ·········                     
+         |                                             ···∘∘∘····                         
+         |                                         ···∘○∘∘···                             
+    -0.1 |                                     ···○○∘∘···                                 
+         |                               · ···∘○○∘···                                     
+         |                             ···∘∘∘∘···                                         
+         |                          ···∘∘····                                             
+         |                      ·········                                                 
+    -2.3 |                  ········                                                      
+         |               ········                                                         
+         |            ······                                                              
+         |          · ·                                                                   
+         |                                                                                
+    -4.5 |·                                                                               
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-       -3.30    -2.52    -1.74    -0.97    -0.19     0.59     1.37     2.14     2.92  
+        -4.5     -3.5     -2.5     -1.5     -0.6     0.4      1.4      2.4      3.3   
 ```
 
-You can see that although we still sample from the full range of `x` values, for any given sample, `x` and `z` are quite close to each other.
+You can see that although we still sample from the full range of `x` values,
+for any given sample, `x` and `z` are quite close to each other.
 
-A note about the `Real` type: you may have noticed that, for example, `x` is a `RandomVariable[Real]` or that `normal.mean` was a `Real`. What's that? `Real` is a special numeric type used by Rainier to represent your model's parameter values, and any values derived from those parameters (if you do arithmetic on a `Real`, you get back another `Real`). It's also the type that all the distribution objects like `Normal` expect to be parameterized with, so that you can chain things together like we did for `z` - though you can also use regular `Int` or `Double` values here and they'll get wrapped automatically. `Real` is, by design, an extremely restricted type: it only supports the 4 basic arithmetic operations, `log`, and `exp`. Restricting it in this way helps keep Rainier models as efficient to perform inference on as possible. At sampling time, however, any `Real` outputs are converted to `Double` so that you can work with them from there.
+A note about the `Real` type: you may have noticed that, for example,
+`x` is a `RandomVariable[Real]` or that `normal.mean` was a `Real`. What's that?
+`Real` is a special numeric type used by Rainier to represent your model's parameter values,
+and any values derived from those parameters (if you do arithmetic on a `Real`, you get back another `Real`).
+It's also the type that all the distribution objects like `Normal` expect to be parameterized with,
+so that you can chain things together like we did for `z` -
+though you can also use regular `Int` or `Double` values here and they'll get wrapped automatically.
+`Real` is, by design, an extremely restricted type:
+it only supports the 4 basic arithmetic operations, `log`, and `exp`.
+Restricting it in this way helps keep Rainier models as efficient to perform inference on as possible.
+At sampling time, however, any `Real` outputs are converted to `Double` so that you can work with them from there.
 
 ## `fit`
 
-Just like every Rainier model has one more more parameters with priors, every Rainier model uses some observational data to update our belief about the values of those parameters (again, if your model doesn't have this, you're probably using the wrong library).
+Just like every Rainier model has one more more parameters with priors,
+every Rainier model uses some observational data to update our belief about
+the values of those parameters (again, if your model doesn't have this, you're probably using the wrong library).
 
-Let's say that we have some data that represents the last week's worth of sales on a website, at (we believe) a constant daily rate, and we'd like to know how many sales we might get tomorrow. Here's our data:
-
-```scala
-scala> val sales = List(4, 4, 7, 11, 8, 12, 10)
-sales: List[Int] = List(4, 4, 7, 11, 8, 12, 10)
-```
-
-We can model the number of sales we get on each day as a poisson distribution parameterized by the underlying rate. For example, looking at that data, we might guess that it came from a `Poisson(9)` or `Poisson(10)`. We can test those hypotheses by using the `fit` method available on all `Distribution` objects. Since `Poisson` is a `Distribution[Int]`, its `fit` will accept either `Int` or `Seq[Int]`, and return a `RandomVariable` which encodes the likelihood of the provided data being produced by that distribution. (We're not going to worry right now about what *kind* of `RandomVariable` it is, since we're only really interested in the likelihood).
+Let's say that we have some data that represents the last week's worth of sales
+on a website, at (we believe) a constant daily rate, and we'd like to know
+how many sales we might get tomorrow.
+Here's our data:
 
 ```scala
-scala> val poisson9: RandomVariable[_] = Poisson(9).fit(sales)
-poisson9: com.stripe.rainier.core.RandomVariable[_] = com.stripe.rainier.core.RandomVariable@57227bda
-
-scala> val poisson10: RandomVariable[_] = Poisson(10).fit(sales)
-poisson10: com.stripe.rainier.core.RandomVariable[_] = com.stripe.rainier.core.RandomVariable@4cbce5c8
+val sales = List(4, 4, 7, 11, 8, 12, 10)
 ```
 
-Although it's almost never necessary, we can reach into any `RandomVariable` and get its current probability `density`:
-
-```scala
-scala> poisson9.density
-res5: com.stripe.rainier.compute.Real = Constant(-18.03523006575617)
-```
-
-We can use this to find the likelihood ratio of these two hypotheses. Since the density is stored in log space, the best way to do this numerically is to subtract the logs first before exponentiating:
-
-```scala
-scala> val lr = (poisson9.density - poisson10.density).exp
-lr: com.stripe.rainier.compute.Real = Constant(3.0035986601488043)
-```
-
-We can see here that our data is about 3x as likely to have come from a `Poisson(9)` as it is to have come from a `Poisson(10)`. We could keep doing this with a large number of values to build up a sense of the rate distribution, but it would be tedious, and we'd be ignoring any prior we had on the rate. Instead, the right way to do this in Rainier is to make the rate a parameter, and let the library do the hard work of exploring the space. Specifically, we can use `flatMap` to chain the creation of the parameter with the creation and fit of the `Poisson` distribution. Since we want our rate to be a positive number, and expect it to be more likely to be on the small side than the large side, the log-normal parameter we created earlier as `e_x` seems like a reasonable choice.
-
-```scala
-scala> val poisson: RandomVariable[_] = e_x.flatMap{r => Poisson(r).fit(sales)}
-poisson: com.stripe.rainier.core.RandomVariable[_] = com.stripe.rainier.core.RandomVariable@2e53a756
-```
-
-By the way: before, when we looked at `poisson9.density`, the model had no parameters and so we got a constant value back. Now, since the model's density is a function of the parameter value, we get something more opaque back. This is why inspecting `density` is not normally useful.
-
-```scala
-scala> poisson.density
-res6: com.stripe.rainier.compute.Real = com.stripe.rainier.compute.Line@d415bc0
-```
-
-Instead, we can sample the quantity we're actually interested in. To start with, let's try to sample the rate parameter of the Poisson, conditioned by our observed data. Here's almost the same thing we had above, recreated with the slightly friendlier `for` syntax, and yielding the `r` parameter at the end:
+We can model the number of sales we get on each day as a Poisson distribution
+parameterized by the underlying rate.
+Looking at the data, we might guess that it came from a `Poisson(9)` or `Poisson(10)`.
+In Rainier, we define our model and it fit to the observed data.
+Since we want our rate to be a positive number,
+and expect it to be more likely to be on the small side than the large side,
+the log-normal parameter we created earlier as `e_x` seems like a reasonable choice.
+We use `flatMap` to chain the creation of the parameter with the creation and
+fit of the `Poisson` distribution.
+Although we _can_ do this with explicit `flatMaps` and `maps`,
+it's much neater with `for{...}` syntax.
 
 ```scala
 scala> val rate = for {
      |     r <- e_x
      |     poisson <- Poisson(r).fit(sales)
      | } yield r
-rate: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@77065612
+rate: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@3086889e
 ```
 
-This is our first "full" model: we have a parameter with a log-normal prior, bundled into the `RandomVariable` named `e_x`; we use that parameter to initialize a `Poisson` noise distribution which we fit to our observations; and at the end, we output the same parameter (referenced by `r`) as the quantity we're interested in sampling from the posterior.
+This is our first "full" model: we have a parameter with a log-normal prior bundled into the `RandomVariable` named `e_x`;
+we use that parameter to initialize a `Poisson` noise distribution which we fit to our observations;
+and at the end, we output the same parameter (referenced by `r`) as the quantity we're interested in sampling from the posterior.
 
 Let's plot the results!
 
 ```scala
 scala> plot1D(rate.sample())
-     420 |                                                                                
-         |                            ∘    ∘                                              
-         |                            ○·   ○                                              
-         |                            ○○  ·○                                              
-         |                         ○ ∘○○∘·○○                                              
-     310 |                         ○·○○○○○○○○∘                                            
-         |                      ∘  ○○○○○○○○○○○·                                           
-         |                      ○○○○○○○○○○○○○○○○·                                         
-         |                    ∘∘○○○○○○○○○○○○○○○○○                                         
-         |                    ○○○○○○○○○○○○○○○○○○○ ∘                                       
-     210 |                   ○○○○○○○○○○○○○○○○○○○○○○∘                                      
-         |                ∘ ·○○○○○○○○○○○○○○○○○○○○○○○                                      
-         |                ○○○○○○○○○○○○○○○○○○○○○○○○○○ ·○                                   
-         |                ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·                                  
-         |                ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·                                 
-     100 |              ○·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                                 
-         |              ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○ ∘ ∘ ∘                           
-         |           ∘ ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○ ○                           
-         |         ∘∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·                         
-         |    ∘  · ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·∘  ·                    
-       0 |· ○∘○·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○○○∘··∘∘··· ∘        ·
+     350 |                                                                                
+         |                        ∘      ·                                                
+         |                       ·○· ·   ○   ·                                            
+         |                       ○○○○○··∘○ ○ ○                                            
+         |                      ○○○○○○○○○○○○∘○ ∘                                          
+     260 |                     ·○○○○○○○○○○○○○○ ○·                                         
+         |                    ·○○○○○○○○○○○○○○○ ○○·                                        
+         |                  · ○○○○○○○○○○○○○○○○ ○○○                                        
+         |                  ○·○○○○○○○○○○○○○○○○○○○○·                                       
+         |                 ·○○○○○○○○○○○○○○○○○○○○○○○○                                      
+     170 |               ○ ○○○○○○○○○○○○○○○○○○○○○○○○○                                      
+         |              ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                                     
+         |              ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                                   
+         |              ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○ ·                                 
+         |            ··○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○·                                
+      80 |          · ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○· ·                             
+         |         ○○∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○ ○                           
+         |       ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○·∘                         
+         |   · ··○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○ ∘·                      
+         |  ·○·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○○∘∘··  ∘               
+       0 |∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘∘···∘· ····· ·
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        4.68     5.55     6.42     7.28     8.15     9.02     9.88    10.75    11.61  
+        5.03     5.82     6.60     7.39     8.17     8.96     9.74    10.53    11.31  
 ```
 
-Looks like our daily rate is probably somewhere between 6 and 9, which corresponds well to the steep 3x dropoff we saw before between 9 and 10.
+Looks like our daily rate is probably somewhere between 6 and 9,
+and is in fact much more likely to be around 9 than 10.
 
 ## A mathematical digression
 
 Please feel free to skip this section if it's not helping you.
 
-One thing that sometimes confuses people at this stage is, what is the line with `fit` actually doing? It seems to return a `poisson` object that we just ignore. (That object, by the way, is just the `Poisson(r)` distribution object that we used to do the `fit`.) And yet the line is clearly doing something, because sampling from `rate` gives quite different results from just sampling directly from `e_x`.
+One thing that sometimes confuses people at this stage is,
+what is the line with `fit` actually doing?
+It seems to return some value `poisson` that we just ignore.
+(That object, by the way, is just the `Poisson(r)` distribution object that we used
+to do the `fit`.)
+And yet the line is clearly doing something, because sampling from `rate` gives quite different results from just sampling directly from `e_x`.
 
-The key is to remember that a `RandomVariable` has two parts: a `value` and a `density`. Mathematically, you should think of these as two different *functions* of the same latent parameter space `Q`. That is, you should think of `value` as being some deterministic function `f = F(q)`, and `density` as being the (unnormalized) probability function `P(Q=q)`.
+The key is to remember that a `RandomVariable` has two parts: a `value` and a `density`.
+Mathematically, you should think of these as two different *functions* of the same latent parameter space `Q`.
+That is, you should think of `value` as being some deterministic function `f = F(q)`,
+and `density` as being the (unnormalized) probability function `P(Q=q)`.
 
- When we `map` or `flatMap` a `RandomVariable` (whether explicitly or inside a `for` construct), the object we see and work with (like, the `r` above) is the `value` object. And we can see in the definition of `rate` that it's just passing that value object through to the end; it should end up with the same `value` function as the prior, `e_x`. And indeed, it does:
+When we `map` or `flatMap` a `RandomVariable` (whether explicitly or inside a `for` construct),
+the object we see and work with (like, the `r` above) is the `value` object.
+And we can see in the definition of `rate` that it's just passing that value object through to the end;
+it should end up with the same `value` function as the prior, `e_x`. And indeed, it does:
 
 ```scala
 scala> e_x.value == rate.value
-res8: Boolean = true
+res7: Boolean = true
 ```
 
 So, for the same input in the latent parameter space, `e_x` and `rate` will produce the same output.
 
-However, when we `flatMap`, behind the scenes we're also working with the `density` object. Specifically, when we start with one `RandomVariable` (like `e_x`), and use `flatMap` to flatten another `RandomVariable` into it (like the result of `fit`), the resulting `RandomVariable` (like `rate`) will have a `density` that *combines* the densities of the other two `RandomVariable`s. Put another way, `flatMap` is the bayesian update operation: you're putting in a prior, coming up with a likelihood, and getting back the posterior. That's what the `fit` line is doing: constructing a likelihood function that we can incorporate into our posterior density. And if we look at the densities, we'll see that they are indeed different:
+However, when we `flatMap`, behind the scenes we're also working with the `density` object.
+Specifically, when we start with one `RandomVariable` (like `e_x`),
+and use `flatMap` to flatten another `RandomVariable` into it (like the result of `fit`),
+the resulting `RandomVariable` (like `rate`) will have a `density` that *combines*
+the densities of the other two `RandomVariable`s.
+Put another way, `flatMap` is the Bayesian update operation:
+you're putting in a prior, coming up with a likelihood, and getting back the posterior.
+That's what the `fit` line is doing: constructing a likelihood function that we can incorporate into our posterior density.
+And if we look at the densities, we'll see that they are indeed different:
 
 ```scala
 scala> e_x.density == rate.density
-res9: Boolean = false
+res8: Boolean = false
 ```
 
-So although `F(q)` has not changed, `P(Q=q)` *has* changed; which means that `P(F(q)=f)` has also changed, and it's that change which we're observing when we see that sampling values of `F` produces different results in the two cases.
+So although `F(q)` has not changed, `P(Q=q)` *has* changed;
+which means that `P(F(q)=f)` has also changed, and it's that change which we're observing
+when we see that sampling values of `F` produces different results in the two cases.
 
 ## `generator` and `Generator`
 
-Sampling from the rate parameter is nice, but what we originally said is that we wanted to predict how many sales to expect tomorrow. As we just discussed in the digression, we got a `poisson` value back from `fit` but didn't do anything with it. This value is just the distribution we used for the `fit`, that is, `Poisson(r)`. Now, instead of fitting data *to* that distribution, we want to generate data *from* that distribution. One idea might be to do that with `param`, that is, with something like this:
+Sampling from the rate parameter is nice, but what we originally said is that
+we wanted to predict how many sales to expect tomorrow.
+As we just discussed in the digression, we got a `poisson` value back from `fit` but didn't do anything with it.
+This value is just the distribution we used for the `fit`, that is, `Poisson(r)`.
+Now, instead of fitting data *to* that distribution, we want to generate data *from* that distribution.
+One idea might be to do that with `param`, that is, with something like this:
 
 ```scala
 //This code won't compile
@@ -327,9 +388,19 @@ for {
 } yield prediction
 ```
 
-This has a couple of problems. First, it seems conceptually wrong to think of a prediction as a parameter: there is no true value of "how many sales will we have tomorrow" for us to infer, and we have no observational data that can influence our belief about its value; once we've derived the rate parameter, the prediction is purely generative. Second, as a practical matter, Rainier only supports continuous parameters, and here we need to generate discrete values, so `poisson.param` won't, in fact, compile.
+This has a couple of problems.
+First, it seems conceptually wrong to think of a prediction as a parameter:
+there is no true value of "how many sales will we have tomorrow" for us to infer,
+and we have no observational data that can influence our belief about its value;
+once we've derived the rate parameter, the prediction is purely generative.
+Second, as a practical matter, Rainier only supports continuous parameters,and
+here we need to generate discrete values, so `poisson.param` won't, in fact, compile.
 
-Luckily, all distributions, continious or discrete, implement `generator`, which gives us what we need: a way to randomly generate new values from a distribution as part of the sampling process. Every `Distribution[T]` can give us a `Generator[T]`, and if we sample from a `RandomVariable[Generator[T]]`, we will get values of type `T`. (You can think of `Real` as being a special case that acts in this sense like a `Generator[Double]`).
+Luckily, all distributions, continious or discrete, implement `generator`,
+which gives us what we need: a way to randomly generate new values from a distribution as part of the sampling process.
+Every `Distribution[T]` can give us a `Generator[T]`, and if we sample from a `RandomVariable[Generator[T]]`,
+we will get values of type `T`.
+(You can think of `Real` as being a special case that acts in this sense like a `Generator[Double]`).
 
 Here's one way we could implement what we're looking for:
 
@@ -338,47 +409,53 @@ scala> val prediction = for {
      |     r <- e_x
      |     poisson <- Poisson(r).fit(sales)
      | } yield poisson.generator
-prediction: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@620ce32e
+prediction: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@2c7c57f8
 ```
 
-This is almost the same model as `rate` above, but instead of taking the real-valued `r` rate parameter as the output, we're producing poisson-distributed integers. The samples look like this:
+This is almost the same model as `rate` above,
+but instead of taking the real-valued `r` rate parameter as the output,
+we're producing poisson-distributed integers.
+The samples look like this:
 
 ```scala
 scala> prediction.sample()
-res10: List[Int] = List(8, 8, 3, 14, 13, 9, 2, 6, 4, 7, 11, 4, 7, 9, 8, 8, 17, 11, 10, 11, 14, 14, 5, 4, 7, 9, 4, 9, 7, 3, 7, 5, 10, 8, 13, 5, 7, 12, 16, 10, 9, 6, 11, 12, 4, 9, 10, 6, 13, 10, 8, 6, 7, 4, 9, 9, 6, 6, 9, 8, 8, 5, 7, 5, 9, 10, 5, 10, 10, 4, 10, 7, 10, 7, 4, 8, 7, 8, 5, 7, 13, 5, 6, 8, 7, 7, 8, 6, 3, 16, 5, 8, 7, 8, 6, 8, 8, 5, 9, 11, 11, 9, 7, 6, 9, 3, 7, 10, 10, 5, 5, 8, 5, 10, 4, 8, 5, 12, 3, 3, 9, 4, 5, 5, 8, 10, 8, 9, 13, 3, 10, 9, 4, 6, 7, 9, 11, 7, 9, 10, 12, 10, 4, 12, 12, 16, 4, 9, 14, 6, 7, 12, 14, 10, 5, 5, 3, 8, 6, 8, 5, 4, 6, 9, 4, 7, 9, 5, 8, 7, 9, 10, 9, 7, 6, 6, 10, 13, 8, 7, 7, 6, 8, 3, 3, 11, 10, 6, 7, 5, 6, 5, 13, 10, 7, 9, 12, 6, 8, 6, 11, 10, 15, 10, 5, 6, 6, 2, 9, 6, 7, 12, 7, 6, 3, 4, 6, 8, 6, 11, 8, 8, 9, 9, 10, 8, 9, 10, 4...
+res9: List[Int] = List(12, 6, 7, 7, 8, 8, 4, 6, 10, 5, 8, 17, 10, 8, 5, 5, 10, 10, 6, 5, 12, 7, 7, 6, 6, 8, 9, 15, 10, 6, 10, 4, 9, 6, 11, 12, 8, 9, 6, 5, 6, 10, 1, 10, 8, 4, 12, 8, 6, 3, 6, 10, 4, 10, 9, 15, 6, 4, 8, 8, 11, 6, 6, 5, 6, 5, 6, 7, 10, 3, 9, 6, 10, 8, 14, 7, 10, 4, 6, 7, 6, 10, 5, 7, 7, 10, 10, 8, 7, 8, 11, 9, 6, 9, 7, 10, 14, 8, 3, 2, 15, 8, 10, 11, 10, 7, 13, 2, 7, 10, 12, 9, 10, 6, 11, 14, 7, 10, 7, 7, 11, 7, 10, 7, 3, 7, 5, 7, 6, 12, 9, 10, 7, 10, 7, 6, 10, 7, 7, 9, 9, 4, 5, 9, 7, 6, 6, 5, 9, 7, 5, 7, 5, 9, 6, 9, 4, 8, 8, 7, 7, 7, 6, 9, 5, 13, 6, 5, 12, 10, 3, 5, 9, 9, 5, 15, 9, 8, 5, 10, 4, 8, 7, 9, 6, 8, 9, 7, 6, 9, 4, 9, 7, 6, 10, 5, 15, 12, 6, 4, 6, 8, 13, 5, 12, 9, 7, 7, 9, 7, 8, 8, 10, 8, 11, 7, 7, 8, 13, 6, 5, 12, 9, 5, 7, 8, 6, 6, 4, 4...
 ```
 Or, if we plot them, like this:
 
 ```scala
 scala> plot1D(prediction.sample())
-    1410 |                                                                                
-         |                        ○                                                       
-         |                        ○  ·                                                    
-         |                    ·   ○  ○                                                    
-         |                    ○   ○  ○                                                    
-    1050 |                 ·  ○   ○  ○   ○                                                
-         |                 ○  ○   ○  ○   ○                                                
-         |                 ○  ○   ○  ○   ○                                                
-         |                 ○  ○   ○  ○   ○  ·                                             
-         |                 ○  ○   ○  ○   ○  ○                                             
-     700 |             ·   ○  ○   ○  ○   ○  ○                                             
-         |             ○   ○  ○   ○  ○   ○  ○   ·                                         
-         |             ○   ○  ○   ○  ○   ○  ○   ○                                         
-         |             ○   ○  ○   ○  ○   ○  ○   ○                                         
-         |             ○   ○  ○   ○  ○   ○  ○   ○  ·                                      
-     350 |          ∘  ○   ○  ○   ○  ○   ○  ○   ○  ○                                      
-         |          ○  ○   ○  ○   ○  ○   ○  ○   ○  ○   ·                                  
-         |          ○  ○   ○  ○   ○  ○   ○  ○   ○  ○   ○                                  
-         |      ∘   ○  ○   ○  ○   ○  ○   ○  ○   ○  ○   ○  ·                               
-         |      ○   ○  ○   ○  ○   ○  ○   ○  ○   ○  ○   ○  ○  ·                            
-       0 |·  ∘  ○   ○  ○   ○  ○   ○  ○   ○  ○   ○  ○   ○  ○  ○   ∘  ·   ·  ·   ·  ·   ·  ·
+    1380 |                                                                                
+         |                         ○                                                      
+         |                     ∘   ○  ∘                                                   
+         |                     ○   ○  ○                                                   
+         |                     ○   ○  ○   ·                                               
+    1040 |                     ○   ○  ○   ○                                               
+         |                  ∘  ○   ○  ○   ○                                               
+         |                  ○  ○   ○  ○   ○                                               
+         |                  ○  ○   ○  ○   ○   ○                                           
+         |                  ○  ○   ○  ○   ○   ○                                           
+     690 |              ○   ○  ○   ○  ○   ○   ○                                           
+         |              ○   ○  ○   ○  ○   ○   ○                                           
+         |              ○   ○  ○   ○  ○   ○   ○  ○                                        
+         |              ○   ○  ○   ○  ○   ○   ○  ○                                        
+         |              ○   ○  ○   ○  ○   ○   ○  ○                                        
+     340 |          ·   ○   ○  ○   ○  ○   ○   ○  ○   ○                                    
+         |          ○   ○   ○  ○   ○  ○   ○   ○  ○   ○                                    
+         |          ○   ○   ○  ○   ○  ○   ○   ○  ○   ○   ○                                
+         |       ·  ○   ○   ○  ○   ○  ○   ○   ○  ○   ○   ○  ∘                             
+         |       ○  ○   ○   ○  ○   ○  ○   ○   ○  ○   ○   ○  ○   ∘                         
+       0 |·  ∘   ○  ○   ○   ○  ○   ○  ○   ○   ○  ○   ○   ○  ○   ○  ∘   ·   ·  ·   ·   ·  ·
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        0.0      2.6      5.2      7.8      10.4     13.0     15.6     18.2     20.8  
+        0.0      2.5      5.0      7.5      9.9      12.4     14.9     17.4     19.9  
 ```
 
 ## `Likelihood` and `Predictor`
 
-What if, instead of assuming that our website's sales are constant over time, we assume that they're growing at a constant rate? We might have data like the following, organized in (day, sales) pairs. (You may recognize this data from the start of the tour.)
+What if, instead of assuming that our website's sales are constant over time,
+we assume that they're growing at a constant rate?
+We might have data like the following, organized in (day, sales) pairs.
+(You may recognize this data from the start of the tour.)
 
 ```scala
 scala> val data =  List((0,8), (1,12), (2,16), (3,20), (4,21), (5,31), (6,23), (7,33), (8,31), (9,33), (10,36), (11,42), (12,39), (13,56), (14,55), (15,63), (16,52), (17,66), (18,52), (19,80), (20,71))
@@ -414,149 +491,195 @@ scala> plot2D(data)
         0.0      2.3      4.5      6.8      9.0      11.3     13.6     15.8     18.1  
 ```
 
-How should we model this? We'll need to know what the rate was on day 0 (the intercept), as well as how fast the rate increases each day (the slope). We know they're both positive and not too large, so let's keep using log-normal priors. (This time we can just use the builtin `LogNormal` instead of deriving it ourselves).
+How should we model this? We'll need to know what the rate was on day 0 (the intercept),
+as well as how fast the rate increases each day (the slope).
+We know they're both positive and not too large, so let's keep using log-normal priors.
+(This time we can just use the builtin `LogNormal` instead of deriving it ourselves).
 
 ```scala
 scala> val prior = for {
      |     slope <- LogNormal(0,1).param
      |     intercept <- LogNormal(0,1).param
      |     } yield (slope, intercept)
-prior: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@5a99dd10
+prior: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@13217c9e
 ```
 
-Now, for any given day `i`, we want to check the number of sales against `Poisson(intercept + slope*i)`. We could write some kind of recursive flatMap to build and fit each of these different distribution objects in turn, but this is a common enough pattern that Rainier already has something built in for it: `Predictor`. `Predictor` is not a `Distribution`, but instead wraps a function from `X => Distribution[Y]` for some `(X,Y)`; you can use this any time you have a dependent variable of type `Y` that you're modeling with some independent variables jointly represented as `X`. 
+Now, for any given day `i`, we want to check the number of sales against `Poisson(intercept + slope*i)`.
+We could write some kind of recursive flatMap to build and fit each of these different distribution objects in turn,
+but this is a common enough pattern that Rainier already has something built in for it: `Predictor`.
+`Predictor` is not a `Distribution`, but instead wraps a function from `X => Distribution[Y]` for some `(X,Y)`;
+you can use this any time you have a dependent variable of type `Y` that you're modeling
+with some independent variables jointly represented as `X`.
 
 Like `Distribution`, `Predictor` implements `fit` (in fact, they both extend the `Likelihood` trait which provides that method). So we can extend the previous model to create and use a `Predictor` like this:
 
 ```scala
 scala> val regr = for {
      |     (slope, intercept) <- prior
-     |     predictor <- Predictor.from{i: Int =>
+     |     predictor <- Predictor.fromInt{i =>
      |                     Poisson(intercept + slope*i)
-     |                 }.fit(data) 
+     |                 }.fit(data)
      | } yield (slope, intercept)
-regr: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@5cd8e466
+regr: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@14b8a978
 ```
-As before, we're starting out by just sampling the parameters. By plotting them, we can see that the model's confidence in the intercept, in particular, is pretty low: although it's most likely to be somewhere around 8, it could be anywhere from 3 to 13 or even higher. Second, as you'd hope, the two parameters are anti-correlated: a smaller intercept would imply a higher slope, and vice versa.
+
+As before, we're starting out by just sampling the parameters.
+By plotting them, we can see that the model's confidence in the intercept, in particular, is pretty low:
+although it's most likely to be somewhere around 8, it could be anywhere from 3 to 13 or even higher.
+Second, as you'd hope, the two parameters are anti-correlated:
+a smaller intercept would imply a higher slope, and vice versa.
 
 ```scala
 scala> plot2D(regr.sample())
-    15.1 |                                                                                
-         |·                                                                               
-         |    ·             ·  ·                                                          
-         |·   ·    ·····       ·  ·                                                       
-         |   ·  ········· ······ · ··     ·                                               
-    12.1 |  ·   · ··· ··················· · · ·                                           
-         |         · ······················ · ····    ·                                   
-         |   ·     ···· ··························· ·                                     
-         |          ··· ······························                                    
-         |          · · ···········∘∘··∘∘∘∘∘∘············· ·   ·                          
-     9.2 |            · ··········∘∘·∘∘∘∘∘○∘∘∘∘·∘·········· ·    ·                        
-         |                 ··········∘∘∘∘○∘○∘○∘∘○∘∘∘∘···········  ··                      
-         |                   ·········∘∘·∘○∘∘○∘○∘○○○∘∘∘∘·········· ·· · ·                 
-         |                ··  ··········∘∘∘∘∘○∘∘○∘○○∘○∘∘∘∘··········· ··  ·               
-         |                      ···········∘·∘○∘○∘○○○∘∘○○·∘············· ·· ·     ·       
-     6.2 |                           ··········∘·∘∘∘·∘∘∘∘∘∘∘··············  ··            
-         |                         ··    ··········∘∘·∘··∘∘∘∘············· ·  ·  ·        
-         |                                 · · ··························· · ··    ·      
-         |                                       ······························           
-         |                                       ·    ··· ···· ·· ······ · ·       ·      
-     3.3 |                                            ·        ·  ·  · ·   ·· ·· ·       ·
+    15.2 |                                                                                
+         |        ·      · ·                                                              
+         |·  · ·   ·    ·   ·· ··                                                         
+         |             ·   ·········   · ··                                               
+         |            · ·············· · ·· ··· ·    ·                                    
+    12.2 |             · ·· ················· ·  ·   ·                                    
+         |         · ·  ···························· ·    ·                               
+         |               ·······························  ···                             
+         |        ·      · ···················∘············· ··                           
+         |              ·   ···········∘·····∘∘∘∘∘·∘∘··········· ··   ·  ·                
+     9.1 |           ·        ············∘·∘∘∘∘∘∘∘∘∘∘∘∘·············· ·                  
+         |                      · ··········∘∘∘∘∘∘○○○∘∘∘∘∘∘············ ·· ··             
+         |                            ·········∘∘∘∘○○○∘∘∘○○∘∘··∘········· ···· ·  ·       
+         |                          ·· ·········∘·∘∘∘∘○○○○○○○∘∘∘∘∘············ ·· ·       
+         |                             ··············∘∘∘∘○·○○∘○○○∘·∘·∘············       ·
+     6.1 |                                  ·  ···········∘∘∘∘∘∘∘∘·∘∘·∘···········  ·· ·  
+         |                                    ··  ··············∘···················· ·   
+         |                                         ··· ··· ····················· ······· ·
+         |                                      ·     ··    ························  ··· 
+         |                                                ·  ··· ·   ·· ······ ·· ··· ·   
+     3.0 |                                                             ·  · ·  ·     ··   
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        2.42     2.60     2.78     2.96     3.14     3.32     3.49     3.67     3.85  
+        2.31     2.48     2.65     2.82     2.99     3.16     3.32     3.49     3.66  
 ```
 
-Alternatively, as in the earlier example, we could try to predict what will happen tomorrow. This is similar to calling `poisson.generator` before, but this time, we use the `predict` method on `Predictor`, which takes the covariate (the day, in this case), and returns a `Generator` for the dependent variable (the number of sales). Putting it all together, it looks like this:
+Alternatively, as in the earlier example, we could try to predict what will happen tomorrow.
+This is similar to calling `poisson.generator` before, but this time, we use the `predict` method on `Predictor`,
+which takes the covariate (the day, in this case), and returns a `Generator` for the dependent variable (the number of sales).
+Putting it all together, it looks like this:
 
 ```scala
 scala> val regr2 = for {
      |     slope <- LogNormal(0,1).param
      |     intercept <- LogNormal(0,1).param
-     |     predictor <- Predictor.from{i: Int => 
+     |     predictor <- Predictor.fromInt{i =>
      |                     Poisson(intercept + slope*i)
      |                 }.fit(data)
      | } yield predictor.predict(21)
-regr2: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@59ce705b
+regr2: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@6e07d752
 ```
 
-Plotting this gives us a prediction which incorporates both the natural noise of a poisson distribution and our uncertainty about its underlying parameterization.
+Plotting this gives us a prediction which incorporates both the natural noise of a Poisson distribution
+and our uncertainty about its underlying parameterization.
 
 ```scala
 scala> plot1D(regr2.sample())
-     470 |                                                                                
-         |                                     ∘                                          
-         |                                ∘○∘∘∘○                                          
-         |                               ·○○○○○○                                          
-         |                            ∘∘ ○○○○○○○○                                         
-     350 |                            ○○ ○○○○○○○○○ ○                                      
-         |                           ∘○○ ○○○○○○○○○ ○                                      
-         |                           ○○○ ○○○○○○○○○ ○○ ·                                   
-         |                          ○○○○ ○○○○○○○○○ ○○·○                                   
-         |                         ·○○○○ ○○○○○○○○○ ○○○○                                   
-     230 |                        ·○○○○○ ○○○○○○○○○ ○○○○∘·                                 
-         |                      ∘ ○○○○○○ ○○○○○○○○○ ○○○○○○·                                
-         |                      ○○○○○○○○ ○○○○○○○○○ ○○○○○○○                                
-         |                     ∘○○○○○○○○ ○○○○○○○○○ ○○○○○○○                                
-         |                   · ○○○○○○○○○ ○○○○○○○○○ ○○○○○○○·∘                              
-     110 |                   ○ ○○○○○○○○○ ○○○○○○○○○ ○○○○○○○○○ ∘                            
-         |                  ·○ ○○○○○○○○○ ○○○○○○○○○ ○○○○○○○○○ ○·                           
-         |                ∘∘○○ ○○○○○○○○○ ○○○○○○○○○ ○○○○○○○○○ ○○∘·                         
-         |             ·∘∘○○○○ ○○○○○○○○○ ○○○○○○○○○ ○○○○○○○○○ ○○○○∘                        
-         |            ∘○○○○○○○ ○○○○○○○○○ ○○○○○○○○○ ○○○○○○○○○ ○○○○○∘○·· ·                  
-       0 |·········○ ○○○○○○○○○ ○○○○○○○○○ ○○○○○○○○○ ○○○○○○○○○ ○○○○○○○○○ ○∘∘······ ·· ·    ·
+     440 |                                                                                
+         |                                  ·∘ ∘ · ·                                      
+         |                                  ○○·○○○ ○·                                     
+         |                               ∘  ○○○○○○ ○○·                                    
+         |                               ○ ○○○○○○○ ○○○∘                                   
+     330 |                             · ○ ○○○○○○○ ○○○○                                   
+         |                             ○○○ ○○○○○○○ ○○○○○                                  
+         |                             ○○○ ○○○○○○○ ○○○○○○                                 
+         |                           ∘·○○○ ○○○○○○○ ○○○○○○·                                
+         |                          ·○○○○○ ○○○○○○○ ○○○○○○○ ·                              
+     220 |                          ○○○○○○ ○○○○○○○ ○○○○○○○ ○·                             
+         |                         ∘○○○○○○ ○○○○○○○ ○○○○○○○ ○○                             
+         |                       ∘ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○                             
+         |                       ○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○∘○                           
+         |                      ∘○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○∘                         
+     110 |                     ·○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○                         
+         |                    ∘○○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○∘ ·                      
+         |                   ○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○·                     
+         |               · ·○○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○∘·                   
+         |             ∘∘○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○○○∘∘                 
+       0 |·  ····  ·∘∘∘○○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○∘○∘··· ·  · ··
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        43.0     51.1     59.2     67.3     75.4     83.6     91.7     99.8    107.9  
+        41.0     48.9     56.8     64.7     72.5     80.4     88.3     96.2    104.1  
 ```
 
-Finally, let's close with a small and somewhat contrived example of a hierarchical model, where we have two separate regressions that share a parameter. For the sake of the example, let's assume that we have a second sales dataset, much like the first, where we know they had the same rate at the start of the observations, but may have grown at different rates - so their intercepts will be equal but their slopes will not. Here's the data:
+Finally, let's close with a small and somewhat contrived example of a hierarchical model,
+where we have two separate regressions that share a parameter.
+For the sake of the example, let's assume that we have a second sales dataset,
+much like the first, where we know they had the same rate at the start of the observations,
+but may have grown at different rates - so their intercepts will be equal but their slopes will not.
+Here's the data:
 
 ```scala
 scala> val data2 = List((0,9), (1,2), (2,3), (3,17), (4,21), (5,12), (6,21), (7,19), (8,21), (9,18), (10,25), (11,27), (12,33), (13,23), (14,28), (15,45), (16,35), (17,45), (18,47), (19,54), (20,40))
 data2: List[(Int, Int)] = List((0,9), (1,2), (2,3), (3,17), (4,21), (5,12), (6,21), (7,19), (8,21), (9,18), (10,25), (11,27), (12,33), (13,23), (14,28), (15,45), (16,35), (17,45), (18,47), (19,54), (20,40))
 ```
 
-It's straightforward to set up two separate slopes, two separate predictor, but the same interecept. We'll still just sample the first slope so we can compare to the previous model.
+It's straightforward to set up two separate slopes, two separate predictors,
+but the same interecept.
+We'll still just sample the first slope so we can compare to the previous model.
+We _could_ write out the parameters of the models separately and fit each one
+to its respective data, but this is a bit tedious,
+so we can use Rainier's `Lookup` to do it more succinctly.
 
 ```scala
-scala> val regr3 = for {
-     |     slope1 <- LogNormal(0,1).param
-     |     slope2 <- LogNormal(0,1).param
-     |     intercept <- LogNormal(0,1).param
-     |     pred1 <- Predictor.from{i: Int => Poisson(intercept + slope1*i)}.fit(data)
-     |     pred2 <- Predictor.from{i: Int => Poisson(intercept + slope2*i)}.fit(data2)
-     | } yield (slope1, intercept)
-regr3: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@12980f7a
-```
+scala> val allData = data.map{ case (x,y) => ((0, x), y) } ++ data2.map{ case (x, y) => ((1, x), y) }
+allData: List[((Int, Int), Int)] = List(((0,0),8), ((0,1),12), ((0,2),16), ((0,3),20), ((0,4),21), ((0,5),31), ((0,6),23), ((0,7),33), ((0,8),31), ((0,9),33), ((0,10),36), ((0,11),42), ((0,12),39), ((0,13),56), ((0,14),55), ((0,15),63), ((0,16),52), ((0,17),66), ((0,18),52), ((0,19),80), ((0,20),71), ((1,0),9), ((1,1),2), ((1,2),3), ((1,3),17), ((1,4),21), ((1,5),12), ((1,6),21), ((1,7),19), ((1,8),21), ((1,9),18), ((1,10),25), ((1,11),27), ((1,12),33), ((1,13),23), ((1,14),28), ((1,15),45), ((1,16),35), ((1,17),45), ((1,18),47), ((1,19),54), ((1,20),40))
 
-Plotting slope vs intercept now, we can see that, even though these are two separate regressions, we get tighter bounds than before by letting the new data influence the shared parameter. It makes sense that we'd get more confidence on the intercept, since we have two different time series to learn from now; but because of the anti-correlation, that also leads to somewhat more confidence than before on the `slope1` parameter as well.
+scala> val regr3 = for {
+     |   slopes <- RandomVariable.fill(2)(LogNormal(0,1).param).map(Lookup(_))
+     |   intercept <- LogNormal(0,1).param
+     |   _ <- Predictor.from[(Int, Int), Int, (Real, Real), Real]{ case (i,x) => Poisson(intercept + slopes(i) * x) }.fit(allData)
+     | } yield (slopes(0), intercept)
+regr3: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@6fa66fd
+```
+Here, `i` indexes the model and `x` is the x-value of the observation.
+Plotting slope vs intercept now, we can see that,
+even though these are two separate regressions,
+we get tighter bounds than before by letting the new data influence the shared parameter.
+It makes sense that we'd get more confidence on the intercept,
+since we have two different time series to learn from now;
+but because of the anti-correlation, that also leads to somewhat more confidence
+than before on the `slope1` parameter as well.
 
 ```scala
 scala> plot2D(regr3.sample())
-    10.8 |                                                                                
-         |         ·       ·                                                              
-         | ·   ·   · ··    ·   ·                                                          
-         |  · ··    ····   · ·  · ·                                                       
-         |   ·   ············· ··· ····                                                   
-     8.9 |     ····· ······················  ·   ·                                        
-         |·  ··   ······························   · ·  ··                                
-         |·  · · ······························· ··· ·  ·····                             
-         |   ··· ················∘∘∘∘····················   ·               ·             
-         |·  · ·  ·············∘·∘∘·∘∘·∘∘∘·∘···················   ··                      
-     7.0 |       ··············∘·∘·∘∘∘∘○∘∘∘∘∘∘∘∘··∘·∘···············  ·    ·              
-         | ·   · · ··  ·········∘∘∘∘∘∘∘○∘∘○○∘○∘○∘∘∘∘·∘··············   ··                 
-         |       ·   ···· ·····∘··∘·∘∘∘○∘∘∘○∘○○∘○∘·∘∘∘∘·∘············ ···· ·  ·           
-         |             ··············∘·∘∘∘∘∘∘○○○∘○∘∘∘∘∘∘∘∘∘·∘············· ·     ·        
-         |            ···· ·············∘·∘∘∘∘○∘○∘∘∘∘○∘∘·∘·∘∘··············· ···          
-     5.1 |               ·  ·  · ···············∘∘∘·○·∘·∘∘···∘············· ···  ·        
-         |                   ·  · ·· · ·································· ····· ···       
-         |                         · ·  ···························· ······ · ··          
-         |                               ·  ·   ·  ········ ····· ·········· · · ·     · ·
-         |                                        ·  ···  · ··    ·      ·    ·      ··   
-     3.2 |                                        ·     · ·  ·         ··   ·             
+    11.5 |                                                                                
+         |                    ·                                                           
+         |                             ·                                                  
+         |        · ··    ·    ·          ·                                               
+         |     ·  · ·   ·· ·   ·  ··   ·  ·                                               
+     9.4 |·    ·    ·  ··· ···········   · ·  ···        ·                                
+         |   ·     · · ·····················   ··  ··   ·  ··  ·                          
+         |       ···································· ··· ·                               
+         |         ····  ·····································   ·  ·                     
+         |       ··   ··················∘∘∘···∘∘·∘················   ·                    
+     7.3 |          ··············∘···∘∘∘∘∘∘∘∘∘∘∘∘·∘·∘∘∘·············· ··                 
+         |            ·  ·········∘··∘∘∘∘○∘○∘∘○∘○○○∘∘∘∘∘·∘···················             
+         |             ·················∘∘∘∘∘○○○○○○∘○∘∘∘○∘∘∘·∘∘·············· · ·         
+         |               ····· ·········∘·∘∘○∘∘∘○∘○○○○∘∘○○○∘∘∘∘∘∘∘∘··········· ·· · ·     
+         |                     · ·············∘∘∘∘∘○○∘○∘○○∘∘○∘∘∘∘∘∘·················      
+     5.2 |                      ·  ················∘∘∘∘·∘∘∘∘∘∘∘∘·∘·∘·∘·············· · ·  
+         |                         · ·· ····················∘·∘∘····················· ·  ·
+         |                            ···  · ··· ·························· ···· ··  ·    
+         |                                   ·      ·· ····················· · ····  · ·· 
+         |                                 ·          ··· · · ······· ·  · · ·· ·         
+     3.1 |                                                      ·   ·   ·                 
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        2.79     2.92     3.05     3.19     3.32     3.46     3.59     3.72     3.86  
+        2.72     2.85     2.97     3.10     3.23     3.36     3.49     3.62     3.75  
 ```
 
 ## Learning More
 
-This tour has focused on the high-level API. If you want to understand more about what's going on under the hood, you might enjoy reading about [Real](real.md) or checking out some [implementation notes](impl.md). If you want to learn more about Bayesian modeling in general, [Cam Davidson Pilon's book](http://camdavidsonpilon.github.io/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers/) is an excellent resource - the examples are in Python, but porting them to Rainier is a good learning exercise. Over time, we hope to add more Rainier-specific documentation and community resources; for now, feel free to file a [GitHub issue](https://github.com/stripe/rainier/issues) with any questions or problems.
+This tour has focused on the high-level API.
+If you want to understand more about what's going on under the hood,
+you might enjoy reading about [Real](real.md) or checking out some
+[implementation notes](impl.md).
+If you want to learn more about Bayesian modeling in general,
+[Cam Davidson Pilon's book][CDP] is an excellent resource - the examples are in Python,
+but porting them to Rainier is a good learning exercise.
+Over time, we hope to add more Rainier-specific documentation and community resources;
+for now, feel free to file a [GitHub issue][GISSUES] with any questions or problems.
+
+[CDP]: http://camdavidsonpilon.github.io/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers/
+[GISSUES]: https://github.com/stripe/rainier/issues
+[UC]: https://en.wikipedia.org/wiki/Uniform_distribution_(continuous)

--- a/docs/tour.md
+++ b/docs/tour.md
@@ -30,7 +30,7 @@ Rainier implements various familiar families of probability distributions like t
 
 ```scala
 scala> val normal: Distribution[Double] = Normal(0,1)
-normal: com.stripe.rainier.core.Distribution[Double] = com.stripe.rainier.core.Injection$$anon$1@5c99a14b
+normal: com.stripe.rainier.core.Distribution[Double] = com.stripe.rainier.core.Injection$$anon$1@59dd28b0
 ```
 
 In Rainier, `Distribution` objects play three different roles. `Continuous` distributions (like `Normal`), implement `param`, and all distributions implement `fit` and `generator`. Each of these methods is central to one of the three stages of building a model in Rainier:
@@ -51,43 +51,43 @@ Let's use that same `Normal(0,1)` distribution as a prior for a new parameter:
 
 ```scala
 scala> val x = Normal(0,1).param
-x: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@7230afcb
+x: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@68b8b03
 ```
 
 You can see that the type of `x` is `RandomVariable[Real]`. `RandomVariable` pairs a type of value (in this case, a real number) with some knowledge of the relative probability density of different values of that type. We can use this knowledge to produce a sample of these possible values:
 
 ```scala
 scala> x.sample()
-res0: List[Double] = List(-0.5350756732175771, 0.4095879847940215, -0.48103750803591966, 0.6195772581111134, -0.1881177537347165, 0.5153578542054698, -0.40835882409772284, 0.31110274452483294, 0.48174662765081644, -0.5408499092051309, 0.4172522334231373, -0.14313607661092242, 0.36536408757761807, -0.4915431077636774, 0.39268870034628256, -0.25104249119668204, 0.42524503968352634, -0.7774682430044022, 1.0916362983757233, -0.79307761222504, 0.17955091468343598, 0.2116520724912656, -0.2544159474840291, -0.2544159474840291, 0.6933882180446678, -0.18042154050586623, 0.12743839889299519, -0.5422614153952039, 0.3626523108500808, -0.06231261510660291, 0.05715475723870011, -0.027061013200473716, -0.4245638566089802, -0.15596907820181993, -0.3961564095037544, 0.111219079...
+res0: List[Double] = List(-0.5310496933506796, 0.49808970998312374, 0.49808970998312374, -0.5986527929482448, 0.869445190709651, -0.6019443511107341, 0.5612406779519676, -0.6082035971460475, 0.9659420210003276, -0.5393207107669853, 0.32700309526786, -0.29527586149715357, 0.23981674357575078, -0.3216981704203738, -0.04615624121769368, -0.052861959693735305, -0.5012620291134708, 0.42735088534888366, -0.517923832882594, 0.082942226000152, 0.17971850591172522, 0.03799100919698528, 0.14554829585726292, -0.007093594388935087, 0.07057633066241223, -0.4194569456680919, 0.7170767319659431, -0.839886602346586, 0.9433501750138381, 0.9433501750138381, -1.090726778471308, 0.8433245281096444, -0.85401769987228, -0.85401769987228, 0.9460189562401292, -1.0565260444066338, 1.01...
 ```
 
 Each element of the list above represents a single sample from the distribution over `x`. It's easier to understand these if we plot them as a histogram:
 
 ```scala
 scala> plot1D(x.sample())
-     400 |                                                                                
-         |                                     ∘ ·                                        
-         |                                     ○ ○                                        
-         |                                    ·○ ○ ∘○∘                                    
-         |                                   ○○○∘○·○○○·                                   
-     300 |                                 ∘·○○○○○○○○○○○∘                                 
-         |                                 ○○○○○○○○○○○○○○○∘                               
-         |                                 ○○○○○○○○○○○○○○○○                               
-         |                             ·∘ ○○○○○○○○○○○○○○○○○○                              
-         |                             ○○∘○○○○○○○○○○○○○○○○○○○ ○                           
-     200 |                             ○○○○○○○○○○○○○○○○○○○○○○ ○                           
-         |                            ○○○○○○○○○○○○○○○○○○○○○○○○○                           
-         |                           ·○○○○○○○○○○○○○○○○○○○○○○○○○∘○                         
-         |                        · ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○·                        
-         |                        ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                       
-     100 |                       ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·○                     
-         |                    ○ ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·                    
-         |                  · ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘                   
-         |                 ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○  ·               
-         |             ··∘∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘·             
-       0 |···· ··∘··∘∘∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·∘···· ····
+     330 |                                                                                
+         |                                       ∘·  ·                                    
+         |                                    ··∘○○∘∘○·                                   
+         |                                 · ∘○○○○○○○○○ ··                                
+         |                                ·○○○○○○○○○○○○∘○○ ∘                              
+     250 |                               ∘○○○○○○○○○○○○○○○○○○                              
+         |                               ○○○○○○○○○○○○○○○○○○○                              
+         |                              ○○○○○○○○○○○○○○○○○○○○·                             
+         |                           ·· ○○○○○○○○○○○○○○○○○○○○○ ∘                           
+         |                           ○○∘○○○○○○○○○○○○○○○○○○○○○○○                           
+     160 |                          ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○                         
+         |                         ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                         
+         |                        ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘                        
+         |                       ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○  ·                    
+         |                      ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○○                    
+      80 |                   · ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                   
+         |                   ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○··                 
+         |                 ○·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                 
+         |            · ·○∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘·             
+         |            ○·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘∘·          
+       0 |·······∘·∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘∘∘∘······
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-       -3.61    -2.81    -2.01    -1.21    -0.41     0.40     1.20     2.00     2.80  
+       -3.31    -2.57    -1.84    -1.10    -0.37     0.37     1.10     1.84     2.57  
 ```
 
 Since the only information we have about `x` so far is its `Normal` prior, this distribution unsurprisingly looks normal. Later we'll see how to update our beliefs about `x` based on observational data.
@@ -96,102 +96,102 @@ For now, though, let's explore what we can do just with priors. `RandomVariable`
 
 ```scala
 scala> val e_x = x.map(_.exp)
-e_x: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@7ce65611
+e_x: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@4618a047
 
 scala> plot1D(e_x.sample())
-    2400 |                                                                                
-         | ·                                                                              
+    1830 |                                                                                
          | ○                                                                              
          | ○                                                                              
          | ○                                                                              
-    1800 |∘○                                                                              
-         |○○                                                                              
-         |○○·                                                                             
+         | ○                                                                              
+    1370 | ○○                                                                             
+         | ○○                                                                             
+         |·○○                                                                             
          |○○○                                                                             
          |○○○                                                                             
-    1200 |○○○                                                                             
-         |○○○                                                                             
-         |○○○○                                                                            
+     910 |○○○○                                                                            
          |○○○○                                                                            
          |○○○○∘                                                                           
-     600 |○○○○○                                                                           
          |○○○○○·                                                                          
-         |○○○○○○·                                                                         
+         |○○○○○○                                                                          
+     450 |○○○○○○∘                                                                         
          |○○○○○○○∘                                                                        
-         |○○○○○○○○○∘·                                                                     
-       0 |○○○○○○○○○○○○∘∘∘··························  ···     · ··    ·       ·    ·      ·
+         |○○○○○○○○·                                                                       
+         |○○○○○○○○○○∘                                                                     
+         |○○○○○○○○○○○○∘∘·                                                                 
+       0 |○○○○○○○○○○○○○○○○○∘∘∘∘∘··∘························ ·  ·· ·      ··   · · · ·    ·
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        0.0      3.5      7.1      10.6     14.1     17.6     21.1     24.6     28.1  
+        0.0      2.5      5.0      7.6      10.1     12.6     15.1     17.6     20.1  
 ```
 
 Or we can create another `Normal` parameter and zip the two together to produce a 2D gaussian. Since there's nothing relating these two parameters to each other, you can see in the plot that they're completely independent.
 
 ```scala
 scala> val y = Normal(0,1).param
-y: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@c23a6c4
+y: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@7a42cd6c
 
 scala> val xy = x.zip(y)
-xy: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@1477366
+xy: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@6945d067
 
 scala> plot2D(xy.sample())
-     3.8 |                                                                                
-         |                              ·                 ·                               
-         |                         ·   ·             ··  ··      ·                        
-         |                                ···· · ·  ······      ·  ·                      
-         |                  · · ·  ·· ··  · ········ ·  ···· ·· ·         ·               
-     2.0 |               ·   ·   ·· ················· ···············   ·     ·   ·       
-         |             · ··· · ·· ······························· · · ·····   ·    ·   ·  
-         |     ·  · · · ··········· ··································· ·      ·  ·       
-         |   ·    ·····  · · ··············∘··∘·∘∘···∘····∘····················· ··      ·
-         |   ·    ···  ··············∘·∘··∘·∘·∘∘∘∘∘∘∘∘∘·∘∘·····∘··············· ·· · ·    
-     0.2 |·      · ··············∘·····∘∘·∘∘∘∘∘∘∘∘∘∘○○∘○∘∘·∘∘∘··············· ···      ·  
-         |      ··  ···················∘∘○∘∘∘○∘∘∘∘○∘∘·∘○∘∘∘∘∘················ ······   ·  
-         |···   ···  ·················∘·∘∘∘∘○∘∘∘∘∘∘∘∘○∘∘∘∘∘∘∘∘·∘·∘·········· ·········    
-         |   ·   · ·  ·····················∘∘·∘∘∘∘∘∘∘∘∘∘∘∘···················· ···  ·    ·
-         |     ···· ·· ·· ·················∘·∘···∘∘∘∘·∘····∘···················  ·  ··    
-    -1.6 |      ·   · · · ······················∘·····∘∘················ ····· ·   ··    ·
-         |            ·· ··········· ··································· ·· ·             
-         |           ·        · ·· · ·· ···················  ····· · ···      ·     ·     
-         |                      ·· · ····· ·  ······ ·· ·  ··· ··· ··           ·         
-         |   ·          ·             ···· ··   ···   ··         · ·                      
-    -3.4 |                       ·           ·    · ·  ··       ·                         
+     3.6 |                                                                                
+         |                                  ·         ·   ·         ·   ·                 
+         |                  ·     ···  · ·      ·  ··    ·   ···      ·                   
+         |          ·       · ·   · ··   · ··· ····   ·· ···  ·  ·· ·                 ·   
+         |         ·         ······  ·····························   ·       ·            
+     1.7 |                ·  ············································· ·  ·     ·     
+         |    ·  ··  ········ ··········································· ···     ·  ·    
+         |       ·  ·  ··················∘∘·∘∘·∘∘∘···∘∘·∘······················ ··        
+         |   ·   ··  ·················∘··∘∘·∘○·∘∘○○○∘∘∘∘·∘∘·∘∘················· ···       
+         |·     ····· ···················∘∘∘○·○○○∘○○∘∘∘∘·∘∘∘∘················· · ··       
+    -0.2 |      ·   ·· ················∘∘·∘∘∘∘∘∘○○∘∘∘∘∘∘∘∘○∘∘∘················ ·····      
+         |  ·    · · ············∘······∘∘∘∘∘∘○∘∘∘∘∘∘∘∘∘∘∘∘∘○∘················· ···      ·
+         |     · ··  · ···················∘∘∘∘∘·∘∘∘·∘∘∘∘∘·∘·∘············· ···· · ··· ·   
+         | ·  ·   ····· ·······················∘····∘······∘·∘············· · · ·         
+         |          · ····· ·······················∘∘····················· · · ·   ··     
+    -2.2 |           ·   · · · ··· ························· ···· ·· ······  ·  · ·       
+         |            · ···  ·     ················· ·············· · · · ·  ·            
+         |                 ··  ·      · ··· · ···· ······ ·    ··  ·   ·                  
+         |                        · ·   ·  ··  · ·   ··  ··     ·   ·                     
+         |                            ·         ·  ·                                      
+    -4.1 |                     ·                         ·                                
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-       -3.57    -2.76    -1.96    -1.16    -0.36     0.44     1.24     2.04     2.84  
+       -3.74    -2.91    -2.07    -1.24    -0.41     0.43     1.26     2.10     2.93  
 ```
 
 Finally, we can use `flatMap` to create two parameters that *are* related to each other. In particular, we'll create a new parameter `z` that we believe to be very close to `x`: its prior is a `Normal` centered on `x` with a very small standard deviation. We'll then make a 2D plot of `(x,z)` to see the relationship.
 
 ```scala
 scala> val z = x.flatMap{a => Normal(a, 0.1).param}
-z: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@46cf30d1
+z: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@5e0257e7
 
 scala> val xz = x.zip(z)
-xz: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@7db1d351
+xz: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@195f24b8
 
 scala> plot2D(xz.sample())
-     3.9 |                                                                                
-         |                                                                           ·  ··
-         |                                                                      ······    
-         |                                                                  ······        
-         |                                                             ········           
-     1.8 |                                                          ········              
-         |                                                     ··········                 
-         |                                                 ···∘∘∘····                     
-         |                                             ···∘∘∘∘·· ·                        
-         |                                         ···∘○∘∘··                              
-    -0.3 |                                     ···∘○○∘···                                 
-         |                                  ··∘○○∘···                                     
-         |                              ···∘∘∘···                                         
-         |                          ····∘∘···                                             
-         |                       ········                                                 
-    -2.3 |                  ·········                                                     
-         |               ········                                                         
-         |            ·······                                                             
-         |         ····                                                                   
-         |                                                                                
-    -4.4 |·                                                                               
+     3.6 |                                                                                
+         |                                                                           · · ·
+         |                                                                       ·······  
+         |                                                                  ·······       
+         |                                                              ········          
+     1.7 |                                                          ·········             
+         |                                                      ········                  
+         |                                                  ···∘∘····                     
+         |                                             ····∘∘∘···                         
+         |                                         ····∘○∘∘···                            
+    -0.1 |                                      ···∘○∘∘···                                
+         |                                  ···∘○∘∘···                                    
+         |                               ··∘∘∘∘···                                        
+         |                           ····∘·····                                           
+         |                      ··········                                                
+    -2.0 |                   ·········                                                    
+         |                ········ ·                                                      
+         |            ········                                                            
+         |          ·····                                                                 
+         |     ·· · ·                                                                     
+    -3.9 |·    ·                                                                          
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        -4.5     -3.6     -2.6     -1.7     -0.7     0.3      1.2      2.2      3.1   
+       -4.04    -3.18    -2.32    -1.46    -0.59     0.27     1.13     1.99     2.85  
 ```
 
 You can see that although we still sample from the full range of `x` values, for any given sample, `x` and `z` are quite close to each other.
@@ -216,35 +216,38 @@ val poisson9: RandomVariable[_] = Poisson(9).fit(sales)
 val poisson10: RandomVariable[_] = Poisson(10).fit(sales)
 ```
 
-A `RandomVariable`'s density is a rather opaque object and, since it is almost never necessary to reach into a `RandomVariable` and get its current probability `density`, Rainier makes this hard to do. Taking on faith momentarily that
+Although it's almost never necessary, we can reach into any `RandomVariable` and get its current probability `density`:
 
 ```scala
-val poisson9density = -18.03523006575617
-val poisson10density = -19.135041188917896
+scala> poisson9.densityValue()
+res5: com.stripe.rainier.compute.Real = Constant(-18.03523032144858760000)
+
+scala> poisson10.densityValue()
+res6: com.stripe.rainier.compute.Real = Constant(-19.13504144461030920000)
 ```
 
-we can find the likelihood ratio of these two hypotheses. Since the density is stored in log space, the best way to do this numerically is to subtract the logs first before exponentiating:
+We can use this to find the likelihood ratio of these two hypotheses. Since the density is stored in log space, the best way to do this numerically is to subtract the logs first before exponentiating:
 
 ```scala
-scala> val lr = math.exp(poisson9density - poisson10density)
-lr: Double = 3.0035986601488043
+scala> val lr = (poisson9.densityValue() - poisson10.densityValue()).exp
+lr: com.stripe.rainier.compute.Real = Constant(3.0035986601487936)
 ```
 
 We can see here that our data is about 3x as likely to have come from a `Poisson(9)` as it is to have come from a `Poisson(10)`. We could keep doing this with a large number of values to build up a sense of the rate distribution, but it would be tedious, and we'd be ignoring any prior we had on the rate. Instead, the right way to do this in Rainier is to make the rate a parameter, and let the library do the hard work of exploring the space. Specifically, we can use `flatMap` to chain the creation of the parameter with the creation and fit of the `Poisson` distribution. Since we want our rate to be a positive number, and expect it to be more likely to be on the small side than the large side, the log-normal parameter we created earlier as `e_x` seems like a reasonable choice.
 
 ```scala
 scala> val poisson: RandomVariable[_] = e_x.flatMap{r => Poisson(r).fit(sales)}
-poisson: com.stripe.rainier.core.RandomVariable[_] = com.stripe.rainier.core.RandomVariable@12c14902
+poisson: com.stripe.rainier.core.RandomVariable[_] = com.stripe.rainier.core.RandomVariable@6116b453
 ```
 
 Reaching under the hood for a second: our `poisson9`'s `density` had no parameters whereas now, our model's density is a function of the parameter value
 
 ```scala
 scala> poisson9.density().nVars
-res5: Int = 0
+res7: Int = 0
 
 scala> poisson.density().nVars
-res6: Int = 1
+res8: Int = 1
 ```
 
 Rather than manipulating the `density` directly, we can sample the quantity we're actually interested in. To start with, let's try to sample the rate parameter of the Poisson, conditioned on our observed data. Here's almost the same thing we had above, recreated with the slightly friendlier `for` syntax, and yielding the `r` parameter at the end:
@@ -254,7 +257,7 @@ scala> val rate = for {
      |     r <- e_x
      |     poisson <- Poisson(r).fit(sales)
      | } yield r
-rate: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@50f2331
+rate: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@12a173a
 ```
 
 This is our first "full" model: we have a parameter with a log-normal prior, bundled into the `RandomVariable` named `e_x`; we use that parameter to initialize a `Poisson` noise distribution which we fit to our observations; and at the end, we output the same parameter (referenced by `r`) as the quantity we're interested in sampling from the posterior.
@@ -263,29 +266,29 @@ Let's plot the results!
 
 ```scala
 scala> plot1D(rate.sample())
-     370 |                                                                                
-         |                                ∘                                               
-         |                             ○  ○○·                                             
-         |                             ○ ∘○○○○∘                                           
-         |                            ○○○○○○○○○                                           
-     280 |                            ○○○○○○○○○  ∘                                        
-         |                         ○∘∘○○○○○○○○○○○○                                        
-         |                       ○·○○○○○○○○○○○○○○○∘·∘                                     
-         |                     ∘ ○○○○○○○○○○○○○○○○○○○○                                     
-         |                     ○○○○○○○○○○○○○○○○○○○○○○∘                                    
-     180 |                     ○○○○○○○○○○○○○○○○○○○○○○○ ∘·                                 
-         |                   ○○○○○○○○○○○○○○○○○○○○○○○○○○○○                                 
-         |                 ··○○○○○○○○○○○○○○○○○○○○○○○○○○○○                                 
-         |                 ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                                
-         |               · ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·∘                              
-      90 |              ·○∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○∘                           
-         |           ··∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○ ·                         
-         |          ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○ ·                      
-         |          ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘                     
-         |     ·· ∘∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘ ∘··              
-       0 |··∘·∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○∘∘··········
+     430 |                                                                                
+         |                         · ∘                                                    
+         |                         ○·○  ○                                                 
+         |                         ○○○  ○                                                 
+         |                      · ○○○○∘∘○                                                 
+     320 |                     ∘○∘○○○○○○○∘··                                              
+         |                    ·○○○○○○○○○○○○○  ·                                           
+         |                  · ○○○○○○○○○○○○○○··○                                           
+         |                  ○∘○○○○○○○○○○○○○○○○○                                           
+         |                 ○○○○○○○○○○○○○○○○○○○○                                           
+     210 |                ·○○○○○○○○○○○○○○○○○○○○··                                         
+         |               ·○○○○○○○○○○○○○○○○○○○○○○○∘                                        
+         |               ○○○○○○○○○○○○○○○○○○○○○○○○○ ∘                                      
+         |              ·○○○○○○○○○○○○○○○○○○○○○○○○○○○·                                     
+         |             ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                                     
+     100 |             ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·∘                                   
+         |           ∘·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘                                  
+         |        ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○· ·                               
+         |       ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘ ·                            
+         |      ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○∘····                       
+       0 |····∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘∘∘∘·∘·····           ·
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        4.84     5.61     6.37     7.14     7.90     8.67     9.44    10.20    10.97  
+        4.96     5.83     6.70     7.56     8.43     9.30    10.16    11.03    11.90  
 ```
 
 Looks like our daily rate is probably somewhere between 6 and 9, which corresponds well to the steep 3x dropoff we saw before between 9 and 10.
@@ -301,7 +304,7 @@ When we `map` or `flatMap` a `RandomVariable` (whether explicitly or inside a `f
 
 ```scala
 scala> e_x.value == rate.value
-res8: Boolean = true
+res10: Boolean = true
 ```
 
 So, for the same input in the latent parameter space, `e_x` and `rate` will produce the same output.
@@ -336,42 +339,42 @@ scala> val prediction = for {
      |     r <- e_x
      |     poisson <- Poisson(r).fit(sales)
      | } yield poisson.generator
-prediction: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@439eee6c
+prediction: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@2335e2b8
 ```
 
 This is almost the same model as `rate` above, but instead of taking the real-valued `r` rate parameter as the output, we're producing poisson-distributed integers. The samples look like this:
 
 ```scala
 scala> prediction.sample()
-res9: List[Int] = List(7, 13, 7, 6, 13, 7, 7, 5, 10, 5, 8, 9, 7, 9, 6, 11, 12, 3, 11, 9, 9, 4, 7, 9, 6, 15, 8, 5, 10, 13, 12, 7, 7, 9, 6, 12, 8, 9, 12, 5, 12, 6, 12, 13, 7, 10, 6, 4, 3, 9, 5, 6, 9, 4, 9, 7, 11, 7, 9, 7, 8, 14, 4, 6, 10, 6, 4, 7, 13, 7, 7, 11, 10, 13, 7, 10, 8, 5, 10, 6, 8, 13, 10, 6, 9, 4, 6, 11, 11, 6, 10, 4, 11, 6, 7, 3, 8, 6, 5, 6, 9, 13, 12, 6, 10, 3, 8, 9, 7, 7, 11, 10, 14, 8, 4, 5, 11, 12, 12, 8, 7, 11, 6, 8, 11, 6, 8, 8, 13, 3, 10, 8, 12, 12, 7, 5, 8, 8, 8, 14, 9, 16, 7, 14, 13, 5, 9, 4, 8, 5, 2, 4, 7, 6, 8, 6, 8, 10, 7, 4, 8, 8, 7, 6, 5, 7, 8, 11, 10, 7, 11, 10, 11, 7, 7, 11, 6, 5, 12, 8, 11, 4, 10, 8, 10, 3, 4, 6, 4, 9, 7, 5, 9, 5, 5, 8, 7, 8, 5, 8, 8, 9, 8, 8, 11, 5, 10, 11, 10, 5, 8, 5, 3, 13, 9, 13, 8, 14, 3, 5, 2, 9, 5, 2, 5, 6, 7,...
+res11: List[Int] = List(8, 10, 4, 11, 5, 7, 8, 3, 7, 13, 2, 5, 8, 6, 9, 4, 4, 9, 5, 12, 9, 6, 11, 7, 6, 5, 7, 13, 2, 8, 5, 11, 2, 14, 8, 13, 7, 11, 9, 8, 9, 9, 4, 7, 6, 8, 13, 14, 8, 5, 6, 6, 5, 6, 12, 7, 7, 6, 9, 7, 14, 6, 8, 5, 7, 9, 7, 7, 14, 7, 5, 6, 14, 6, 12, 6, 14, 4, 5, 10, 9, 6, 6, 7, 7, 5, 7, 8, 5, 9, 9, 4, 6, 7, 4, 8, 4, 9, 3, 6, 11, 5, 7, 9, 9, 7, 7, 10, 9, 13, 9, 11, 9, 7, 6, 6, 4, 1, 8, 3, 7, 7, 7, 7, 13, 10, 8, 3, 7, 10, 9, 4, 14, 9, 6, 8, 3, 6, 3, 11, 5, 5, 5, 7, 5, 11, 5, 10, 8, 10, 8, 10, 2, 9, 6, 13, 11, 4, 3, 6, 13, 8, 7, 8, 8, 7, 6, 15, 3, 4, 13, 11, 8, 10, 5, 6, 9, 10, 8, 9, 8, 13, 4, 7, 3, 5, 8, 5, 8, 10, 10, 8, 4, 11, 3, 7, 8, 8, 8, 8, 11, 8, 8, 4, 4, 5, 5, 6, 5, 1, 5, 20, 3, 6, 6, 8, 4, 9, 5, 13, 3, 9, 4, 15, 6, 8, 13, 3, 5, 12, 7, 3, 2...
 ```
 Or, if we plot them, like this:
 
 ```scala
 scala> plot1D(prediction.sample())
-    1430 |                                                                                
-         |                          ○                                                     
-         |                          ○                                                     
-         |                      ∘   ○   ∘                                                 
-         |                      ○   ○   ○                                                 
-    1070 |                      ○   ○   ○   ∘                                             
-         |                  ○   ○   ○   ○   ○                                             
-         |                  ○   ○   ○   ○   ○                                             
-         |                  ○   ○   ○   ○   ○                                             
-         |                  ○   ○   ○   ○   ○  ○                                          
-     710 |               ·  ○   ○   ○   ○   ○  ○                                          
-         |               ○  ○   ○   ○   ○   ○  ○                                          
-         |               ○  ○   ○   ○   ○   ○  ○   ∘                                      
-         |               ○  ○   ○   ○   ○   ○  ○   ○                                      
-         |               ○  ○   ○   ○   ○   ○  ○   ○                                      
-     350 |           ∘   ○  ○   ○   ○   ○   ○  ○   ○   ∘                                  
-         |           ○   ○  ○   ○   ○   ○   ○  ○   ○   ○                                  
-         |           ○   ○  ○   ○   ○   ○   ○  ○   ○   ○   ○                              
-         |       ·   ○   ○  ○   ○   ○   ○   ○  ○   ○   ○   ○   ·                          
-         |       ○   ○   ○  ○   ○   ○   ○   ○  ○   ○   ○   ○   ○  ·                       
-       0 |·  ∘   ○   ○   ○  ○   ○   ○   ○   ○  ○   ○   ○   ○   ○  ○   ∘   ∘   ·   ·  ·   ·
+    1350 |                                                                                
+         |                        ○  ·                                                    
+         |                    ○   ○  ○                                                    
+         |                    ○   ○  ○                                                    
+         |                    ○   ○  ○                                                    
+    1010 |                 ∘  ○   ○  ○   ∘                                                
+         |                 ○  ○   ○  ○   ○                                                
+         |                 ○  ○   ○  ○   ○  ·                                             
+         |                 ○  ○   ○  ○   ○  ○                                             
+         |                 ○  ○   ○  ○   ○  ○                                             
+     670 |             ·   ○  ○   ○  ○   ○  ○                                             
+         |             ○   ○  ○   ○  ○   ○  ○   ·                                         
+         |             ○   ○  ○   ○  ○   ○  ○   ○                                         
+         |             ○   ○  ○   ○  ○   ○  ○   ○                                         
+         |             ○   ○  ○   ○  ○   ○  ○   ○  ∘                                      
+     330 |          ○  ○   ○  ○   ○  ○   ○  ○   ○  ○                                      
+         |          ○  ○   ○  ○   ○  ○   ○  ○   ○  ○                                      
+         |          ○  ○   ○  ○   ○  ○   ○  ○   ○  ○   ○                                  
+         |      ∘   ○  ○   ○  ○   ○  ○   ○  ○   ○  ○   ○  ·                               
+         |      ○   ○  ○   ○  ○   ○  ○   ○  ○   ○  ○   ○  ○  ·                            
+       0 |·  ○  ○   ○  ○   ○  ○   ○  ○   ○  ○   ○  ○   ○  ○  ○   ∘  ∘   ·  ·   ·         ·
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        0.0      2.4      4.7      7.1      9.5      11.9     14.2     16.6     19.0  
+        0.0      2.6      5.2      7.8      10.4     13.0     15.6     18.2     20.8  
 ```
 
 ## `Likelihood` and `Predictor`
@@ -419,7 +422,7 @@ scala> val prior = for {
      |     slope <- LogNormal(0,1).param
      |     intercept <- LogNormal(0,1).param
      |     } yield (slope, intercept)
-prior: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@50992ee0
+prior: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@62294af9
 ```
 
 Now, for any given day `i`, we want to check the number of sales against `Poisson(intercept + slope*i)`. We could write some kind of recursive flatMap to build and fit each of these different distribution objects in turn, but this is a common enough pattern that Rainier already has something built in for it: `Predictor`. `Predictor` is not a `Distribution`, but instead wraps a function from `X => Distribution[Y]` for some `(X,Y)`; you can use this any time you have a dependent variable of type `Y` that you're modeling with some independent variables jointly represented as `X`.
@@ -433,7 +436,7 @@ scala> val regr = for {
      |                     Poisson(intercept + slope*i)
      |                 }.fit(data)
      | } yield (slope, intercept)
-regr: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@56dd6b7e
+regr: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@25c6893c
 ```
 
 As before, we're starting out by just sampling the parameters. By plotting them, we can see that the model's confidence in the intercept, in particular, is pretty low: although it's most likely to be somewhere around 8, it could be anywhere from 3 to 13 or even higher. Second, as you'd hope, the two parameters are anti-correlated:
@@ -441,29 +444,29 @@ a smaller intercept would imply a higher slope, and vice versa.
 
 ```scala
 scala> plot2D(regr.sample())
-    15.1 |                                                                                
-         |              ·                                                                 
-         |   ·       ·    ·    · · ·                                                      
-         |    · ······ · · · ····     · ··                                                
-         |·  ·  ·  · ················ ··                                                  
-    12.1 |· ·     ·· ··················· ··· · · ·                                        
-         |     ·  ························· ······  ·                                     
-         |      ····································· ··                                  
-         |  ·      ···············∘························  ··                           
-         |         ·   ··············∘∘∘·∘∘∘∘··∘············ ··   ·                       
-     9.2 |    ·        · ·········∘∘··∘∘∘∘∘∘∘∘∘∘∘∘············ · ·             ·          
-         |        ·    ··· ··········∘∘∘∘∘∘∘∘○○∘∘∘∘○∘···∘·············· · ·               
-         |              · ···········∘∘∘∘∘∘∘∘○∘∘∘○∘∘∘∘∘∘∘∘··∘∘·············   ·           
-         |                 ·   ···········∘∘∘∘∘∘∘○∘○○○○○∘∘∘∘∘∘·∘········· ·· · ·  ·       
-         |                        ·· ·········∘∘∘∘∘∘∘○∘∘∘∘∘∘∘·∘∘············· ·           
-     6.3 |                      ··  ··· ·········∘∘·∘∘∘∘∘∘∘·∘∘∘···∘········  ·· ·   ·     
-         |                            ··· · ·············∘··∘∘∘··∘············  ··   ·    
-         |                                ·   ···················∘············· ·· ·  ·   
-         |                                       ·  ··· ························· ·      ·
-         |                                       ·  ···  ········· ·········· · ··        
-     3.3 |                                                 · ·     · ·   ··            ·  
+    15.7 |                                                                                
+         |           ···     ·                                                            
+         |    ·                ·                                                          
+         |              · · ·····    ·        ·                                           
+         |           ·     ·· ··    ···  ·  ··· ·                                         
+    12.2 |·    ·   ···   ··· ················· · ·  ·                                     
+         |            ·  ····························   ·                                 
+         |               ·· ·································                             
+         |             · · ··············∘··∘·∘············· ····     ·                   
+         |                 ··· ············∘∘∘∘∘∘∘∘∘∘·∘·············                      
+     8.7 |                  · ··· ·········∘∘∘∘∘∘○∘○∘∘∘∘∘∘·············                   
+         |                        ··········∘·∘∘∘∘○○○○○○○○∘∘∘∘∘············· ·            
+         |                          ············∘∘∘∘○○○○○○○○∘○∘∘∘············  · ·        
+         |                              ···········∘·∘∘∘∘○∘○∘∘∘∘∘∘∘··············· ·      
+         |                            ·   · ··············∘∘∘∘∘∘··∘·∘··········· ··       
+     5.2 |                                  ·  ·  ··············∘·∘···················  · 
+         |                                        ·· ·  ························· · · ·  ·
+         |                                           ·  ·     · ··········· ········ · ·  
+         |                                                    ·   · ·······       ··      
+         |                                                                               ·
+     1.7 |                                                           ·                ·   
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        2.45     2.61     2.78     2.94     3.10     3.26     3.43     3.59     3.75  
+        2.26     2.45     2.63     2.82     3.00     3.18     3.37     3.55     3.73  
 ```
 
 Alternatively, as in the earlier example, we could try to predict what will happen tomorrow. This is similar to calling `poisson.generator` before, but this time, we use the `predict` method on `Predictor`, which takes the covariate (the day, in this case), and returns a `Generator` for the dependent variable (the number of sales). Putting it all together, it looks like this:
@@ -476,36 +479,36 @@ scala> val regr2 = for {
      |                     Poisson(intercept + slope*i)
      |                 }.fit(data)
      | } yield predictor.predict(21)
-regr2: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@e5f3ce1
+regr2: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@7e6eb544
 ```
 
 Plotting this gives us a prediction which incorporates both the natural noise of a Poisson distribution and our uncertainty about its underlying parameterization.
 
 ```scala
 scala> plot1D(regr2.sample())
-     470 |                                                                                
-         |                                 · ∘ ∘                                          
-         |                                 ○ ○ ○·                                         
-         |                                 ○ ○○○○· ∘                                      
-         |                              ∘ ○○ ○○○○○·○                                      
-     350 |                              ○·○○ ○○○○○○○                                      
-         |                              ○○○○ ○○○○○○○ ∘                                    
-         |                            · ○○○○ ○○○○○○○∘○∘                                   
-         |                           ·○○○○○○ ○○○○○○○○○○                                   
-         |                           ○○○○○○○ ○○○○○○○○○○  ·                                
-     230 |                         ·○○○○○○○○ ○○○○○○○○○○○ ○                                
-         |                         ○○○○○○○○○ ○○○○○○○○○○○ ○·                               
-         |                        ∘○○○○○○○○○ ○○○○○○○○○○○ ○○                               
-         |                      ○ ○○○○○○○○○○ ○○○○○○○○○○○ ○○○ ·                            
-         |                     ·○ ○○○○○○○○○○ ○○○○○○○○○○○ ○○○ ○                            
-     110 |                     ○○ ○○○○○○○○○○ ○○○○○○○○○○○ ○○○○○                            
-         |                  ∘∘·○○ ○○○○○○○○○○ ○○○○○○○○○○○ ○○○○○∘∘                          
-         |                  ○○○○○ ○○○○○○○○○○ ○○○○○○○○○○○ ○○○○○○○∘○                        
-         |                ·∘○○○○○ ○○○○○○○○○○ ○○○○○○○○○○○ ○○○○○○○○○○ ∘                     
-         |             ··○○○○○○○○ ○○○○○○○○○○ ○○○○○○○○○○○ ○○○○○○○○○○ ○∘○· ·                
-       0 |··· ······∘ ○○○○○○○○○○○ ○○○○○○○○○○ ○○○○○○○○○○○ ○○○○○○○○○○ ○○○○○○·∘··· · ·   ····
+     460 |                                                                                
+         |                              ∘                                                 
+         |                           ∘· ○                                                 
+         |                          ○○○○○○·                                               
+         |                       ·∘∘○○○○○○○·                                              
+     350 |                       ○○○○○○○○○○○○                                             
+         |                       ○○○○○○○○○○○○··                                           
+         |                      ·○○○○○○○○○○○○○○                                           
+         |                     ○○○○○○○○○○○○○○○○·                                          
+         |                     ○○○○○○○○○○○○○○○○○·                                         
+     230 |                   ○∘○○○○○○○○○○○○○○○○○○ ∘                                       
+         |                   ○○○○○○○○○○○○○○○○○○○○○○                                       
+         |                  ∘○○○○○○○○○○○○○○○○○○○○○○·                                      
+         |                 ○○○○○○○○○○○○○○○○○○○○○○○○○∘                                     
+         |                 ○○○○○○○○○○○○○○○○○○○○○○○○○○                                     
+     110 |               ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○·                                   
+         |               ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘                                  
+         |            ○·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○ ∘                               
+         |           ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○ ··                            
+         |        ·∘∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·                           
+       0 |·  ··∘∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘∘∘∘······   ·           ·
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        41.0     49.2     57.4     65.7     73.9     82.1     90.3     98.6    106.8  
+        45.0     53.9     62.8     71.7     80.6     89.5     98.4    107.3    116.2  
 ```
 
 Finally, let's close with a small and somewhat contrived example of a hierarchical model, where we have two separate regressions that share a parameter. For the sake of the example, let's assume that we have a second sales dataset, much like the first, where we know they had the same rate at the start of the observations, but may have grown at different rates - so their intercepts will be equal but their slopes will not. Here's the data:
@@ -525,7 +528,7 @@ scala> val regr3 =  for {
      |     _ <- Predictor.fromInt{ i => Poisson(intercept + slope0 * i) }.fit(data)
      |     _ <- Predictor.fromInt{ i => Poisson(intercept + slope1 * i) }.fit(data2)
      | } yield (slope0, intercept)
-regr3: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@289ee645
+regr3: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@6f3d5
 ```
 
 or we can use Rainier's `Lookup` to package the two slopes into a single `RandomVariable` from which we can lookup the one we want. This means that our predictor now has to take both the index of the model to which the data belongs as well as the actual observation as input.
@@ -539,36 +542,36 @@ scala> val regr4 = for {
      |   intercept <- LogNormal(0,1).param
      |   _ <- Predictor.fromIntPair{ case (index, x) => Poisson(intercept + slopes(index) * x) }.fit(allData)
      | } yield (slopes(0), intercept)
-regr4: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@32e1f26b
+regr4: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@2ed5baad
 ```
 
 Plotting slope vs. intercept now, we see that, even though these are two separate regressions, we get tighter bounds than before by letting the new data influence the shared parameter. It makes sense that we'd get more confidence on the intercept, since we have two different time series to learn from now; but because of the anti-correlation, that also leads to somewhat more confidence than before on the `slopes(0)` parameter as well.
 
 ```scala
 scala> plot2D(regr4.sample())
-    11.9 |                                                                                
-         |                       ·                                                        
-         |                                                                                
-         |           ·                                                                    
-         |   ·        ·  · · ·  ·                                                         
-     9.7 |         ·      · ·· ·     ··                                                   
-         |      ··   · ···· ·· ·  · ····  ··  ··                                          
-         |· ·     ··········· ················· · ·   ·                                   
-         |    ·   ···· ······························· ··  ·  ··                          
-         |      ··  ······································· ··                            
-     7.6 |·     ··················∘∘·∘∘··∘·∘······∘·············· ·                       
-         |        ·················∘·∘∘∘∘∘∘∘∘∘∘∘∘∘∘···················  · ·               
-         |     ·   ···· ············∘∘∘∘∘∘○∘∘○○∘○∘○∘∘∘∘·∘∘··············· ··    ·         
-         |               ···· ······∘∘∘∘∘∘∘○∘○∘○○∘∘∘∘○○∘∘∘∘∘···············    ··· ·      
-         |                 ·· ··········∘∘∘∘∘∘∘∘∘∘∘∘○∘○○∘∘∘∘∘·∘············ ·····   ·     
-     5.4 |                  ···················∘∘∘∘∘∘∘∘∘∘∘∘∘∘·∘∘················ ·· ·     
-         |                        ·  ···············∘····∘···∘··················· ·       
-         |                   · ·· ··    ·································· ·····   ···   ·
-         |                              ·  ··· ···················· ·········· ·    ·     
-         |                                   · ··  ··· ·   · ····· ·······   · ·     ·    
-     3.2 |                                              · ···   ····   ··                 
+    11.6 |                                                                                
+         |                  ·                                                             
+         |                             ·                                                  
+         |            · ·  ·   ·                                                          
+         |        ··  ·· ·   ··    ··                                                     
+     9.4 |·       ·· · ·  ··· ····· ··  ····   ····                                       
+         |      ·  ·············· ··· ······· ···    ·                                    
+         |   · ······ ·························· ·· ··  ·                                 
+         |··    ·· ········································   · ·                         
+         |    ···· ·················∘····∘···················· ···                        
+     7.1 |  ·    · ·············∘···∘∘∘∘∘∘∘∘∘∘·∘∘··············· ···· ·    ··             
+         |       ·· ·············∘··∘∘∘∘∘∘∘∘○∘∘∘∘∘∘∘∘············ ··· ····                
+         |         ·   ············∘·∘∘∘∘∘∘○∘∘∘∘○∘∘∘∘∘∘∘·················· ···   ·        
+         |           ···· ···············∘∘∘∘∘○○∘∘∘∘○∘∘○∘∘∘···∘·············  ·           
+         |                 ··· ···············∘∘·∘∘∘∘∘∘∘·∘····················  ·         
+     4.9 |                  · · ··········································· ···           
+         |                          ··  ·································  ······   ·    ·
+         |                             ·  · ································  · ·         
+         |                            ·     ·      · ·   ·· · · ····   · ·    ·       ·   
+         |                                               ·            ·    ·       ·      
+     2.6 |                                                         ·   ·  ·               
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        2.73     2.87     3.00     3.13     3.27     3.40     3.54     3.67     3.80  
+        2.75     2.89     3.03     3.16     3.30     3.44     3.57     3.71     3.85  
 ```
 
 ## Learning More

--- a/docs/tour.md
+++ b/docs/tour.md
@@ -30,7 +30,7 @@ Rainier implements various familiar families of probability distributions like t
 
 ```scala
 scala> val normal: Distribution[Double] = Normal(0,1)
-normal: com.stripe.rainier.core.Distribution[Double] = com.stripe.rainier.core.Injection$$anon$1@3af3f2ff
+normal: com.stripe.rainier.core.Distribution[Double] = com.stripe.rainier.core.Injection$$anon$1@3f2f9691
 ```
 
 In Rainier, `Distribution` objects play three different roles. `Continuous` distributions (like `Normal`), implement `param`, and all distributions implement `fit` and `generator`. Each of these methods is central to one of the three stages of building a model in Rainier:
@@ -51,43 +51,43 @@ Let's use that same `Normal(0,1)` distribution as a prior for a new parameter:
 
 ```scala
 scala> val x = Normal(0,1).param
-x: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@12923443
+x: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@5ef3e25f
 ```
 
 You can see that the type of `x` is `RandomVariable[Real]`. `RandomVariable` pairs a type of value (in this case, a real number) with some knowledge of the relative probability density of different values of that type. We can use this knowledge to produce a sample of these possible values:
 
 ```scala
 scala> x.sample()
-res0: List[Double] = List(-0.18335402858821503, 0.12637027213326735, -0.0909145715670816, -0.07166696569046849, 0.07803275896131082, -0.05040464075957829, 0.1897249425715697, -0.330228482917843, 0.29965009657113517, -0.40602332519956974, 0.441077167782878, -0.3949473715507188, 0.45978333367455837, -0.5143347774096683, 0.6465595812782159, -0.6291418113784523, 0.602344765822807, -0.6782438010324159, 0.6017609703237092, -0.5867708084865426, 0.6101485229941813, -0.642168306512582, 0.746102033263268, -0.9605321871082824, 0.8961307642704281, -0.929275238981264, 0.9299583803293722, -0.8849925826546923, 0.864738096148032, -0.89885494150736, 0.8132466530209046, -0.8692849626536547, 0.7123405480709657, -0.7424428425719571, 0.7295653489853273, -0.8074931634378057, 0.90256...
+res0: List[Double] = List(2.7320868146154833, -2.114482036120509, 1.8622401967684508, -2.1317031570134173, 1.4099652428520755, 1.4099652428520755, -1.9119610208674604, 1.5174995353655856, 1.5174995353655856, -1.3224056116513343, 1.1605088815846267, -1.059387184609826, 0.819204480401514, -0.826600300631543, 1.5740636261404948, -1.4522356859322578, 1.0088525762232425, -0.47095639978798864, 0.5494198693935901, -0.3336382551798249, 0.23636136930974416, -0.5895766586155893, 0.7738118483394821, 0.7738118483394821, -0.5862264157051207, 0.8181619383840418, -1.0154057558108898, -0.3260332232615033, -0.06800479011766747, 0.1089726524770406, 0.14764437975109945, -0.47610029166300893, 0.2799643641223927, -0.9914004408252017, 1.366414861041127, -1.5743852223344068, 1.829391...
 ```
 
 Each element of the list above represents a single sample from the distribution over `x`. It's easier to understand these if we plot them as a histogram:
 
 ```scala
 scala> plot1D(x.sample())
-     400 |                                                                                
-         |                                           ∘                                    
-         |                                   ·   ∘   ○                                    
-         |                                   ○ ○○○·○ ○                                    
-         |                                   ○ ○○○○○∘○○∘                                  
-     300 |                                  ○○○○○○○○○○○○·∘                                
-         |                                ○○○○○○○○○○○○○○○○                                
-         |                                ○○○○○○○○○○○○○○○○○·                              
-         |                               ∘○○○○○○○○○○○○○○○○○○·                             
-         |                               ○○○○○○○○○○○○○○○○○○○○                             
-     200 |                             ·∘○○○○○○○○○○○○○○○○○○○○ ∘                           
-         |                            ∘○○○○○○○○○○○○○○○○○○○○○○·○·                          
-         |                          ··○○○○○○○○○○○○○○○○○○○○○○○○○○                          
-         |                          ○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘                         
-         |                          ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·∘                       
-     100 |                       ·○∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○ ·                     
-         |                     ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○··                   
-         |                   ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                   
-         |                  ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                 
-         |               ··∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘∘ ·             
-       0 |·· ·····∘∘∘∘∘∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○∘·∘∘·······
+     230 |                                                                                
+         |                                          ·                                     
+         |                                      ∘   ○∘                                    
+         |                                    ·○○  ·○○∘      ·                            
+         |                             ·     ∘○○○  ○○○○      ○                            
+     170 |                            ∘○     ○○○○○ ○○○○      ○  ·     ·                   
+         |                       ○ ∘∘ ○○     ○○○○○ ○○○○      ○ ·○     ○                   
+         |                    ∘· ○○○○∘○○  ·  ○○○○○∘○○○○∘ ∘ ∘ ○○○○∘○·  ○                   
+         |                   ○○○ ○○○○○○○·∘○∘∘○○○○○○○○○○○ ○ ○○○○○○○○○○ ○                   
+         |                  ∘○○○·○○○○○○○○○○○○○○○○○○○○○○○○○ ○○○○○○○○○○○○○                  
+     110 |             ·   ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○   ∘             
+         |           · ○∘· ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○  ·○ ∘ ∘         
+         |         ·∘○○○○○ ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘∘○○∘○ ○         
+         |        ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·∘       
+         |       ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○       
+      50 |       ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○      
+         |      ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○      
+         |     ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘     
+         |    ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○ ·  
+         |  ·∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○  
+       0 |·∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘·
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-       -3.92    -3.05    -2.18    -1.31    -0.44     0.43     1.30     2.16     3.03  
+       -1.78    -1.38    -0.98    -0.59    -0.19     0.21     0.61     1.00     1.40  
 ```
 
 Since the only information we have about `x` so far is its `Normal` prior, this distribution unsurprisingly looks normal. Later we'll see how to update our beliefs about `x` based on observational data.
@@ -96,102 +96,102 @@ For now, though, let's explore what we can do just with priors. `RandomVariable`
 
 ```scala
 scala> val e_x = x.map(_.exp)
-e_x: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@5282b4d1
+e_x: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@548bca8e
 
 scala> plot1D(e_x.sample())
-     430 |                                                                                
-         |        ∘                                                                       
-         |       ○○                                                                       
-         |   ∘   ○○·                                                                      
-         |   ○   ○○○                                                                      
-     320 | ∘○○   ○○○                                                                      
-         | ○○○   ○○○·                                                                     
-         | ○○○   ○○○○                                                                     
-         | ○○○   ○○○○                                                                     
-         | ○○○  ∘○○○○·                                                                    
-     210 | ○○○  ○○○○○○                                                                    
-         | ○○○  ○○○○○○ ·                                                                  
-         | ○○○··○○○○○○∘○·○·                                                               
-         | ○○○○○○○○○○○○○○○○                       ○·○∘                                    
-         | ○○○○○○○○○○○○○○○○ · ∘ ∘  ∘ · ·      ∘∘·○○○○○○∘                                  
-     100 | ○○○○○○○○○○○○○○○○○○ ○○○  ○ ○○○· ○  ·○○○○○○○○○○○                                 
-         |○○○○○○○○○○○○○○○○○○○ ○○○  ○·○○○○·○○○○○○○○○○○○○○○           ∘  ·                  
-         |○○○○○○○○○○○○○○○○○○○∘○○○○·○○○○○○○○○○○○○○○○○○○○○○∘○· ·      ○○∘○○·∘  ·∘∘          
-         |○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·○ ·∘  ∘○○○○○○○∘○○○○·         
-         |○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○· ∘∘    
-       0 |○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘···
+    2600 |                                                                                
+         |·                                                                               
+         |○∘                                                                              
+         |○○                                                                              
+         |○○                                                                              
+    1900 |○○                                                                              
+         |○○                                                                              
+         |○○                                                                              
+         |○○·                                                                             
+         |○○○                                                                             
+    1300 |○○○                                                                             
+         |○○○                                                                             
+         |○○○                                                                             
+         |○○○·                                                                            
+         |○○○○                                                                            
+     600 |○○○○                                                                            
+         |○○○○∘                                                                           
+         |○○○○○∘                                                                          
+         |○○○○○○∘                                                                         
+         |○○○○○○○○∘                                                                       
+       0 |○○○○○○○○○○○∘∘·················································· ··· ·· ·  ·    ·
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        0.37     0.63     0.90     1.16     1.42     1.68     1.94     2.21     2.47  
+        0.0      4.3      8.6      12.9     17.2     21.6     25.9     30.2     34.5  
 ```
 
 Or we can create another `Normal` parameter and zip the two together to produce a 2D gaussian. Since there's nothing relating these two parameters to each other, you can see in the plot that they're completely independent.
 
 ```scala
 scala> val y = Normal(0,1).param
-y: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@63843992
+y: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@65bd5883
 
 scala> val xy = x.zip(y)
-xy: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@469ba2bc
+xy: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@18dad9e9
 
 scala> plot2D(xy.sample())
-     3.7 |                                                                                
-         |                                ·                                               
-         |                                      ·                ·    ·                   
-         |                ·       ·    ·· ·· ··  ··  ··· ··  ·                            
-         |                      ···· · ······· ····· ·· ······ · ··    ··                 
-     1.9 |           ·   ····· ································  ·····  ·                 
-         |            ·· ·· ··········································· · ·  ·            
-         |         ·  · ··· ······································· ···· ·                
-         |        · ·····················∘··∘∘∘∘··∘···∘·······················  ·    ·    
-         |·    ·  ·   ·· ···············∘∘∘·∘∘∘∘∘∘○·∘∘·∘∘·················  ·· ·          
-     0.1 |    ·     · ··············∘·∘∘∘∘∘∘∘∘∘∘∘○∘∘∘∘∘·∘·∘·∘∘···············  ·          
-         |    ·   · ················∘·∘···∘∘∘·∘∘∘∘∘·∘∘∘∘∘∘·∘∘··············· ·  ·        ·
-         |     ·  ·  ················∘·∘∘∘∘∘∘∘∘∘∘∘○∘∘∘·∘∘∘∘··················· ·          
-         |         ···  ··················∘∘∘○∘∘∘·∘∘∘·∘···∘············ ·· · ··  ·        
-         |         ····· ······················∘∘···∘·····∘············    · · ···        
-    -1.7 | ·        ················································· ····  ·  ·          
-         |        ·   ·     ····································· · · ··· ·     ·         
-         |             ·   ·  ·· ································· ·· · ·                 
-         |                       · · ·· ······················ ·· · ··                    
-         |                  ·    ···            · ·  ···    ····· ·                       
-    -3.5 |            ·           ·     · ·     · ·                                       
+     3.9 |                                                                                
+         |                                        · · · ·                                 
+         |                       ·        ·      ··         · ·                           
+         |                     ·        ···· ·· · · ··   ·    ··· ··   ·                  
+         |             ·      ·  · · ··········· ···· ··· ··   · ···                      
+     2.0 |                 ··  ··· · ······························  ·                    
+         |            · ·   ········································· ·  ·                
+         |     ·     ··  ·  ················∘························· ··· ···  ·         
+         |      ·    · ·················∘···∘∘·∘∘∘·∘∘∘·∘∘·············· · · ·             
+         |           ·    ··············∘··∘∘∘∘∘∘∘○∘∘∘∘∘∘∘∘·∘·················      · ·   
+     0.1 |·          ··  ·············∘∘·∘∘∘∘∘○○○∘○○∘∘∘∘∘∘∘·∘··∘···············           
+         |·   ·    ················∘···∘∘∘∘∘○∘∘○○○○∘○∘○∘∘∘∘·∘∘·············· · ·  ·      ·
+         |      ··  ··  ·· ·············∘∘∘∘∘∘∘∘∘∘○○∘○∘∘∘∘∘∘·∘·∘······· ····· · ··        
+         |           · ···················∘·∘∘∘∘∘∘∘○∘∘∘∘∘∘·∘················· ·· ··       
+         |        ·  ···   ······ ···········∘·∘···∘··∘∘∘················· ···     ·      
+    -1.7 |       ·  ·   ····· ·················∘········∘··············· · ·         ·    
+         |                    ··· ································ · ···    ·     ·       
+         |                     ···· ·· ··· ·· ·········· ····· ·  ·       ·      ·        
+         |                        ·   · ···· ······· ·· · ·· · ·  ·    ·   ·  ·           
+         |                         ···     ·····   ··           ·                         
+    -3.6 |                        ·              · ·                                      
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-       -3.62    -2.78    -1.94    -1.10    -0.26     0.58     1.43     2.27     3.11  
+        -4.1     -3.2     -2.3     -1.4     -0.4     0.5      1.4      2.3      3.2   
 ```
 
 Finally, we can use `flatMap` to create two parameters that *are* related to each other. In particular, we'll create a new parameter `z` that we believe to be very close to `x`: its prior is a `Normal` centered on `x` with a very small standard deviation. We'll then make a 2D plot of `(x,z)` to see the relationship.
 
 ```scala
 scala> val z = x.flatMap{a => Normal(a, 0.1).param}
-z: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@24e254c4
+z: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@7286a2f0
 
 scala> val xz = x.zip(z)
-xz: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@b448352
+xz: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@186ac4b4
 
 scala> plot2D(xz.sample())
-     4.0 |                                                                                
+     4.4 |                                                                                
          |                                                                               ·
-         |                                                                        · ··    
-         |                                                                    ······      
-         |                                                               ·······          
-     2.1 |                                                           ········             
-         |                                                      ········                  
-         |                                                  ··········                    
-         |                                              ···∘∘∘····                        
-         |                                        ····∘∘∘∘···                             
-     0.2 |                                     ···∘∘∘○∘···                                
-         |                                  ··∘○○○∘···                                    
-         |                             ···∘∘○○∘··                                         
-         |                          ··∘∘∘∘····                                            
-         |                     ····∘∘∘···                                                 
-    -1.8 |                  ·········                                                     
-         |              ·········                                                         
-         |           ········                                                             
-         |        ······                                                                  
-         |     ····                                                                       
-    -3.7 |· ···                                                                           
+         |                                                                      ·         
+         |                                                                     ···        
+         |                                                             ······             
+     2.5 |                                                          ······ ·              
+         |                                                      ·······                   
+         |                                                ··········                      
+         |                                            ··········                          
+         |                                         ···∘∘····                              
+     0.5 |                                    ···∘∘∘∘···                                  
+         |                                ···∘∘○∘···                                      
+         |                            ···∘○○∘····                                         
+         |                        ···∘∘∘∘····                                             
+         |                    ····∘∘∘···                                                  
+    -1.4 |                ·····∘····                                                      
+         |             ·········                                                          
+         |         ·········                                                              
+         |      ·······                                                                   
+         |   ·······                                                                      
+    -3.4 |· ·                                                                             
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-       -3.69    -2.83    -1.98    -1.12    -0.27     0.59     1.44     2.29     3.15  
+       -3.25    -2.39    -1.52    -0.66     0.21     1.07     1.94     2.80     3.67  
 ```
 
 You can see that although we still sample from the full range of `x` values, for any given sample, `x` and `z` are quite close to each other.
@@ -216,14 +216,11 @@ val poisson9: RandomVariable[_] = Poisson(9).fit(sales)
 val poisson10: RandomVariable[_] = Poisson(10).fit(sales)
 ```
 
-Since it is almost never necessary to reach into a `RandomVariable` and get its current probability `density`, Rainier makes this hard to do. Taking on faith momentarily that
+A `RandomVariable`'s density is a rather opaque objects and, since it is almost never necessary to reach into a `RandomVariable` and get its current probability `density`, Rainier makes this hard to do. Taking on faith momentarily that
 
 ```scala
-scala> val poisson9density = -18.03523006575617
-poisson9density: Double = -18.03523006575617
-
-scala> val poisson10density = -19.135041188917896
-poisson10density: Double = -19.135041188917896
+val poisson9density = -18.03523006575617
+val poisson10density = -19.135041188917896
 ```
 
 we can find the likelihood ratio of these two hypotheses. Since the density is stored in log space, the best way to do this numerically is to subtract the logs first before exponentiating:
@@ -237,23 +234,27 @@ We can see here that our data is about 3x as likely to have come from a `Poisson
 
 ```scala
 scala> val poisson: RandomVariable[_] = e_x.flatMap{r => Poisson(r).fit(sales)}
-poisson: com.stripe.rainier.core.RandomVariable[_] = com.stripe.rainier.core.RandomVariable@3d897c
+poisson: com.stripe.rainier.core.RandomVariable[_] = com.stripe.rainier.core.RandomVariable@12af2210
 ```
 
-By the way: before, when we looked at `poisson9.density`, the model had no parameters and so we got a constant value back. Now, since the model's density is a function of the parameter value, we get something more opaque back. This is why inspecting `density` is not normally useful.
+Reaching under the hood for a second: our `poisson9`'s `density` had no parameters whereas now, our model's density is a function of the parameter value
 
-```
-poisson.density
+```scala
+scala> poisson9.density().nVars
+res5: Int = 0
+
+scala> poisson.density().nVars
+res6: Int = 1
 ```
 
-Instead, we can sample the quantity we're actually interested in. To start with, let's try to sample the rate parameter of the Poisson, conditioned by our observed data. Here's almost the same thing we had above, recreated with the slightly friendlier `for` syntax, and yielding the `r` parameter at the end:
+As mentioned, the `density` itself is rather opaque so instead of manipulating it directly, we can sample the quantity we're actually interested in. To start with, let's try to sample the rate parameter of the Poisson, conditioned by our observed data. Here's almost the same thing we had above, recreated with the slightly friendlier `for` syntax, and yielding the `r` parameter at the end:
 
 ```scala
 scala> val rate = for {
      |     r <- e_x
      |     poisson <- Poisson(r).fit(sales)
      | } yield r
-rate: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@38404e54
+rate: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@60df0b8b
 ```
 
 This is our first "full" model: we have a parameter with a log-normal prior, bundled into the `RandomVariable` named `e_x`; we use that parameter to initialize a `Poisson` noise distribution which we fit to our observations; and at the end, we output the same parameter (referenced by `r`) as the quantity we're interested in sampling from the posterior.
@@ -262,29 +263,29 @@ Let's plot the results!
 
 ```scala
 scala> plot1D(rate.sample())
-     450 |                                                                                
-         |                           ∘ ∘                                                  
-         |                          ∘○∘○·∘                                                
-         |                          ○○○○○○                                                
-         |                         ○○○○○○○○·                                              
-     330 |                        ∘○○○○○○○○○                                              
-         |                     ∘ ○○○○○○○○○○○· ·                                           
-         |                    ∘○ ○○○○○○○○○○○○∘○·                                          
-         |                    ○○·○○○○○○○○○○○○○○○·                                         
-         |                    ○○○○○○○○○○○○○○○○○○○                                         
-     220 |                  ··○○○○○○○○○○○○○○○○○○○                                         
-         |                  ○○○○○○○○○○○○○○○○○○○○○∘                                        
-         |                  ○○○○○○○○○○○○○○○○○○○○○○··                                      
-         |               ·○∘○○○○○○○○○○○○○○○○○○○○○○○○                                      
-         |               ○○○○○○○○○○○○○○○○○○○○○○○○○○○∘∘                                    
-     110 |              ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘                                   
-         |              ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○··                                
-         |            ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·                               
-         |          ∘∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘                             
-         |       ·○∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘·∘·                         
-       0 |···∘∘·∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘··········    ·  ·   ·
+     390 |                                                                                
+         |                               ∘                                                
+         |                             ∘ ○                                                
+         |                           ○∘○ ○∘                                               
+         |                      ∘  ○○○○○∘○○                                               
+     290 |                     ∘○ ∘○○○○○○○○∘∘○                                            
+         |                     ○○·○○○○○○○○○○○○  ·                                         
+         |                    ·○○○○○○○○○○○○○○○  ○                                         
+         |                 ·○ ○○○○○○○○○○○○○○○○∘·○∘                                        
+         |                 ○○∘○○○○○○○○○○○○○○○○○○○○·                                       
+     190 |                 ○○○○○○○○○○○○○○○○○○○○○○○○  ·                                    
+         |                ∘○○○○○○○○○○○○○○○○○○○○○○○○ ·○                                    
+         |                ○○○○○○○○○○○○○○○○○○○○○○○○○∘○○                                    
+         |              ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘                                   
+         |            ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘                                 
+      90 |           ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○··                               
+         |           ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                               
+         |       ·∘∘∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘ ∘∘                           
+         |       ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○○∘∘                         
+         |   ∘ ○∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘·∘  ·                   
+       0 |·∘○○∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·∘∘·∘·· ·    ·   ·
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        4.6      5.5      6.5      7.4      8.3      9.3      10.2     11.1     12.1  
+        5.20     5.95     6.70     7.45     8.19     8.94     9.69    10.44    11.19  
 ```
 
 Looks like our daily rate is probably somewhere between 6 and 9, which corresponds well to the steep 3x dropoff we saw before between 9 and 10.
@@ -300,7 +301,7 @@ When we `map` or `flatMap` a `RandomVariable` (whether explicitly or inside a `f
 
 ```scala
 scala> e_x.value == rate.value
-res6: Boolean = true
+res8: Boolean = true
 ```
 
 So, for the same input in the latent parameter space, `e_x` and `rate` will produce the same output.
@@ -335,40 +336,40 @@ scala> val prediction = for {
      |     r <- e_x
      |     poisson <- Poisson(r).fit(sales)
      | } yield poisson.generator
-prediction: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@149239c5
+prediction: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@1514c8d1
 ```
 
 This is almost the same model as `rate` above, but instead of taking the real-valued `r` rate parameter as the output, we're producing poisson-distributed integers. The samples look like this:
 
 ```scala
 scala> prediction.sample()
-res7: List[Int] = List(10, 4, 16, 3, 5, 10, 11, 3, 8, 6, 5, 10, 12, 10, 7, 4, 8, 7, 6, 8, 7, 15, 7, 10, 5, 6, 5, 7, 7, 9, 10, 8, 9, 9, 12, 4, 5, 9, 7, 9, 5, 8, 8, 8, 8, 6, 8, 3, 9, 14, 7, 10, 7, 7, 7, 10, 12, 7, 5, 5, 13, 8, 9, 6, 6, 7, 4, 7, 5, 5, 3, 9, 10, 3, 9, 5, 2, 10, 3, 10, 8, 4, 10, 8, 6, 6, 7, 12, 7, 9, 8, 10, 9, 8, 5, 8, 9, 7, 8, 8, 11, 12, 9, 4, 4, 14, 11, 7, 3, 5, 5, 5, 6, 8, 9, 9, 10, 7, 4, 7, 9, 7, 7, 13, 10, 8, 9, 6, 5, 4, 5, 8, 7, 8, 6, 9, 7, 6, 10, 4, 7, 7, 12, 6, 4, 10, 7, 9, 6, 8, 8, 6, 7, 6, 3, 4, 9, 9, 10, 7, 4, 7, 6, 6, 10, 10, 7, 6, 8, 7, 8, 8, 6, 6, 7, 7, 12, 15, 4, 11, 9, 13, 5, 10, 6, 9, 9, 11, 8, 6, 7, 11, 10, 7, 12, 8, 4, 5, 11, 6, 4, 4, 14, 6, 9, 6, 10, 12, 5, 7, 5, 5, 6, 9, 7, 9, 8, 9, 2, 7, 8, 5, 4, 6, 8, 7, 10, 8, 11, 9, 13, 9, 9...
+res9: List[Int] = List(8, 15, 3, 10, 6, 7, 6, 10, 6, 6, 8, 3, 10, 7, 5, 7, 9, 5, 14, 1, 8, 9, 10, 7, 4, 8, 8, 9, 10, 8, 3, 10, 7, 6, 8, 8, 7, 5, 7, 4, 9, 1, 12, 7, 10, 7, 6, 6, 3, 7, 7, 10, 7, 9, 6, 9, 10, 7, 9, 9, 12, 5, 8, 10, 6, 7, 11, 6, 7, 4, 8, 6, 5, 5, 8, 10, 8, 7, 7, 12, 9, 7, 6, 10, 8, 7, 11, 14, 5, 8, 5, 7, 9, 2, 9, 6, 10, 14, 5, 13, 13, 4, 5, 7, 17, 8, 10, 6, 7, 8, 14, 5, 5, 10, 4, 6, 6, 11, 9, 6, 8, 8, 7, 8, 3, 10, 11, 4, 10, 9, 11, 9, 5, 11, 2, 6, 5, 5, 7, 7, 5, 10, 8, 8, 7, 12, 15, 12, 7, 9, 11, 6, 4, 7, 7, 7, 5, 9, 7, 6, 15, 6, 8, 4, 10, 5, 11, 6, 10, 4, 10, 9, 8, 6, 9, 6, 12, 10, 5, 13, 4, 6, 9, 3, 13, 12, 6, 7, 6, 14, 9, 5, 11, 6, 7, 10, 6, 7, 8, 2, 11, 2, 7, 11, 4, 7, 8, 10, 12, 7, 11, 8, 5, 7, 11, 11, 6, 7, 8, 9, 9, 9, 3, 3, 12, 8, 6, 8, 5, 1...
 ```
 Or, if we plot them, like this:
 
 ```scala
 scala> plot1D(prediction.sample())
-    1410 |                                                                                
-         |                        ○                                                       
-         |                    ∘   ○  ·                                                    
+    1360 |                                                                                
+         |                    ·   ○                                                       
+         |                    ○   ○  ∘                                                    
          |                    ○   ○  ○                                                    
-         |                    ○   ○  ○                                                    
-    1060 |                    ○   ○  ○                                                    
-         |                 ∘  ○   ○  ○   ·                                                
+         |                 ·  ○   ○  ○                                                    
+    1020 |                 ○  ○   ○  ○   ○                                                
          |                 ○  ○   ○  ○   ○                                                
-         |                 ○  ○   ○  ○   ○  ·                                             
+         |                 ○  ○   ○  ○   ○                                                
+         |                 ○  ○   ○  ○   ○  ∘                                             
          |                 ○  ○   ○  ○   ○  ○                                             
-     700 |             ·   ○  ○   ○  ○   ○  ○                                             
-         |             ○   ○  ○   ○  ○   ○  ○                                             
+     680 |             ∘   ○  ○   ○  ○   ○  ○                                             
+         |             ○   ○  ○   ○  ○   ○  ○   ·                                         
          |             ○   ○  ○   ○  ○   ○  ○   ○                                         
          |             ○   ○  ○   ○  ○   ○  ○   ○                                         
-         |             ○   ○  ○   ○  ○   ○  ○   ○  ·                                      
-     350 |          ∘  ○   ○  ○   ○  ○   ○  ○   ○  ○                                      
+         |             ○   ○  ○   ○  ○   ○  ○   ○  ∘                                      
+     340 |          ·  ○   ○  ○   ○  ○   ○  ○   ○  ○                                      
          |          ○  ○   ○  ○   ○  ○   ○  ○   ○  ○                                      
-         |          ○  ○   ○  ○   ○  ○   ○  ○   ○  ○   ○                                  
+         |          ○  ○   ○  ○   ○  ○   ○  ○   ○  ○   ∘                                  
          |      ∘   ○  ○   ○  ○   ○  ○   ○  ○   ○  ○   ○  ·                               
          |      ○   ○  ○   ○  ○   ○  ○   ○  ○   ○  ○   ○  ○  ·                            
-       0 |·  ○  ○   ○  ○   ○  ○   ○  ○   ○  ○   ○  ○   ○  ○  ○   ∘  ·   ·  ·          ·  ·
+       0 |·  ○  ○   ○  ○   ○  ○   ○  ○   ○  ○   ○  ○   ○  ○  ○   ∘  ∘   ·  ·   ·  ·   ·  ·
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
         0.0      2.6      5.2      7.8      10.4     13.0     15.6     18.2     20.8  
 ```
@@ -418,7 +419,7 @@ scala> val prior = for {
      |     slope <- LogNormal(0,1).param
      |     intercept <- LogNormal(0,1).param
      |     } yield (slope, intercept)
-prior: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@25dd0cdc
+prior: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@4bac3106
 ```
 
 Now, for any given day `i`, we want to check the number of sales against `Poisson(intercept + slope*i)`. We could write some kind of recursive flatMap to build and fit each of these different distribution objects in turn, but this is a common enough pattern that Rainier already has something built in for it: `Predictor`. `Predictor` is not a `Distribution`, but instead wraps a function from `X => Distribution[Y]` for some `(X,Y)`; you can use this any time you have a dependent variable of type `Y` that you're modeling with some independent variables jointly represented as `X`.
@@ -432,7 +433,7 @@ scala> val regr = for {
      |                     Poisson(intercept + slope*i)
      |                 }.fit(data)
      | } yield (slope, intercept)
-regr: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@79d43dad
+regr: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@2f02e317
 ```
 
 As before, we're starting out by just sampling the parameters. By plotting them, we can see that the model's confidence in the intercept, in particular, is pretty low: although it's most likely to be somewhere around 8, it could be anywhere from 3 to 13 or even higher. Second, as you'd hope, the two parameters are anti-correlated:
@@ -440,29 +441,29 @@ a smaller intercept would imply a higher slope, and vice versa.
 
 ```scala
 scala> plot2D(regr.sample())
-    16.2 |                                                                                
-         |     ·                                                                          
-         |            ·                                                                   
-         |·              ·    ·                                                           
-         |      ··    · ·    ·      ·                                                     
-    12.9 |       · ·  ······ ····· ·· ···    ·                                            
-         |    ···· ·  ······················  ·   ··                                      
-         |      ·  ·· ························· ··     ·                                  
-         |        · ·   ······························ · ··                               
-         |             ··································· · ·· ·                         
-     9.5 |              ··············∘∘∘∘·∘∘∘∘·∘∘·················                       
-         |                  ·············∘∘∘∘∘○∘○∘∘∘∘∘···············      ·              
-         |               ·  ··· ··········∘∘∘○○∘○∘○∘∘○∘∘∘·∘·············                  
-         |                        ··········∘∘∘∘∘○○○○∘○○○∘∘∘∘∘··············· · ·         
-         |                       ·  ············∘∘∘∘∘∘∘∘○○∘∘∘∘∘∘∘············             
-     6.1 |                          ·  ···············∘∘∘∘∘∘∘∘∘·∘∘··········· ··    ·     
-         |                               ··   ·················∘∘············ · ··· · ·   
-         |                                      · ·· ······························· ·  · 
-         |                                          ·  ·· ······················ ··  ·    
-         |                                            ·    ·        ·· ·· ·  ····· ·     ·
-     2.7 |                                                            ·           ·   ·   
+    15.3 |                                                                                
+         | ·               ·                                                              
+         |    ··    ·  ·  ·    ·                                                          
+         |       · ·  · · ··   ·   ·   ·                                                  
+         |      ·· ·· ·· ·· ····  ······· · ·                                             
+    12.1 |        ·  ························· ·                                          
+         |·        ··· ·····························   ·                                  
+         |    ·   ····· ··························· ·  ·   ·    ·                         
+         |         · · ·································· · ···    ·                      
+         |       ·   ·················∘∘∘∘∘∘···················  ·                        
+     8.9 |               ·············∘∘∘∘∘∘∘∘∘○∘∘∘∘∘∘············  ·                     
+         |                    ·········∘∘∘∘∘∘○○∘∘○∘∘∘∘∘·∘∘··············                  
+         |                   ···· ········∘∘∘∘∘○○○∘○○∘∘○∘∘∘·∘··············               
+         |                        · ··········∘∘∘∘∘∘○○○∘∘∘∘∘∘∘·∘·········· ··· ··         
+         |                          ···············∘∘∘∘∘∘∘∘∘∘∘∘·∘·············       ··   
+     5.8 |                         · ·   ···············∘∘∘∘∘·∘∘················ ··       
+         |                                 ·································· ···· ·      
+         |                                      · ·························· ····· ·      
+         |                                          · ··· · ·······················      ·
+         |                                         ·         · ··  ·    · · · ··  ·       
+     2.6 |                                                          ·       ·  ·   ·      
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        2.40     2.56     2.73     2.90     3.06     3.23     3.39     3.56     3.73  
+        2.41     2.58     2.75     2.92     3.08     3.25     3.42     3.59     3.75  
 ```
 
 Alternatively, as in the earlier example, we could try to predict what will happen tomorrow. This is similar to calling `poisson.generator` before, but this time, we use the `predict` method on `Predictor`, which takes the covariate (the day, in this case), and returns a `Generator` for the dependent variable (the number of sales). Putting it all together, it looks like this:
@@ -475,7 +476,7 @@ scala> val regr2 = for {
      |                     Poisson(intercept + slope*i)
      |                 }.fit(data)
      | } yield predictor.predict(21)
-regr2: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@50c2f90b
+regr2: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@1b5381ad
 ```
 
 Plotting this gives us a prediction which incorporates both the natural noise of a Poisson distribution and our uncertainty about its underlying parameterization.
@@ -483,28 +484,28 @@ Plotting this gives us a prediction which incorporates both the natural noise of
 ```scala
 scala> plot1D(regr2.sample())
      460 |                                                                                
-         |                               ∘  ∘·  ·                                         
-         |                               ○∘○○○○·○                                         
-         |                               ○○○○○○○○                                         
-         |                             ○ ○○○○○○○○·                                        
-     340 |                             ○ ○○○○○○○○○ ∘                                      
-         |                          · ○○ ○○○○○○○○○ ○                                      
-         |                         ∘○·○○ ○○○○○○○○○ ○∘                                     
-         |                         ○○○○○ ○○○○○○○○○ ○○∘○                                   
-         |                       ··○○○○○ ○○○○○○○○○ ○○○○○                                  
-     230 |                       ○○○○○○○ ○○○○○○○○○ ○○○○○                                  
-         |                       ○○○○○○○ ○○○○○○○○○ ○○○○○ ∘                                
-         |                      ·○○○○○○○ ○○○○○○○○○ ○○○○○∘○∘                               
-         |                      ○○○○○○○○ ○○○○○○○○○ ○○○○○○○○                               
-         |                   · ○○○○○○○○○ ○○○○○○○○○ ○○○○○○○○                               
-     110 |                   ○ ○○○○○○○○○ ○○○○○○○○○ ○○○○○○○○○                              
-         |                ··○○ ○○○○○○○○○ ○○○○○○○○○ ○○○○○○○○○ ○·                           
-         |                ○○○○ ○○○○○○○○○ ○○○○○○○○○ ○○○○○○○○○ ○○○                          
-         |               ○○○○○ ○○○○○○○○○ ○○○○○○○○○ ○○○○○○○○○ ○○○∘∘∘                       
-         |            ∘○○○○○○○ ○○○○○○○○○ ○○○○○○○○○ ○○○○○○○○○ ○○○○○○○○                     
-       0 |······∘∘∘○ ○○○○○○○○○ ○○○○○○○○○ ○○○○○○○○○ ○○○○○○○○○ ○○○○○○○○○ ○∘·∘∘···  · ·     ·
+         |                                         ∘                                      
+         |                                   ∘ ∘ ∘ ○○                                     
+         |                                   ○ ○○○ ○○∘ ○                                  
+         |                                  ○○·○○○ ○○○ ○                                  
+     340 |                                · ○○○○○○ ○○○∘○                                  
+         |                               ·○ ○○○○○○ ○○○○○  ○                               
+         |                              ○○○ ○○○○○○ ○○○○○○ ○                               
+         |                              ○○○ ○○○○○○ ○○○○○○ ○ ∘                             
+         |                            ∘·○○○ ○○○○○○ ○○○○○○ ○○○                             
+     230 |                            ○○○○○ ○○○○○○ ○○○○○○ ○○○                             
+         |                            ○○○○○ ○○○○○○ ○○○○○○ ○○○○○                           
+         |                           ∘○○○○○ ○○○○○○ ○○○○○○ ○○○○○ ·                         
+         |                           ○○○○○○ ○○○○○○ ○○○○○○ ○○○○○ ○∘                        
+         |                        ·∘ ○○○○○○ ○○○○○○ ○○○○○○ ○○○○○ ○○∘                       
+     110 |                        ○○ ○○○○○○ ○○○○○○ ○○○○○○ ○○○○○ ○○○·                      
+         |                      ·○○○ ○○○○○○ ○○○○○○ ○○○○○○ ○○○○○ ○○○○·                     
+         |                     ∘○○○○ ○○○○○○ ○○○○○○ ○○○○○○ ○○○○○ ○○○○○○ ·                  
+         |                  ○∘ ○○○○○ ○○○○○○ ○○○○○○ ○○○○○○ ○○○○○ ○○○○○○ ○○                 
+         |               ∘ ·○○ ○○○○○ ○○○○○○ ○○○○○○ ○○○○○○ ○○○○○ ○○○○○○ ○○○∘○·             
+       0 |·   ·· ···∘∘· ○○○○○○ ○○○○○ ○○○○○○ ○○○○○○ ○○○○○○ ○○○○○ ○○○○○○ ○○○○○○ ○○·∘· ······
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        43.0     51.1     59.2     67.3     75.4     83.6     91.7     99.8    107.9  
+        40.0     47.7     55.3     63.0     70.6     78.3     86.0     93.6    101.3  
 ```
 
 Finally, let's close with a small and somewhat contrived example of a hierarchical model, where we have two separate regressions that share a parameter. For the sake of the example, let's assume that we have a second sales dataset, much like the first, where we know they had the same rate at the start of the observations, but may have grown at different rates - so their intercepts will be equal but their slopes will not. Here's the data:
@@ -524,7 +525,7 @@ scala> val regr3 =  for {
      |     _ <- Predictor.fromInt{ i => Poisson(intercept + slope0 * i) }.fit(data)
      |     _ <- Predictor.fromInt{ i => Poisson(intercept + slope1 * i) }.fit(data2)
      | } yield (slope0, intercept)
-regr3: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@6b79045
+regr3: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@58cf4bc7
 ```
 
 or we can use Rainier's `Lookup` to package the two slopes into a single `RandomVariable` from which we can lookup the one we want. This means that our predictor now has to take both the index of the model to which the data belongs as well as the actual observation as input.
@@ -538,36 +539,36 @@ scala> val regLookup = for {
      |   intercept <- LogNormal(0,1).param
      |   _ <- Predictor.fromIntPair{ case (index, x) => Poisson(intercept + slopes(index) * x) }.fit(allData)
      | } yield (slopes(0), intercept)
-regLookup: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@62dd0be
+regLookup: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@7160a98d
 ```
 
 Plotting slope vs. intercept now, we see that, even though these are two separate regressions, we get tighter bounds than before by letting the new data influence the shared parameter. It makes sense that we'd get more confidence on the intercept, since we have two different time series to learn from now; but because of the anti-correlation, that also leads to somewhat more confidence than before on the `slopes(0)` parameter as well.
 
 ```scala
 scala> plot2D(regLookup.sample())
-    11.0 |                                                                                
-         |·               ·           ·                                                   
-         |                    ··   ·                                                      
-         |      · ·      ···· · ··   ··                ·                                  
-         |      ·  ·· ·· ··  ·······   · ······  · ·  ·                                   
-     9.1 | ·   ·  ··   ········ · ··········· ··  ···                                     
-         |  · ···  ··· ··························· ·  ··  ·                               
-         |    · ·· ······································· ··                             
-         |        ·   ·············∘·····∘····················· ·                         
-         |        · ·  ·············∘·∘∘·∘∘∘∘∘∘∘∘················   · ·                   
-     7.1 |       ·   ··············∘·∘∘∘∘∘∘∘∘∘∘∘∘∘∘··················· ·                  
-         |      ··   ·  ··············∘∘∘∘∘∘∘∘○∘∘∘○∘∘∘∘··∘··············  ·               
-         |             · · ··········∘·∘∘∘○∘∘∘○∘○○∘○○∘∘∘∘∘∘∘··········· ··                
-         |               ·  ············∘∘∘∘∘∘∘○○∘∘○∘○○○∘∘∘∘∘∘··············   ·    ·     
-         |               ·  ·  ·············∘∘∘∘∘∘∘○○∘∘∘∘∘∘∘∘∘··········· · ·····   ·     
-     5.2 |                     ················∘∘∘∘∘∘∘∘∘∘∘·∘·················   ···       
-         |                     ·   ··  ···············∘·······∘··············      ·  ·   
-         |                             ·  ·································  · ·          
-         |                               ·· ······ ················ ········ · ·     ·  · 
-         |                                     ·  · · ··········· · ··· ·  · ·           ·
-     3.3 |                                              ·  ·····  · ··     ··             
+    10.7 |                                                                                
+         |                         ·                                                      
+         |·           ·  ····   ··                                                        
+         |             · · · ··· ····  · · ··    ·                                        
+         |        ·  ······· ··············· ··   ··  ·                                   
+     8.8 |       ·        ·························· ·   ·                                
+         |      ·   ··  ······························· ·    ·      ·                     
+         |       ·      ··································  · ·                           
+         |             ·················∘∘∘·∘∘················  ·· ·                      
+         |                ············∘·∘∘∘∘∘∘∘∘∘∘·∘············· ·····  ·                
+     6.9 |            · · · ··········∘·∘∘∘∘○∘○○○∘∘∘∘∘∘················ ·                 
+         |                   ···········∘∘∘∘○∘∘∘○○○∘∘∘∘∘∘∘·∘········  · ·· ·              
+         |             ·  · ·· ············∘∘∘∘○○○○∘∘○∘○∘·∘∘··············   ·            
+         |                   · ··············∘∘∘∘∘∘∘∘∘∘∘∘∘∘·············   ··      ·      
+         |                ·     ··· · ···········∘∘∘∘∘∘∘∘∘·∘··················· ·         
+     5.0 |                         · ····················∘················                
+         |                         ·     ··· ··························· ·· ····          
+         |                              ···   ······························ ·            
+         |                                       ·· ·········· ············               
+         |                                             · ···     · · ·  · ·               
+     3.0 |                                                       ·      ·      ·         ·
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        2.68     2.83     2.97     3.12     3.26     3.41     3.55     3.70     3.85  
+        2.62     2.78     2.94     3.09     3.25     3.41     3.56     3.72     3.88  
 ```
 
 ## Learning More

--- a/docs/tour.md
+++ b/docs/tour.md
@@ -30,7 +30,7 @@ Rainier implements various familiar families of probability distributions like t
 
 ```scala
 scala> val normal: Distribution[Double] = Normal(0,1)
-normal: com.stripe.rainier.core.Distribution[Double] = com.stripe.rainier.core.Injection$$anon$1@59dd28b0
+normal: com.stripe.rainier.core.Distribution[Double] = com.stripe.rainier.core.Injection$$anon$1@369e8d17
 ```
 
 In Rainier, `Distribution` objects play three different roles. `Continuous` distributions (like `Normal`), implement `param`, and all distributions implement `fit` and `generator`. Each of these methods is central to one of the three stages of building a model in Rainier:
@@ -51,43 +51,43 @@ Let's use that same `Normal(0,1)` distribution as a prior for a new parameter:
 
 ```scala
 scala> val x = Normal(0,1).param
-x: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@68b8b03
+x: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@7cff1544
 ```
 
 You can see that the type of `x` is `RandomVariable[Real]`. `RandomVariable` pairs a type of value (in this case, a real number) with some knowledge of the relative probability density of different values of that type. We can use this knowledge to produce a sample of these possible values:
 
 ```scala
 scala> x.sample()
-res0: List[Double] = List(-0.5310496933506796, 0.49808970998312374, 0.49808970998312374, -0.5986527929482448, 0.869445190709651, -0.6019443511107341, 0.5612406779519676, -0.6082035971460475, 0.9659420210003276, -0.5393207107669853, 0.32700309526786, -0.29527586149715357, 0.23981674357575078, -0.3216981704203738, -0.04615624121769368, -0.052861959693735305, -0.5012620291134708, 0.42735088534888366, -0.517923832882594, 0.082942226000152, 0.17971850591172522, 0.03799100919698528, 0.14554829585726292, -0.007093594388935087, 0.07057633066241223, -0.4194569456680919, 0.7170767319659431, -0.839886602346586, 0.9433501750138381, 0.9433501750138381, -1.090726778471308, 0.8433245281096444, -0.85401769987228, -0.85401769987228, 0.9460189562401292, -1.0565260444066338, 1.01...
+res0: List[Double] = List(1.0789727641139946, -1.0553093839118644, 0.9723748750490253, 0.9723748750490253, -0.9603034968271834, 1.0768114428738016, -1.1247694864281526, 1.2529584415303971, -1.2102358458863696, 1.1906618333223538, -1.1010481737241804, 1.189633360634739, -1.228617170322838, 1.1178584597228283, -1.062429983199118, 1.093919341464783, -1.0190941838880936, 0.9342536325380304, -0.8992733368149997, 0.7688382377967731, -0.6834118973226806, 0.5416394052441835, -0.44677266563724793, 0.5248886112836716, -0.5502756722446693, 0.4734690290354755, -0.40028800194872294, 0.34258597136189106, -0.3732580029472242, 0.34310595686341183, -0.44770606816055514, 0.44470975743430263, -0.3363536041575017, 0.2510462366708255, -0.26377719195600396, 0.3628966071333155, -0.32...
 ```
 
 Each element of the list above represents a single sample from the distribution over `x`. It's easier to understand these if we plot them as a histogram:
 
 ```scala
 scala> plot1D(x.sample())
-     330 |                                                                                
-         |                                       ∘·  ·                                    
-         |                                    ··∘○○∘∘○·                                   
-         |                                 · ∘○○○○○○○○○ ··                                
-         |                                ·○○○○○○○○○○○○∘○○ ∘                              
-     250 |                               ∘○○○○○○○○○○○○○○○○○○                              
-         |                               ○○○○○○○○○○○○○○○○○○○                              
-         |                              ○○○○○○○○○○○○○○○○○○○○·                             
-         |                           ·· ○○○○○○○○○○○○○○○○○○○○○ ∘                           
-         |                           ○○∘○○○○○○○○○○○○○○○○○○○○○○○                           
-     160 |                          ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○                         
-         |                         ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                         
-         |                        ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘                        
-         |                       ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○  ·                    
-         |                      ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○○                    
-      80 |                   · ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                   
-         |                   ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○··                 
-         |                 ○·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                 
-         |            · ·○∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘·             
-         |            ○·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘∘·          
-       0 |·······∘·∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘∘∘∘······
+     430 |                                                                                
+         |                                       ∘   ∘                                    
+         |                                   ○ · ○  ∘○                                    
+         |                                   ○∘○○○ ·○○·                                   
+         |                                 ○∘○○○○○·○○○○                                   
+     320 |                               ∘ ○○○○○○○○○○○○○                                  
+         |                               ○∘○○○○○○○○○○○○○ ○                                
+         |                              ○○○○○○○○○○○○○○○○∘○                                
+         |                              ○○○○○○○○○○○○○○○○○○∘                               
+         |                             ○○○○○○○○○○○○○○○○○○○○·                              
+     210 |                           ·∘○○○○○○○○○○○○○○○○○○○○○                              
+         |                           ○○○○○○○○○○○○○○○○○○○○○○○○∘                            
+         |                          ·○○○○○○○○○○○○○○○○○○○○○○○○○·                           
+         |                          ○○○○○○○○○○○○○○○○○○○○○○○○○○○                           
+         |                        ·∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○                          
+     100 |                       ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘                         
+         |                      ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·                       
+         |                      ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○··                     
+         |                   ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                     
+         |                 ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·∘                   
+       0 |··   ········∘∘·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○··∘·······    ··
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-       -3.31    -2.57    -1.84    -1.10    -0.37     0.37     1.10     1.84     2.57  
+        -4.1     -3.2     -2.2     -1.3     -0.3     0.6      1.5      2.5      3.4   
 ```
 
 Since the only information we have about `x` so far is its `Normal` prior, this distribution unsurprisingly looks normal. Later we'll see how to update our beliefs about `x` based on observational data.
@@ -96,102 +96,102 @@ For now, though, let's explore what we can do just with priors. `RandomVariable`
 
 ```scala
 scala> val e_x = x.map(_.exp)
-e_x: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@4618a047
+e_x: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@633333be
 
 scala> plot1D(e_x.sample())
-    1830 |                                                                                
-         | ○                                                                              
-         | ○                                                                              
-         | ○                                                                              
-         | ○                                                                              
-    1370 | ○○                                                                             
-         | ○○                                                                             
-         |·○○                                                                             
+    4200 |                                                                                
+         |∘                                                                               
+         |○                                                                               
+         |○                                                                               
+         |○                                                                               
+    3100 |○                                                                               
+         |○                                                                               
+         |○                                                                               
+         |○                                                                               
+         |○                                                                               
+    2100 |○·                                                                              
+         |○○                                                                              
+         |○○                                                                              
+         |○○                                                                              
+         |○○·                                                                             
+    1000 |○○○                                                                             
          |○○○                                                                             
-         |○○○                                                                             
-     910 |○○○○                                                                            
-         |○○○○                                                                            
-         |○○○○∘                                                                           
-         |○○○○○·                                                                          
-         |○○○○○○                                                                          
-     450 |○○○○○○∘                                                                         
-         |○○○○○○○∘                                                                        
-         |○○○○○○○○·                                                                       
-         |○○○○○○○○○○∘                                                                     
-         |○○○○○○○○○○○○∘∘·                                                                 
-       0 |○○○○○○○○○○○○○○○○○∘∘∘∘∘··∘························ ·  ·· ·      ··   · · · ·    ·
+         |○○○∘                                                                            
+         |○○○○·                                                                           
+         |○○○○○··                                                                         
+       0 |○○○○○○○∘∘·∘·························· ···  ···  ·       · ··     ·    ·        ·
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        0.0      2.5      5.0      7.6      10.1     12.6     15.1     17.6     20.1  
+        0.0      6.9      13.7     20.6     27.4     34.3     41.1     48.0     54.8  
 ```
 
 Or we can create another `Normal` parameter and zip the two together to produce a 2D gaussian. Since there's nothing relating these two parameters to each other, you can see in the plot that they're completely independent.
 
 ```scala
 scala> val y = Normal(0,1).param
-y: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@7a42cd6c
+y: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@3fdff9f5
 
 scala> val xy = x.zip(y)
-xy: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@6945d067
+xy: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@635660e7
 
 scala> plot2D(xy.sample())
-     3.6 |                                                                                
-         |                                  ·         ·   ·         ·   ·                 
-         |                  ·     ···  · ·      ·  ··    ·   ···      ·                   
-         |          ·       · ·   · ··   · ··· ····   ·· ···  ·  ·· ·                 ·   
-         |         ·         ······  ·····························   ·       ·            
-     1.7 |                ·  ············································· ·  ·     ·     
-         |    ·  ··  ········ ··········································· ···     ·  ·    
-         |       ·  ·  ··················∘∘·∘∘·∘∘∘···∘∘·∘······················ ··        
-         |   ·   ··  ·················∘··∘∘·∘○·∘∘○○○∘∘∘∘·∘∘·∘∘················· ···       
-         |·     ····· ···················∘∘∘○·○○○∘○○∘∘∘∘·∘∘∘∘················· · ··       
-    -0.2 |      ·   ·· ················∘∘·∘∘∘∘∘∘○○∘∘∘∘∘∘∘∘○∘∘∘················ ·····      
-         |  ·    · · ············∘······∘∘∘∘∘∘○∘∘∘∘∘∘∘∘∘∘∘∘∘○∘················· ···      ·
-         |     · ··  · ···················∘∘∘∘∘·∘∘∘·∘∘∘∘∘·∘·∘············· ···· · ··· ·   
-         | ·  ·   ····· ·······················∘····∘······∘·∘············· · · ·         
-         |          · ····· ·······················∘∘····················· · · ·   ··     
-    -2.2 |           ·   · · · ··· ························· ···· ·· ······  ·  · ·       
-         |            · ···  ·     ················· ·············· · · · ·  ·            
-         |                 ··  ·      · ··· · ···· ······ ·    ··  ·   ·                  
-         |                        · ·   ·  ··  · ·   ··  ··     ·   ·                     
-         |                            ·         ·  ·                                      
-    -4.1 |                     ·                         ·                                
+     3.7 |                                                                                
+         |                    ·                                                           
+         |                                 · ·   ·  ··   ·                                
+         |                           ·· · ···· ···· ··  · ···  ·                          
+         |               ·   · · ······ ·························    ·                    
+     1.9 |                 ·  · ··································      ·  ·              
+         |               ·   ·· ································· ·· ·                    
+         |            ···   ················∘·∘··∘················· ····     ·            
+         |·     ·   ·     ··· ·········∘···∘·∘·∘∘··∘○∘∘∘·············· ·  ·· ·    ·    ·  
+         |      ·       ··· ·············∘∘∘∘∘○○∘∘○∘∘∘∘∘·∘∘∘················              
+     0.1 |      ·        ··············∘∘∘∘∘○○∘○○○∘○∘∘∘∘∘·∘··∘······· ··· ··              
+         |           · ··· ·········∘∘∘∘·∘∘∘∘∘○○○∘∘∘∘∘∘∘∘∘···············     ·  ·       ·
+         |     ·  ··     ·············∘··∘∘∘∘∘∘∘∘∘∘○∘○∘∘∘∘∘··············· ·   ·          
+         |  ·         · ··············∘∘∘∘∘∘∘∘∘∘∘∘∘○∘∘∘∘∘·················                
+         |         ·   ····· ············∘·∘·∘∘∘∘∘∘·∘∘·················    ·     ·   ··   
+    -1.7 |               · ·····················∘······················       · ·         
+         |               ···  ·································· ···· ·                   
+         |            ·    ···   ·  ···························· ···                      
+         |                  ·    · · ···· ······· ·······   ·                             
+         |                      ···  ·   ··· ·· ·· · · ·  ·  · ·                          
+    -3.5 |                       ·             ·    ·                                     
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-       -3.74    -2.91    -2.07    -1.24    -0.41     0.43     1.26     2.10     2.93  
+        -4.3     -3.3     -2.3     -1.3     -0.3     0.7      1.7      2.7      3.7   
 ```
 
 Finally, we can use `flatMap` to create two parameters that *are* related to each other. In particular, we'll create a new parameter `z` that we believe to be very close to `x`: its prior is a `Normal` centered on `x` with a very small standard deviation. We'll then make a 2D plot of `(x,z)` to see the relationship.
 
 ```scala
 scala> val z = x.flatMap{a => Normal(a, 0.1).param}
-z: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@5e0257e7
+z: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@70795ade
 
 scala> val xz = x.zip(z)
-xz: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@195f24b8
+xz: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@220f0f41
 
 scala> plot2D(xz.sample())
-     3.6 |                                                                                
-         |                                                                           · · ·
+     3.9 |                                                                                
+         |                                                                               ·
          |                                                                       ·······  
-         |                                                                  ·······       
-         |                                                              ········          
-     1.7 |                                                          ·········             
-         |                                                      ········                  
-         |                                                  ···∘∘····                     
-         |                                             ····∘∘∘···                         
-         |                                         ····∘○∘∘···                            
-    -0.1 |                                      ···∘○∘∘···                                
-         |                                  ···∘○∘∘···                                    
-         |                               ··∘∘∘∘···                                        
-         |                           ····∘·····                                           
-         |                      ··········                                                
-    -2.0 |                   ·········                                                    
-         |                ········ ·                                                      
+         |                                                                   · ·····      
+         |                                                                ········        
+     2.0 |                                                          ·········             
+         |                                                       ········ ·               
+         |                                                  ·····∘····                    
+         |                                              ···∘∘∘∘···                        
+         |                                          ···∘∘∘∘····                           
+     0.1 |                                      ···∘○○∘···                                
+         |                                 ····∘○○∘···                                    
+         |                               ··∘∘∘∘∘··                                        
+         |                          ····∘∘∘···                                            
+         |                       ····∘····                                                
+    -1.9 |                   ·········                                                    
+         |              ·········                                                         
          |            ········                                                            
-         |          ·····                                                                 
-         |     ·· · ·                                                                     
-    -3.9 |·    ·                                                                          
+         |         ······                                                                 
+         |    · ····                                                                      
+    -3.8 |··  ·                                                                           
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-       -4.04    -3.18    -2.32    -1.46    -0.59     0.27     1.13     1.99     2.85  
+       -3.90    -3.04    -2.18    -1.31    -0.45     0.41     1.27     2.13     3.00  
 ```
 
 You can see that although we still sample from the full range of `x` values, for any given sample, `x` and `z` are quite close to each other.
@@ -219,17 +219,17 @@ val poisson10: RandomVariable[_] = Poisson(10).fit(sales)
 Although it's almost never necessary, we can reach into any `RandomVariable` and get its current probability `density`:
 
 ```scala
-scala> poisson9.densityValue()
+scala> poisson9.densityValue
 res5: com.stripe.rainier.compute.Real = Constant(-18.03523032144858760000)
 
-scala> poisson10.densityValue()
+scala> poisson10.densityValue
 res6: com.stripe.rainier.compute.Real = Constant(-19.13504144461030920000)
 ```
 
 We can use this to find the likelihood ratio of these two hypotheses. Since the density is stored in log space, the best way to do this numerically is to subtract the logs first before exponentiating:
 
 ```scala
-scala> val lr = (poisson9.densityValue() - poisson10.densityValue()).exp
+scala> val lr = (poisson9.densityValue - poisson10.densityValue).exp
 lr: com.stripe.rainier.compute.Real = Constant(3.0035986601487936)
 ```
 
@@ -237,27 +237,25 @@ We can see here that our data is about 3x as likely to have come from a `Poisson
 
 ```scala
 scala> val poisson: RandomVariable[_] = e_x.flatMap{r => Poisson(r).fit(sales)}
-poisson: com.stripe.rainier.core.RandomVariable[_] = com.stripe.rainier.core.RandomVariable@6116b453
+poisson: com.stripe.rainier.core.RandomVariable[_] = com.stripe.rainier.core.RandomVariable@596b5ee2
 ```
 
-Reaching under the hood for a second: our `poisson9`'s `density` had no parameters whereas now, our model's density is a function of the parameter value
+By the way: before, when we looked at `poisson9.densityValue`, the model had no parameters and so we got a constant value back. Now, since the model's density is a function of the parameter value, we get something more opaque back. This is why inspecting `density` is not normally useful.
 
 ```scala
-scala> poisson9.density().nVars
-res7: Int = 0
-
-scala> poisson.density().nVars
-res8: Int = 1
+scala> poisson.densityValue
+res7: com.stripe.rainier.compute.Real = com.stripe.rainier.compute.Line@6214f757
 ```
 
-Rather than manipulating the `density` directly, we can sample the quantity we're actually interested in. To start with, let's try to sample the rate parameter of the Poisson, conditioned on our observed data. Here's almost the same thing we had above, recreated with the slightly friendlier `for` syntax, and yielding the `r` parameter at the end:
+Instead, we can sample the quantity we're actually interested in. To start with, let's try to sample the rate parameter of the Poisson, conditioned by our observed data. Here's almost the same thing we had above, recreated with the slightly friendlier `for` syntax, and yielding the `r` parameter at the end:
+
 
 ```scala
 scala> val rate = for {
      |     r <- e_x
      |     poisson <- Poisson(r).fit(sales)
      | } yield r
-rate: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@12a173a
+rate: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@3a4dcc6e
 ```
 
 This is our first "full" model: we have a parameter with a log-normal prior, bundled into the `RandomVariable` named `e_x`; we use that parameter to initialize a `Poisson` noise distribution which we fit to our observations; and at the end, we output the same parameter (referenced by `r`) as the quantity we're interested in sampling from the posterior.
@@ -266,29 +264,29 @@ Let's plot the results!
 
 ```scala
 scala> plot1D(rate.sample())
-     430 |                                                                                
-         |                         · ∘                                                    
-         |                         ○·○  ○                                                 
-         |                         ○○○  ○                                                 
-         |                      · ○○○○∘∘○                                                 
-     320 |                     ∘○∘○○○○○○○∘··                                              
-         |                    ·○○○○○○○○○○○○○  ·                                           
-         |                  · ○○○○○○○○○○○○○○··○                                           
-         |                  ○∘○○○○○○○○○○○○○○○○○                                           
-         |                 ○○○○○○○○○○○○○○○○○○○○                                           
-     210 |                ·○○○○○○○○○○○○○○○○○○○○··                                         
-         |               ·○○○○○○○○○○○○○○○○○○○○○○○∘                                        
-         |               ○○○○○○○○○○○○○○○○○○○○○○○○○ ∘                                      
-         |              ·○○○○○○○○○○○○○○○○○○○○○○○○○○○·                                     
-         |             ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                                     
-     100 |             ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·∘                                   
-         |           ∘·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘                                  
-         |        ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○· ·                               
-         |       ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘ ·                            
-         |      ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○∘····                       
-       0 |····∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘∘∘∘·∘·····           ·
+     370 |                                                                                
+         |                                ∘                                               
+         |                                ○      ∘                                        
+         |                                ○    · ○                                        
+         |                           ·   ∘○∘·· ○ ○                                        
+     270 |                           ○· ·○○○○○·○ ○                                        
+         |                        ·∘·○○ ○○○○○○○○○○                                        
+         |                        ○○○○○○○○○○○○○○○○○ ∘ ·                                   
+         |                       ○○○○○○○○○○○○○○○○○○ ○∘○  ·                                
+         |                       ○○○○○○○○○○○○○○○○○○ ○○○ ∘○                                
+     180 |                    ∘  ○○○○○○○○○○○○○○○○○○○○○○∘○○·                               
+         |                    ○○∘○○○○○○○○○○○○○○○○○○○○○○○○○○ ·                             
+         |                   ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·○                             
+         |               ·· ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                             
+         |               ○○ ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                             
+      90 |               ○○∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘ ··                         
+         |              ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘                        
+         |            ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                      
+         |          ○·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘∘∘○                  
+         |        ∘·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○∘ ··            
+       0 |· ·○·○∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○○○···○·······
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        4.96     5.83     6.70     7.56     8.43     9.30    10.16    11.03    11.90  
+        4.90     5.62     6.34     7.05     7.77     8.49     9.20     9.92    10.64  
 ```
 
 Looks like our daily rate is probably somewhere between 6 and 9, which corresponds well to the steep 3x dropoff we saw before between 9 and 10.
@@ -304,7 +302,7 @@ When we `map` or `flatMap` a `RandomVariable` (whether explicitly or inside a `f
 
 ```scala
 scala> e_x.value == rate.value
-res10: Boolean = true
+res9: Boolean = true
 ```
 
 So, for the same input in the latent parameter space, `e_x` and `rate` will produce the same output.
@@ -339,42 +337,42 @@ scala> val prediction = for {
      |     r <- e_x
      |     poisson <- Poisson(r).fit(sales)
      | } yield poisson.generator
-prediction: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@2335e2b8
+prediction: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@21c38ca1
 ```
 
 This is almost the same model as `rate` above, but instead of taking the real-valued `r` rate parameter as the output, we're producing poisson-distributed integers. The samples look like this:
 
 ```scala
 scala> prediction.sample()
-res11: List[Int] = List(8, 10, 4, 11, 5, 7, 8, 3, 7, 13, 2, 5, 8, 6, 9, 4, 4, 9, 5, 12, 9, 6, 11, 7, 6, 5, 7, 13, 2, 8, 5, 11, 2, 14, 8, 13, 7, 11, 9, 8, 9, 9, 4, 7, 6, 8, 13, 14, 8, 5, 6, 6, 5, 6, 12, 7, 7, 6, 9, 7, 14, 6, 8, 5, 7, 9, 7, 7, 14, 7, 5, 6, 14, 6, 12, 6, 14, 4, 5, 10, 9, 6, 6, 7, 7, 5, 7, 8, 5, 9, 9, 4, 6, 7, 4, 8, 4, 9, 3, 6, 11, 5, 7, 9, 9, 7, 7, 10, 9, 13, 9, 11, 9, 7, 6, 6, 4, 1, 8, 3, 7, 7, 7, 7, 13, 10, 8, 3, 7, 10, 9, 4, 14, 9, 6, 8, 3, 6, 3, 11, 5, 5, 5, 7, 5, 11, 5, 10, 8, 10, 8, 10, 2, 9, 6, 13, 11, 4, 3, 6, 13, 8, 7, 8, 8, 7, 6, 15, 3, 4, 13, 11, 8, 10, 5, 6, 9, 10, 8, 9, 8, 13, 4, 7, 3, 5, 8, 5, 8, 10, 10, 8, 4, 11, 3, 7, 8, 8, 8, 8, 11, 8, 8, 4, 4, 5, 5, 6, 5, 1, 5, 20, 3, 6, 6, 8, 4, 9, 5, 13, 3, 9, 4, 15, 6, 8, 13, 3, 5, 12, 7, 3, 2...
+res10: List[Int] = List(8, 7, 5, 4, 5, 7, 3, 10, 13, 11, 4, 7, 12, 6, 10, 10, 7, 5, 5, 9, 3, 5, 5, 8, 10, 14, 3, 9, 8, 15, 6, 4, 9, 5, 11, 9, 5, 6, 5, 8, 4, 11, 11, 8, 7, 11, 6, 6, 9, 7, 7, 6, 6, 14, 11, 14, 8, 5, 9, 5, 5, 8, 9, 4, 7, 0, 11, 9, 10, 7, 5, 9, 9, 7, 6, 13, 5, 5, 8, 9, 5, 12, 3, 9, 5, 12, 10, 3, 7, 8, 9, 11, 7, 15, 7, 15, 4, 7, 5, 8, 9, 11, 9, 9, 9, 5, 7, 13, 6, 6, 9, 4, 12, 12, 8, 7, 6, 12, 7, 13, 14, 2, 4, 5, 7, 5, 3, 10, 10, 10, 10, 7, 10, 7, 12, 10, 7, 5, 7, 8, 7, 6, 8, 8, 9, 9, 4, 10, 9, 5, 6, 14, 5, 7, 9, 3, 6, 1, 9, 8, 5, 7, 9, 10, 8, 14, 11, 8, 9, 7, 12, 8, 8, 9, 12, 5, 13, 7, 4, 8, 11, 12, 6, 6, 11, 3, 5, 5, 5, 7, 7, 7, 5, 10, 8, 8, 5, 12, 9, 2, 16, 7, 1, 11, 5, 7, 8, 7, 15, 8, 5, 6, 8, 4, 7, 10, 4, 5, 8, 4, 7, 11, 9, 3, 11, 8, 6, 7, 5, 5,...
 ```
 Or, if we plot them, like this:
 
 ```scala
 scala> plot1D(prediction.sample())
-    1350 |                                                                                
-         |                        ○  ·                                                    
-         |                    ○   ○  ○                                                    
-         |                    ○   ○  ○                                                    
-         |                    ○   ○  ○                                                    
-    1010 |                 ∘  ○   ○  ○   ∘                                                
-         |                 ○  ○   ○  ○   ○                                                
-         |                 ○  ○   ○  ○   ○  ·                                             
-         |                 ○  ○   ○  ○   ○  ○                                             
-         |                 ○  ○   ○  ○   ○  ○                                             
-     670 |             ·   ○  ○   ○  ○   ○  ○                                             
-         |             ○   ○  ○   ○  ○   ○  ○   ·                                         
-         |             ○   ○  ○   ○  ○   ○  ○   ○                                         
-         |             ○   ○  ○   ○  ○   ○  ○   ○                                         
-         |             ○   ○  ○   ○  ○   ○  ○   ○  ∘                                      
-     330 |          ○  ○   ○  ○   ○  ○   ○  ○   ○  ○                                      
-         |          ○  ○   ○  ○   ○  ○   ○  ○   ○  ○                                      
-         |          ○  ○   ○  ○   ○  ○   ○  ○   ○  ○   ○                                  
-         |      ∘   ○  ○   ○  ○   ○  ○   ○  ○   ○  ○   ○  ·                               
-         |      ○   ○  ○   ○  ○   ○  ○   ○  ○   ○  ○   ○  ○  ·                            
-       0 |·  ○  ○   ○  ○   ○  ○   ○  ○   ○  ○   ○  ○   ○  ○  ○   ∘  ∘   ·  ·   ·         ·
+    1360 |                                                                                
+         |                       ○                                                        
+         |                   ∘   ○  ○                                                     
+         |                   ○   ○  ○                                                     
+         |                   ○   ○  ○                                                     
+    1020 |                ∘  ○   ○  ○  ○                                                  
+         |                ○  ○   ○  ○  ○                                                  
+         |                ○  ○   ○  ○  ○                                                  
+         |                ○  ○   ○  ○  ○   ○                                              
+         |                ○  ○   ○  ○  ○   ○                                              
+     680 |             ·  ○  ○   ○  ○  ○   ○                                              
+         |             ○  ○  ○   ○  ○  ○   ○  ·                                           
+         |             ○  ○  ○   ○  ○  ○   ○  ○                                           
+         |             ○  ○  ○   ○  ○  ○   ○  ○                                           
+         |         ·   ○  ○  ○   ○  ○  ○   ○  ○  ·                                        
+     340 |         ○   ○  ○  ○   ○  ○  ○   ○  ○  ○                                        
+         |         ○   ○  ○  ○   ○  ○  ○   ○  ○  ○   ·                                    
+         |         ○   ○  ○  ○   ○  ○  ○   ○  ○  ○   ○                                    
+         |      ∘  ○   ○  ○  ○   ○  ○  ○   ○  ○  ○   ○  ∘                                 
+         |      ○  ○   ○  ○  ○   ○  ○  ○   ○  ○  ○   ○  ○  ∘                              
+       0 |·  ∘  ○  ○   ○  ○  ○   ○  ○  ○   ○  ○  ○   ○  ○  ○   ○  ·  ·   ·  ·  ·         ·
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        0.0      2.6      5.2      7.8      10.4     13.0     15.6     18.2     20.8  
+        0.0      2.7      5.4      8.1      10.8     13.6     16.3     19.0     21.7  
 ```
 
 ## `Likelihood` and `Predictor`
@@ -422,7 +420,7 @@ scala> val prior = for {
      |     slope <- LogNormal(0,1).param
      |     intercept <- LogNormal(0,1).param
      |     } yield (slope, intercept)
-prior: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@62294af9
+prior: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@3a9415d7
 ```
 
 Now, for any given day `i`, we want to check the number of sales against `Poisson(intercept + slope*i)`. We could write some kind of recursive flatMap to build and fit each of these different distribution objects in turn, but this is a common enough pattern that Rainier already has something built in for it: `Predictor`. `Predictor` is not a `Distribution`, but instead wraps a function from `X => Distribution[Y]` for some `(X,Y)`; you can use this any time you have a dependent variable of type `Y` that you're modeling with some independent variables jointly represented as `X`.
@@ -436,7 +434,7 @@ scala> val regr = for {
      |                     Poisson(intercept + slope*i)
      |                 }.fit(data)
      | } yield (slope, intercept)
-regr: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@25c6893c
+regr: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@735d021f
 ```
 
 As before, we're starting out by just sampling the parameters. By plotting them, we can see that the model's confidence in the intercept, in particular, is pretty low: although it's most likely to be somewhere around 8, it could be anywhere from 3 to 13 or even higher. Second, as you'd hope, the two parameters are anti-correlated:
@@ -444,29 +442,29 @@ a smaller intercept would imply a higher slope, and vice versa.
 
 ```scala
 scala> plot2D(regr.sample())
-    15.7 |                                                                                
-         |           ···     ·                                                            
-         |    ·                ·                                                          
-         |              · · ·····    ·        ·                                           
-         |           ·     ·· ··    ···  ·  ··· ·                                         
-    12.2 |·    ·   ···   ··· ················· · ·  ·                                     
-         |            ·  ····························   ·                                 
-         |               ·· ·································                             
-         |             · · ··············∘··∘·∘············· ····     ·                   
-         |                 ··· ············∘∘∘∘∘∘∘∘∘∘·∘·············                      
-     8.7 |                  · ··· ·········∘∘∘∘∘∘○∘○∘∘∘∘∘∘·············                   
-         |                        ··········∘·∘∘∘∘○○○○○○○○∘∘∘∘∘············· ·            
-         |                          ············∘∘∘∘○○○○○○○○∘○∘∘∘············  · ·        
-         |                              ···········∘·∘∘∘∘○∘○∘∘∘∘∘∘∘··············· ·      
-         |                            ·   · ··············∘∘∘∘∘∘··∘·∘··········· ··       
-     5.2 |                                  ·  ·  ··············∘·∘···················  · 
-         |                                        ·· ·  ························· · · ·  ·
-         |                                           ·  ·     · ··········· ········ · ·  
-         |                                                    ·   · ·······       ··      
-         |                                                                               ·
-     1.7 |                                                           ·                ·   
+    14.9 |                                                                                
+         | ·      ·    ·     ·                                                            
+         |     ·      ·  · ·  ·  ·                                                        
+         |        ··· ·  ·····  ··   ··  ·                                                
+         |·     · · ·  ··· ········· ·· ·                                                 
+    11.9 |       ······················· ···  ·      ·                                    
+         |     ·  ···· ······················· ·······                                    
+         |         ·· ································  ··                                
+         |            ··············∘∘∘∘∘·············· ····                              
+         |              · ··········∘∘∘∘∘∘∘∘∘∘∘·∘···········    ·                         
+     8.8 |                ···········∘∘∘∘∘∘○∘○○∘∘∘∘············ ·· ·                      
+         |              ·     ·······∘∘∘∘∘∘∘○○○○∘○∘∘∘∘∘·∘·········· ··                    
+         |                  ·  ···········∘∘∘∘○○○○○○○∘∘∘∘∘∘·········  ·                   
+         |                       ··········∘∘∘∘∘○∘○∘∘∘∘∘∘∘∘∘········· ··                  
+         |                           · ·········∘∘∘∘∘∘∘∘∘∘∘∘∘∘········· · · ·             
+     5.7 |                            ···············∘∘∘∘·∘·················              
+         |                                ·· ·················∘············ ··            
+         |                                ·    · ··························   ·  ·        
+         |                                             ····· · ············· ·   ·        
+         |                                                ·· ·   ··    ·   ·             ·
+     2.7 |                                                          ·     ··              
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        2.26     2.45     2.63     2.82     3.00     3.18     3.37     3.55     3.73  
+        2.37     2.56     2.74     2.93     3.12     3.30     3.49     3.68     3.86  
 ```
 
 Alternatively, as in the earlier example, we could try to predict what will happen tomorrow. This is similar to calling `poisson.generator` before, but this time, we use the `predict` method on `Predictor`, which takes the covariate (the day, in this case), and returns a `Generator` for the dependent variable (the number of sales). Putting it all together, it looks like this:
@@ -479,36 +477,36 @@ scala> val regr2 = for {
      |                     Poisson(intercept + slope*i)
      |                 }.fit(data)
      | } yield predictor.predict(21)
-regr2: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@7e6eb544
+regr2: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@754b7f65
 ```
 
 Plotting this gives us a prediction which incorporates both the natural noise of a Poisson distribution and our uncertainty about its underlying parameterization.
 
 ```scala
 scala> plot1D(regr2.sample())
-     460 |                                                                                
-         |                              ∘                                                 
-         |                           ∘· ○                                                 
-         |                          ○○○○○○·                                               
-         |                       ·∘∘○○○○○○○·                                              
-     350 |                       ○○○○○○○○○○○○                                             
-         |                       ○○○○○○○○○○○○··                                           
-         |                      ·○○○○○○○○○○○○○○                                           
-         |                     ○○○○○○○○○○○○○○○○·                                          
-         |                     ○○○○○○○○○○○○○○○○○·                                         
-     230 |                   ○∘○○○○○○○○○○○○○○○○○○ ∘                                       
-         |                   ○○○○○○○○○○○○○○○○○○○○○○                                       
-         |                  ∘○○○○○○○○○○○○○○○○○○○○○○·                                      
-         |                 ○○○○○○○○○○○○○○○○○○○○○○○○○∘                                     
-         |                 ○○○○○○○○○○○○○○○○○○○○○○○○○○                                     
-     110 |               ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○·                                   
-         |               ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘                                  
-         |            ○·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○ ∘                               
-         |           ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○ ··                            
-         |        ·∘∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·                           
-       0 |·  ··∘∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘∘∘∘······   ·           ·
+     470 |                                                                                
+         |                                ∘∘                                              
+         |                                ○○·∘                                            
+         |                               ·○○○○∘ ∘                                         
+         |                               ○○○○○○ ○○                                        
+     350 |                            ·  ○○○○○○○○○  ·                                     
+         |                            ○○∘○○○○○○○○○ ○○                                     
+         |                          · ○○○○○○○○○○○○ ○○                                     
+         |                         ∘○ ○○○○○○○○○○○○ ○○○                                    
+         |                         ○○ ○○○○○○○○○○○○ ○○○ ·                                  
+     230 |                         ○○ ○○○○○○○○○○○○ ○○○○○                                  
+         |                       ··○○ ○○○○○○○○○○○○ ○○○○○∘                                 
+         |                       ○○○○ ○○○○○○○○○○○○ ○○○○○○·                                
+         |                     ·○○○○○ ○○○○○○○○○○○○ ○○○○○○○                                
+         |                     ○○○○○○ ○○○○○○○○○○○○ ○○○○○○○○∘                              
+     110 |                   ·○○○○○○○ ○○○○○○○○○○○○ ○○○○○○○○○·                             
+         |                  ○○○○○○○○○ ○○○○○○○○○○○○ ○○○○○○○○○○∘                            
+         |                ·∘○○○○○○○○○ ○○○○○○○○○○○○ ○○○○○○○○○○○○·                          
+         |              ··○○○○○○○○○○○ ○○○○○○○○○○○○ ○○○○○○○○○○○○○ ∘·                       
+         |           ·∘ ○○○○○○○○○○○○○ ○○○○○○○○○○○○ ○○○○○○○○○○○○○ ○○○∘·                    
+       0 |·· ·······∘○○ ○○○○○○○○○○○○○ ○○○○○○○○○○○○ ○○○○○○○○○○○○○ ○○○○○○∘·∘··· ·· ·       ·
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        45.0     53.9     62.8     71.7     80.6     89.5     98.4    107.3    116.2  
+        42.0     50.3     58.7     67.0     75.3     83.7     92.0    100.4    108.7  
 ```
 
 Finally, let's close with a small and somewhat contrived example of a hierarchical model, where we have two separate regressions that share a parameter. For the sake of the example, let's assume that we have a second sales dataset, much like the first, where we know they had the same rate at the start of the observations, but may have grown at different rates - so their intercepts will be equal but their slopes will not. Here's the data:
@@ -528,7 +526,7 @@ scala> val regr3 =  for {
      |     _ <- Predictor.fromInt{ i => Poisson(intercept + slope0 * i) }.fit(data)
      |     _ <- Predictor.fromInt{ i => Poisson(intercept + slope1 * i) }.fit(data2)
      | } yield (slope0, intercept)
-regr3: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@6f3d5
+regr3: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@44bc3e7d
 ```
 
 or we can use Rainier's `Lookup` to package the two slopes into a single `RandomVariable` from which we can lookup the one we want. This means that our predictor now has to take both the index of the model to which the data belongs as well as the actual observation as input.
@@ -542,36 +540,36 @@ scala> val regr4 = for {
      |   intercept <- LogNormal(0,1).param
      |   _ <- Predictor.fromIntPair{ case (index, x) => Poisson(intercept + slopes(index) * x) }.fit(allData)
      | } yield (slopes(0), intercept)
-regr4: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@2ed5baad
+regr4: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@157080fc
 ```
 
 Plotting slope vs. intercept now, we see that, even though these are two separate regressions, we get tighter bounds than before by letting the new data influence the shared parameter. It makes sense that we'd get more confidence on the intercept, since we have two different time series to learn from now; but because of the anti-correlation, that also leads to somewhat more confidence than before on the `slopes(0)` parameter as well.
 
 ```scala
 scala> plot2D(regr4.sample())
-    11.6 |                                                                                
-         |                  ·                                                             
-         |                             ·                                                  
-         |            · ·  ·   ·                                                          
-         |        ··  ·· ·   ··    ··                                                     
-     9.4 |·       ·· · ·  ··· ····· ··  ····   ····                                       
-         |      ·  ·············· ··· ······· ···    ·                                    
-         |   · ······ ·························· ·· ··  ·                                 
-         |··    ·· ········································   · ·                         
-         |    ···· ·················∘····∘···················· ···                        
-     7.1 |  ·    · ·············∘···∘∘∘∘∘∘∘∘∘∘·∘∘··············· ···· ·    ··             
-         |       ·· ·············∘··∘∘∘∘∘∘∘∘○∘∘∘∘∘∘∘∘············ ··· ····                
-         |         ·   ············∘·∘∘∘∘∘∘○∘∘∘∘○∘∘∘∘∘∘∘·················· ···   ·        
-         |           ···· ···············∘∘∘∘∘○○∘∘∘∘○∘∘○∘∘∘···∘·············  ·           
-         |                 ··· ···············∘∘·∘∘∘∘∘∘∘·∘····················  ·         
-     4.9 |                  · · ··········································· ···           
-         |                          ··  ·································  ······   ·    ·
-         |                             ·  · ································  · ·         
-         |                            ·     ·      · ·   ·· · · ····   · ·    ·       ·   
-         |                                               ·            ·    ·       ·      
-     2.6 |                                                         ·   ·  ·               
+    11.1 |                                                                                
+         |           ·                                                                    
+         |·   ·      ·                                                                    
+         |      ··    ·      · ·         ·                                                
+         | ·  ·   · · ··  ···   ·   · ··  ·               ·                               
+     9.1 |···  · ··   ·· ······· · ······· ·  ···   ·                                     
+         |   ·  ······· ······················ ······      ·                              
+         |  ·   ··· ······································ ·  ·· ··               ·       
+         |·     ············································ ···                          
+         |     · ···············∘···∘·∘∘·∘∘∘·∘···················· ··· ·   · ·           ·
+     7.0 |      ·  · ················∘∘∘∘∘∘∘○∘∘∘·∘····················· · ·               
+         |   · ··    ·  ··········∘···∘∘∘∘∘∘∘∘∘∘∘○∘∘∘∘∘∘∘················· · ·· ·         
+         |       · ··   ····· ··········∘∘∘∘∘∘∘∘∘∘○∘∘∘∘∘∘∘·∘·············· · ·     · ·    
+         |     ·     · ·   ··············∘·∘∘∘∘○∘∘∘○∘∘∘∘∘∘∘∘∘···∘·············· · ·       
+         |    ·         ·  ···· ···············∘∘∘∘∘∘·∘∘∘∘∘∘················· ·    · ·    
+     5.0 |                ·         ····················∘∘··∘∘··∘··········· ·····   ···  
+         |            ·        ·· · · ·· ········································ ··     ·
+         |                               ·  · ······························ ···   ·      
+         |                                   ·   · ····· ········ ··  ···   ·   · ·  ·    
+         |                                    ·      · ·    · ··     ·   ·    ·  ·  ·     
+     3.0 |                                                                              · 
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        2.75     2.89     3.03     3.16     3.30     3.44     3.57     3.71     3.85  
+        2.77     2.89     3.02     3.15     3.27     3.40     3.52     3.65     3.78  
 ```
 
 ## Learning More

--- a/docs/tour.md
+++ b/docs/tour.md
@@ -30,7 +30,7 @@ Rainier implements various familiar families of probability distributions like t
 
 ```scala
 scala> val normal: Distribution[Double] = Normal(0,1)
-normal: com.stripe.rainier.core.Distribution[Double] = com.stripe.rainier.core.Injection$$anon$1@7253eb2a
+normal: com.stripe.rainier.core.Distribution[Double] = com.stripe.rainier.core.Injection$$anon$1@3b6830b7
 ```
 
 In Rainier, `Distribution` objects play three different roles. `Continuous` distributions (like `Normal`), implement `param`, and all distributions implement `fit` and `generator`. Each of these methods is central to one of the three stages of building a model in Rainier:
@@ -51,43 +51,43 @@ Let's use that same `Normal(0,1)` distribution as a prior for a new parameter:
 
 ```scala
 scala> val x = Normal(0,1).param
-x: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@b2d0943
+x: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@37da90f9
 ```
 
 You can see that the type of `x` is `RandomVariable[Real]`. `RandomVariable` pairs a type of value (in this case, a real number) with some knowledge of the relative probability density of different values of that type. We can use this knowledge to produce a sample of these possible values:
 
 ```scala
 scala> x.sample()
-res0: List[Double] = List(0.7213668558017945, -0.5078214024317078, 0.531292046325315, -0.55848000289016, 0.36167369679489214, -0.37660283559841884, 0.3253573362820674, -0.42560296041627765, 0.3937737948617706, -0.39657132710220916, 0.36536141883005274, -0.32163770600589503, 0.3035313028564322, -0.2307281758826154, 0.2267489961769043, -0.20443125521560027, 0.07257087455666555, -0.10153264544830753, 0.2178616829045299, -0.26100875365982645, 0.2093664119227987, -0.24473854529374572, 0.17728167529249172, -0.12281826813696173, 0.04172764114483507, -0.09259797421135885, 0.0493152917439903, -0.10400265230062078, 0.10356298784663787, -0.2422249120796085, 0.18774324808422027, -0.14381221976943637, 0.09185446778991313, -0.13646427675880268, 0.050318370570520354, 0.089812...
+res0: List[Double] = List(-0.35220846848274046, 0.5858005436586071, -1.2621642960996353, 1.725652319545246, -1.31900274208508, 0.23857488725666265, -0.4906905385717083, 0.1471117947718792, -0.5754910098351603, 0.9032656551750851, -0.1211261014093421, 0.02994936266575221, 0.18948263017233014, 0.08789582956110431, 0.3529053921650007, 0.20363459646390325, -0.7585765027673335, 0.9136150273090323, -1.6869496668527377, 1.363460590284482, -1.0440452946097523, 1.1748327160355092, -0.7889109373128986, 0.6862335881593147, -1.6139490728424328, 1.0983574998917889, 1.0983574998917889, -0.9405507597977106, 0.7201410639868797, -0.24054182865453977, -0.24054182865453977, 0.5987389539152949, -0.14376701926065283, 0.3670848849572113, 0.3670848849572113, 0.18505125535008626, -0.2...
 ```
 
 Each element of the list above represents a single sample from the distribution over `x`. It's easier to understand these if we plot them as a histogram:
 
 ```scala
 scala> plot1D(x.sample())
-     360 |                                                                                
-         |                                        ∘                                       
-         |                                    ·   ○ ∘                                     
-         |                                 ∘  ○   ○ ○ ○                                   
-         |                                 ○ ·○○○∘○·○·○∘ ·                                
-     270 |                               ∘ ○∘○○○○○○○○○○○○○∘                               
-         |                               ○ ○○○○○○○○○○○○○○○○ ·                             
-         |                              ∘○○○○○○○○○○○○○○○○○○○○                             
-         |                              ○○○○○○○○○○○○○○○○○○○○○  ·                          
-         |                            ○ ○○○○○○○○○○○○○○○○○○○○○∘ ○                          
-     180 |                          ··○○○○○○○○○○○○○○○○○○○○○○○○·○·                         
-         |                         ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                         
-         |                       ∘·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘                        
-         |                       ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                      
-         |                      ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                      
-      90 |                      ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘                     
-         |                    ·∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘·                   
-         |                  ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘∘                 
-         |               ·∘·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘  ∘             
-         |           · ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○○  ·          
-       0 |··  ····∘·∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘·∘∘···  ·
+     460 |                                                                                
+         |                                    ∘ ∘∘                                        
+         |                                    ○ ○○○·                                      
+         |                                    ○○○○○○                                      
+         |                                  ○○○○○○○○∘                                     
+     340 |                                 ·○○○○○○○○○∘                                    
+         |                               ∘∘○○○○○○○○○○○○∘                                  
+         |                               ○○○○○○○○○○○○○○○ ·                                
+         |                               ○○○○○○○○○○○○○○○○○                                
+         |                              ○○○○○○○○○○○○○○○○○○                                
+     230 |                             ·○○○○○○○○○○○○○○○○○○∘·                              
+         |                            ∘○○○○○○○○○○○○○○○○○○○○○                              
+         |                          ∘·○○○○○○○○○○○○○○○○○○○○○○ ·                            
+         |                          ○○○○○○○○○○○○○○○○○○○○○○○○·○                            
+         |                         ∘○○○○○○○○○○○○○○○○○○○○○○○○○○·                           
+     110 |                        ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘                          
+         |                      · ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·                         
+         |                     ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘                       
+         |                   ∘·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘                      
+         |                · ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘·                   
+       0 |·   ········∘∘∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○∘∘·······  ·    ·
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-       -3.35    -2.60    -1.86    -1.11    -0.37     0.38     1.13     1.87     2.62  
+        -4.0     -3.0     -2.1     -1.2     -0.3     0.6      1.5      2.5      3.4   
 ```
 
 Since the only information we have about `x` so far is its `Normal` prior, this distribution unsurprisingly looks normal. Later we'll see how to update our beliefs about `x` based on observational data.
@@ -96,102 +96,102 @@ For now, though, let's explore what we can do just with priors. `RandomVariable`
 
 ```scala
 scala> val e_x = x.map(_.exp)
-e_x: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@1676ef88
+e_x: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@d91cd79
 
 scala> plot1D(e_x.sample())
-    2200 |                                                                                
-         | ·                                                                              
-         | ○                                                                              
-         | ○·                                                                             
-         | ○○                                                                             
-    1600 |∘○○                                                                             
+    3200 |                                                                                
+         |∘                                                                               
+         |○                                                                               
+         |○                                                                               
+         |○∘                                                                              
+    2400 |○○                                                                              
+         |○○                                                                              
+         |○○                                                                              
+         |○○                                                                              
+         |○○                                                                              
+    1600 |○○                                                                              
+         |○○·                                                                             
          |○○○                                                                             
          |○○○                                                                             
          |○○○                                                                             
-         |○○○                                                                             
-    1100 |○○○·                                                                            
+     800 |○○○∘                                                                            
          |○○○○                                                                            
          |○○○○                                                                            
-         |○○○○                                                                            
-         |○○○○                                                                            
-     500 |○○○○○                                                                           
-         |○○○○○∘                                                                          
-         |○○○○○○·                                                                         
-         |○○○○○○○·                                                                        
-         |○○○○○○○○∘·                                                                      
-       0 |○○○○○○○○○○○∘∘∘∘∘∘∘∘··∘··························  ·· ·   ··  ·  ·  ·   ·  ·  · ·
+         |○○○○○·                                                                          
+         |○○○○○○∘                                                                         
+       0 |○○○○○○○○∘∘···················· ·  · · · ·           ··       ·  ·              ·
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        0.0      3.5      6.9      10.4     13.9     17.3     20.8     24.2     27.7  
+        0.0      5.6      11.1     16.7     22.2     27.8     33.3     38.9     44.4  
 ```
 
 Or we can create another `Normal` parameter and zip the two together to produce a 2D gaussian. Since there's nothing relating these two parameters to each other, you can see in the plot that they're completely independent.
 
 ```scala
 scala> val y = Normal(0,1).param
-y: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@2df1e38b
+y: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@80b236e
 
 scala> val xy = x.zip(y)
-xy: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@49e9c0ef
+xy: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@1e8ee235
 
 scala> plot2D(xy.sample())
-     4.2 |                                                                                
-         |                              ·  ··                                             
-         |                                                      ·                         
-         |                            ·   · ··  ··      ·               ·                 
-         |                   ·       · · · ·  ····  ·  ·  ···     ·    ·                  
-     2.3 |                      ·  ············  ··············· ···   ·   ·              
-         |                  · ··· ····························· ·· ··· ·  ·               
-         |     ·          ·  ······ ··································· ··· · ··  ··      
-         |          · ·· ·  ····················∘∘··················· · ·         ·       
-         |         ·   · ···················∘∘∘·∘∘∘∘·∘∘∘∘··∘··············· ··            
-     0.3 |           · ·  · ··········∘·∘∘·∘∘∘∘○∘∘·∘∘∘∘∘∘∘∘··················             
-         |    ·     ·    · ···········∘∘∘∘∘∘∘∘∘∘○○∘○∘○∘∘∘∘∘∘∘············ ···            ·
-         |·           · ·················∘∘∘∘∘○○∘○○○○∘∘○∘·∘∘·∘······· ·· ·     ·          
-         |     ·       · ·  ·············∘∘∘∘∘∘∘∘∘∘∘∘∘∘∘∘∘∘∘∘············· ···    ·       
-         |          ·     ···············∘·∘·∘∘·∘∘∘∘∘∘∘··∘··············    ·             
-    -1.6 |           ··   ···· ······················∘················  ··   ·       ·    
-         |                  ·· · ········································  ·              
-         |               ·    ·· ································  ··                     
-         |               ·     ·  ···   ······ ··········· ··  ·· · ·                     
-         |           ·            ·   · ··   ····  ·  ·      ·               ·            
-    -3.5 |      ·                                ·      · ··         ·                    
+     4.4 |                                                                                
+         |                                   ·                                            
+         |                                                                                
+         |                    ·            ·                ·                             
+         |                          ·  ·· · ·  ·····  · ·· ···       ·                    
+     2.4 |             · ·     · ······· ··········· ·······   ·                          
+         |           · · ·· ················· ·················· · ··   ··                
+         |   ·    · · ··················································· ·     ·         
+         |     ·· · ··· ············································ · ·  · ···           
+         |   ·   ····················∘·∘∘····∘∘··∘····∘················· ·· ·  ··         
+     0.4 |  ·  ····· ··················∘∘·∘∘∘∘∘∘∘∘∘∘···∘···················· ·            
+         |    ·  ··· ·················∘∘∘·∘∘○○∘∘○∘∘∘∘∘··∘∘··∘··················  ·   ·    
+         |   ···  ·····················∘∘∘∘∘○○∘∘○∘○○∘∘∘∘··∘·········· · ··   ···   · ·   ·
+         |·· ······ ·············∘···∘∘·∘∘∘∘∘∘∘∘·∘·∘∘∘∘∘················· ·· ·· ··        
+         | ·   ·  ·   ················∘∘·∘·····∘∘···∘·················· ··· · ··· ·       
+    -1.5 |·  ····  ·······················································  ·  ·          
+         |    · ··  · ····· ······································ ·  ··   ·  ·           
+         |   · ·      ·  ·  ·································  ·· · ····    ·  ·          
+         |          ·     ··   ·  ·· · ··················   ·· ··  ·                      
+         |             ·  ·· ·  ···  · ···· ·   ··       ·  · ·· ·   ·          ·         
+    -3.5 |                    ·        ··           ·   ·   ·           ·                 
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        -4.4     -3.4     -2.4     -1.4     -0.5     0.5      1.5      2.5      3.5   
+       -3.34    -2.51    -1.69    -0.86    -0.04     0.79     1.61     2.44     3.26  
 ```
 
 Finally, we can use `flatMap` to create two parameters that *are* related to each other. In particular, we'll create a new parameter `z` that we believe to be very close to `x`: its prior is a `Normal` centered on `x` with a very small standard deviation. We'll then make a 2D plot of `(x,z)` to see the relationship.
 
 ```scala
 scala> val z = x.flatMap{a => Normal(a, 0.1).param}
-z: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@568e7186
+z: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@34cb64bc
 
 scala> val xz = x.zip(z)
-xz: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@4f56bb48
+xz: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@3aa567c
 
 scala> plot2D(xz.sample())
-     3.7 |                                                                                
-         |                                                                          ···· ·
-         |                                                                      ······    
-         |                                                                  ········      
-         |                                                              ········          
-     1.6 |                                                         ·········              
-         |                                                     ··········                 
-         |                                                 ···∘∘∘···                      
-         |                                             ···∘∘∘····                         
-         |                                         ···∘○○∘··                              
-    -0.5 |                                     ···∘∘∘···                                  
-         |                                ····∘∘∘∘···                                     
-         |                            ······∘···                                          
-         |                         ·········                                              
-         |                      ········                                                  
-    -2.6 |                   ······                                                       
-         |              · ·····                                                           
-         |           ·····                                                                
-         |           ·                                                                    
-         |                                                                                
-    -4.7 |·                                                                               
+     3.9 |                                                                                
+         |                                                                              ··
+         |                                                                         ····   
+         |                                                                  ·· ····       
+         |                                                               ·······          
+     2.0 |                                                           ·······              
+         |                                                      ·········                 
+         |                                                 ···········                    
+         |                                              ···∘∘∘···                         
+         |                                         ···∘∘∘∘····                            
+     0.1 |                                     ···∘○∘∘∘···                                
+         |                                  ··∘○○∘∘···                                    
+         |                              ··∘∘∘∘∘··                                         
+         |                         ····∘∘∘···                                             
+         |                     ·····∘····                                                 
+    -1.8 |                 ··········                                                     
+         |              ·········                                                         
+         |        · ·········                                                             
+         |       ·······                                                                  
+         |    ·····                                                                       
+    -3.7 |···                                                                             
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        -4.7     -3.7     -2.8     -1.8     -0.9     0.0      1.0      1.9      2.8   
+       -3.64    -2.81    -1.97    -1.14    -0.31     0.53     1.36     2.20     3.03  
 ```
 
 You can see that although we still sample from the full range of `x` values, for any given sample, `x` and `z` are quite close to each other.
@@ -215,7 +215,7 @@ scala> val rate = for {
      |     r <- e_x
      |     poisson <- Poisson(r).fit(sales)
      | } yield r
-rate: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@64b1257e
+rate: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@d2b15bc
 ```
 
 This is our first "full" model: we have a parameter with a log-normal prior bundled into the `RandomVariable` named `e_x`; we use that parameter to initialize a `Poisson` noise distribution which we fit to our observations; and at the end, we output the same parameter (referenced by `r`) as the quantity we're interested in sampling from the posterior.
@@ -224,29 +224,29 @@ Let's plot the results!
 
 ```scala
 scala> plot1D(rate.sample())
-     400 |                                                                                
-         |                         ·∘ ∘                                                   
-         |                         ○○·○○ ∘·                                               
-         |                         ○○○○○ ○○                                               
-         |                        ∘○○○○○∘○○∘                                              
-     300 |                      ∘∘○○○○○○○○○○∘                                             
-         |                      ○○○○○○○○○○○○○· ∘                                          
-         |                    ∘○○○○○○○○○○○○○○○∘○                                          
-         |                   ·○○○○○○○○○○○○○○○○○○                                          
-         |                   ○○○○○○○○○○○○○○○○○○○                                          
-     200 |                ··○○○○○○○○○○○○○○○○○○○○○                                         
-         |                ○○○○○○○○○○○○○○○○○○○○○○○∘○                                       
-         |               ∘○○○○○○○○○○○○○○○○○○○○○○○○○ ∘                                     
-         |              ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○                                     
-         |             ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘ ·                                  
-     100 |           · ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                                 
-         |           ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○  ∘                              
-         |         ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·○∘                             
-         |      · ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·∘                           
-         |  ○· ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘·∘ ·                      
-       0 |∘○○○∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘∘·······∘··  · ·   ·
+     430 |                                                                                
+         |                           ·  ∘                                                 
+         |                           ○·○○                                                 
+         |                        · ·○○○○                                                 
+         |                      · ○ ○○○○○··○                                              
+     320 |                      ○ ○∘○○○○○○○○·∘                                            
+         |                     ·○∘○○○○○○○○○○○○                                            
+         |                    ·○○○○○○○○○○○○○○○   ·                                        
+         |                    ○○○○○○○○○○○○○○○○○∘∘○                                        
+         |                   ·○○○○○○○○○○○○○○○○○○○○                                        
+     210 |                  ·○○○○○○○○○○○○○○○○○○○○○∘                                       
+         |                  ○○○○○○○○○○○○○○○○○○○○○○○·                                      
+         |                ∘ ○○○○○○○○○○○○○○○○○○○○○○○○○                                     
+         |                ○ ○○○○○○○○○○○○○○○○○○○○○○○○○∘·                                   
+         |               ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                                   
+     100 |              ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘                                  
+         |             ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                                 
+         |          ∘ ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·                              
+         |          ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘                             
+         |      ··∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘∘∘ ·· ·                     
+       0 |·····○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○·∘∘∘······ · ··     ·
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        4.83     5.71     6.58     7.46     8.34     9.21    10.09    10.96    11.84  
+        4.68     5.58     6.47     7.37     8.26     9.16    10.05    10.95    11.84  
 ```
 
 Looks like our daily rate is probably somewhere between 6 and 9, and is in fact much more likely to be around 9 than 10.
@@ -298,42 +298,42 @@ scala> val prediction = for {
      |     r <- e_x
      |     poisson <- Poisson(r).fit(sales)
      | } yield poisson.generator
-prediction: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@1cab1233
+prediction: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@1734d8bf
 ```
 
 This is almost the same model as `rate` above, but instead of taking the real-valued `r` rate parameter as the output, we're producing poisson-distributed integers. The samples look like this:
 
 ```scala
 scala> prediction.sample()
-res7: List[Int] = List(9, 9, 5, 8, 5, 13, 4, 6, 4, 7, 4, 4, 7, 12, 9, 6, 8, 6, 8, 2, 6, 7, 9, 7, 5, 6, 7, 5, 12, 10, 8, 7, 9, 6, 11, 3, 7, 4, 3, 10, 13, 5, 15, 6, 7, 14, 4, 6, 11, 3, 15, 9, 2, 8, 11, 1, 7, 8, 7, 6, 12, 5, 6, 8, 8, 8, 9, 6, 13, 4, 9, 7, 7, 6, 6, 12, 10, 13, 8, 11, 8, 7, 14, 4, 4, 10, 13, 8, 6, 8, 14, 9, 9, 4, 10, 12, 5, 8, 5, 10, 6, 8, 4, 6, 7, 7, 10, 5, 8, 11, 5, 6, 8, 5, 5, 10, 8, 8, 5, 6, 4, 4, 3, 7, 6, 7, 5, 8, 7, 9, 5, 4, 2, 7, 10, 9, 12, 6, 9, 7, 8, 8, 6, 10, 4, 8, 4, 5, 12, 7, 8, 13, 8, 6, 5, 8, 7, 12, 5, 13, 6, 13, 6, 5, 12, 10, 3, 6, 6, 9, 8, 6, 7, 8, 5, 6, 7, 7, 1, 9, 5, 9, 8, 8, 6, 10, 8, 6, 11, 12, 4, 9, 5, 9, 4, 4, 6, 4, 12, 7, 7, 21, 9, 10, 5, 9, 4, 11, 8, 6, 4, 10, 4, 7, 6, 10, 6, 9, 7, 14, 9, 10, 3, 9, 5, 5, 7, 6, 12, 9, 12, 16, ...
+res7: List[Int] = List(13, 10, 9, 10, 5, 10, 5, 7, 2, 6, 6, 10, 11, 7, 11, 3, 14, 9, 11, 4, 10, 8, 6, 7, 5, 8, 5, 10, 14, 5, 8, 14, 12, 9, 10, 13, 3, 7, 9, 2, 6, 7, 8, 10, 9, 5, 14, 4, 7, 4, 10, 5, 8, 5, 7, 5, 9, 5, 9, 7, 10, 9, 4, 9, 9, 9, 8, 7, 11, 10, 12, 8, 7, 6, 5, 7, 5, 8, 9, 9, 6, 12, 4, 11, 9, 10, 6, 9, 7, 6, 8, 8, 6, 3, 8, 3, 9, 9, 12, 5, 5, 10, 7, 4, 11, 9, 7, 4, 9, 2, 10, 0, 8, 8, 15, 6, 8, 7, 4, 8, 16, 6, 7, 5, 6, 15, 8, 5, 5, 7, 13, 8, 5, 8, 12, 10, 4, 5, 8, 6, 6, 9, 9, 3, 11, 5, 6, 6, 8, 8, 8, 10, 8, 6, 7, 9, 4, 8, 6, 4, 16, 6, 6, 7, 9, 6, 3, 6, 13, 15, 6, 12, 7, 11, 3, 6, 11, 4, 6, 8, 4, 2, 12, 10, 6, 8, 3, 10, 7, 7, 10, 4, 4, 15, 10, 4, 10, 7, 9, 9, 2, 10, 11, 8, 8, 16, 6, 9, 7, 4, 5, 6, 4, 6, 14, 8, 12, 5, 10, 6, 11, 9, 4, 8, 9, 10, 6, 12, 6, 9...
 ```
 Or, if we plot them, like this:
 
 ```scala
 scala> plot1D(prediction.sample())
-    1390 |                                                                                
-         |                          ○                                                     
-         |                      ·   ○   ○                                                 
-         |                      ○   ○   ○                                                 
-         |                      ○   ○   ○                                                 
-    1040 |                      ○   ○   ○   ∘                                             
-         |                  ·   ○   ○   ○   ○                                             
-         |                  ○   ○   ○   ○   ○                                             
-         |                  ○   ○   ○   ○   ○  ∘                                          
-         |                  ○   ○   ○   ○   ○  ○                                          
-     690 |               ∘  ○   ○   ○   ○   ○  ○                                          
-         |               ○  ○   ○   ○   ○   ○  ○   ·                                      
-         |               ○  ○   ○   ○   ○   ○  ○   ○                                      
-         |               ○  ○   ○   ○   ○   ○  ○   ○                                      
-         |               ○  ○   ○   ○   ○   ○  ○   ○   ∘                                  
-     340 |           ∘   ○  ○   ○   ○   ○   ○  ○   ○   ○                                  
-         |           ○   ○  ○   ○   ○   ○   ○  ○   ○   ○   ·                              
-         |           ○   ○  ○   ○   ○   ○   ○  ○   ○   ○   ○                              
-         |       ·   ○   ○  ○   ○   ○   ○   ○  ○   ○   ○   ○   ·                          
-         |       ○   ○   ○  ○   ○   ○   ○   ○  ○   ○   ○   ○   ○  ·                       
-       0 |·  ○   ○   ○   ○  ○   ○   ○   ○   ○  ○   ○   ○   ○   ○  ○   ∘   ∘   ·   ·  ·   ·
+    1350 |                                                                                
+         |                        ○                                                       
+         |                    ○   ○  ○                                                    
+         |                    ○   ○  ○                                                    
+         |                    ○   ○  ○   ∘                                                
+    1010 |                 ○  ○   ○  ○   ○                                                
+         |                 ○  ○   ○  ○   ○                                                
+         |                 ○  ○   ○  ○   ○                                                
+         |                 ○  ○   ○  ○   ○  ∘                                             
+         |                 ○  ○   ○  ○   ○  ○                                             
+     670 |             ○   ○  ○   ○  ○   ○  ○                                             
+         |             ○   ○  ○   ○  ○   ○  ○   ∘                                         
+         |             ○   ○  ○   ○  ○   ○  ○   ○                                         
+         |             ○   ○  ○   ○  ○   ○  ○   ○                                         
+         |          ·  ○   ○  ○   ○  ○   ○  ○   ○                                         
+     330 |          ○  ○   ○  ○   ○  ○   ○  ○   ○  ∘                                      
+         |          ○  ○   ○  ○   ○  ○   ○  ○   ○  ○   ·                                  
+         |          ○  ○   ○  ○   ○  ○   ○  ○   ○  ○   ○                                  
+         |      ·   ○  ○   ○  ○   ○  ○   ○  ○   ○  ○   ○  ·                               
+         |      ○   ○  ○   ○  ○   ○  ○   ○  ○   ○  ○   ○  ○  ·                            
+       0 |·  ○  ○   ○  ○   ○  ○   ○  ○   ○  ○   ○  ○   ○  ○  ○   ∘  ·   ·  ·   ·      ·  ·
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        0.0      2.4      4.7      7.1      9.5      11.9     14.2     16.6     19.0  
+        0.0      2.6      5.2      7.8      10.4     13.0     15.6     18.2     20.8  
 ```
 
 ## `Likelihood` and `Predictor`
@@ -381,7 +381,7 @@ scala> val prior = for {
      |     slope <- LogNormal(0,1).param
      |     intercept <- LogNormal(0,1).param
      |     } yield (slope, intercept)
-prior: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@6f695aa0
+prior: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@53997e37
 ```
 
 Now, for any given day `i`, we want to check the number of sales against `Poisson(intercept + slope*i)`. We could write some kind of recursive flatMap to build and fit each of these different distribution objects in turn, but this is a common enough pattern that Rainier already has something built in for it: `Predictor`. `Predictor` is not a `Distribution`, but instead wraps a function from `X => Distribution[Y]` for some `(X,Y)`; you can use this any time you have a dependent variable of type `Y` that you're modeling with some independent variables jointly represented as `X`.
@@ -395,7 +395,7 @@ scala> val regr = for {
      |                     Poisson(intercept + slope*i)
      |                 }.fit(data)
      | } yield (slope, intercept)
-regr: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@4bdccf83
+regr: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@4b9bc4b9
 ```
 
 As before, we're starting out by just sampling the parameters. By plotting them, we can see that the model's confidence in the intercept, in particular, is pretty low: although it's most likely to be somewhere around 8, it could be anywhere from 3 to 13 or even higher. Second, as you'd hope, the two parameters are anti-correlated:
@@ -403,29 +403,29 @@ a smaller intercept would imply a higher slope, and vice versa.
 
 ```scala
 scala> plot2D(regr.sample())
-    15.1 |                                                                                
-         |·   ·      ··  ·                                                                
-         |             ··  ·  ·                                                           
-         |   ··   ·  ····· · ···  ··                                                      
-         |   ·  ·   ·  ············ ·······                                               
-    11.9 |  ·  ·  ·· ························  ··  ·                                      
-         |         · · ···························      ·                                 
-         |        ·   ·······························    · ·                              
-         |           ·  ················∘················· ··                             
-         |             ················∘∘∘∘∘∘·∘··············· ·  ·                       
-     8.7 |                 ···········∘·∘∘∘○∘∘∘∘∘∘∘∘∘··············                       
-         |                   ··· ······∘∘∘∘∘∘∘∘○○○○∘∘∘∘∘∘∘∘········ ·  ·                  
-         |                   ·  ···········∘∘∘∘∘∘○∘○∘○○∘∘∘∘··∘···········   ·             
-         |                         ···········∘∘∘∘∘∘∘∘○∘∘∘○∘∘∘∘·········   ·  ·· ·        
-         |                           ············∘··∘∘∘·∘∘∘∘∘∘∘··············· · ··       
-     5.6 |                            ·   ········································        
-         |                                  ··· ·································         
-         |                                        · ························· ···  ·      
-         |                                             ·  ·· ·  ··········· ···· ·        
-         |                                               ·      ·   ·      ·    · ·       
-     2.4 |                                               ·                         ·     ·
+    15.4 |                                                                                
+         |     ·  ·                                                                       
+         |   ·                    · ·                                                     
+         |· ·    ·  ···· · ··    ·        ·                                               
+         | ·     ·  ·············  ····    ·                                              
+    12.2 |   ·   ·  · ······················· ·    ·                                      
+         |     ·  · ························· ·· ·    ·                                   
+         |          ····························· ···· ·  ·                               
+         |        ··· ·  ······························ ····  ·                           
+         |        ·    ·  ··········∘∘·∘∘∘·∘∘∘∘···············  ·                         
+     8.9 |             ·· ···········∘∘·∘∘∘∘∘∘∘∘∘∘··∘·············                        
+         |                  ···········∘∘∘∘∘∘∘∘∘○○∘∘∘∘○∘∘∘·∘········· · ··                
+         |                       ···········∘∘∘∘○○○○○○○○∘∘∘∘∘∘·············               
+         |                        · ·········∘·∘∘∘∘○∘○∘○○○∘○∘∘···············             
+         |                             ············∘∘∘∘∘∘∘∘∘∘∘·····∘···········   ·       
+     5.7 |                                ·················∘·∘··∘··∘·········· · ···   ·  
+         |                                     ································· ··   ·  ·
+         |                                       · ··· ························· ·   ·    
+         |                                            ···    ············· ········   ·  ·
+         |                                                        ·  ···· ···  ·   · ·    
+     2.5 |                                                                   ··     ·     
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        2.39     2.56     2.74     2.91     3.09     3.26     3.43     3.61     3.78  
+        2.40     2.57     2.74     2.90     3.07     3.23     3.40     3.57     3.73  
 ```
 
 Alternatively, as in the earlier example, we could try to predict what will happen tomorrow. This is similar to calling `poisson.generator` before, but this time, we use the `predict` method on `Predictor`, which takes the covariate (the day, in this case), and returns a `Generator` for the dependent variable (the number of sales). Putting it all together, it looks like this:
@@ -438,36 +438,36 @@ scala> val regr2 = for {
      |                     Poisson(intercept + slope*i)
      |                 }.fit(data)
      | } yield predictor.predict(21)
-regr2: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@7cce4353
+regr2: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@3ebe0336
 ```
 
 Plotting this gives us a prediction which incorporates both the natural noise of a Poisson distribution and our uncertainty about its underlying parameterization.
 
 ```scala
 scala> plot1D(regr2.sample())
-     470 |                                                                                
-         |                                 ·∘                                             
-         |                                 ○○                                             
-         |                               · ○○ ○○                                          
-         |                               ○ ○○∘○○∘○                                        
-     350 |                             ∘ ○ ○○○○○○○  ○                                     
-         |                            ∘○○○ ○○○○○○○ ·○∘                                    
-         |                            ○○○○ ○○○○○○○ ○○○                                    
-         |                          ·○○○○○ ○○○○○○○ ○○○·                                   
-         |                         ·○○○○○○ ○○○○○○○ ○○○○                                   
-     230 |                         ○○○○○○○ ○○○○○○○ ○○○○○·                                 
-         |                      ∘∘ ○○○○○○○ ○○○○○○○ ○○○○○○·                                
-         |                      ○○ ○○○○○○○ ○○○○○○○ ○○○○○○○                                
-         |                    ··○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○·                             
-         |                    ○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○                             
-     110 |                   ∘○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○○∘                           
-         |                 · ○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○○○∘∘                         
-         |                 ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○∘                        
-         |              ∘· ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ∘·                     
-         |           ··○○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○○∘··                 
-       0 |· ·····∘ ∘∘○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○∘ ○······    ·  ·
+     450 |                                                                                
+         |                                     ·   ∘                                      
+         |                                   ·○○ ∘ ○                                      
+         |                               ○ ∘ ○○○∘○ ○·                                     
+         |                               ○·○ ○○○○○ ○○∘                                    
+     340 |                               ○○○ ○○○○○ ○○○·                                   
+         |                             ∘ ○○○ ○○○○○ ○○○○∘                                  
+         |                           · ○ ○○○ ○○○○○ ○○○○○ ○                                
+         |                           ○ ○○○○○ ○○○○○ ○○○○○ ○                                
+         |                           ○ ○○○○○ ○○○○○ ○○○○○ ○                                
+     220 |                         ∘ ○ ○○○○○ ○○○○○ ○○○○○ ○·○·                             
+         |                        ○○∘○ ○○○○○ ○○○○○ ○○○○○ ○○○○ ·                           
+         |                      · ○○○○ ○○○○○ ○○○○○ ○○○○○ ○○○○ ○                           
+         |                      ○ ○○○○ ○○○○○ ○○○○○ ○○○○○ ○○○○ ○∘                          
+         |                     ∘○ ○○○○ ○○○○○ ○○○○○ ○○○○○ ○○○○ ○○                          
+     110 |                    ∘○○ ○○○○ ○○○○○ ○○○○○ ○○○○○ ○○○○ ○○∘○                        
+         |                   ∘○○○ ○○○○ ○○○○○ ○○○○○ ○○○○○ ○○○○ ○○○○○ ∘                     
+         |                  ∘○○○○ ○○○○ ○○○○○ ○○○○○ ○○○○○ ○○○○ ○○○○○ ○·                    
+         |               ○∘ ○○○○○ ○○○○ ○○○○○ ○○○○○ ○○○○○ ○○○○ ○○○○○ ○○·                   
+         |             ·○○○ ○○○○○ ○○○○ ○○○○○ ○○○○○ ○○○○○ ○○○○ ○○○○○ ○○○○○ ∘· ·            
+       0 |··  · ··∘∘○ ○○○○○ ○○○○○ ○○○○ ○○○○○ ○○○○○ ○○○○○ ○○○○ ○○○○○ ○○○○○ ○○○○∘ ∘∘·· ··· ·
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        43.0     50.9     58.8     66.7     74.5     82.4     90.3     98.2    106.1  
+        43.0     50.4     57.9     65.3     72.7     80.2     87.6     95.1    102.5  
 ```
 
 Finally, let's close with a small and somewhat contrived example of a hierarchical model, where we have two separate regressions that share a parameter. For the sake of the example, let's assume that we have a second sales dataset, much like the first, where we know they had the same rate at the start of the observations, but may have grown at different rates - so their intercepts will be equal but their slopes will not. Here's the data:
@@ -487,7 +487,7 @@ scala> val regr3 =  for {
      |     _ <- Predictor.fromInt{ i => Poisson(intercept + slope0 * i) }.fit(data)
      |     _ <- Predictor.fromInt{ i => Poisson(intercept + slope1 * i) }.fit(data2)
      | } yield (slope0, intercept)
-regr3: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@bfbbc8f
+regr3: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@28f54f1b
 ```
 
 or we can use Rainier's `Lookup` to package the two slopes into a single `RandomVariable` from which we can lookup the one we want. This means that our predictor now has to take both the index of the model to which the data belongs as well as the actual observation as input.
@@ -501,64 +501,38 @@ scala> val regLookup = for {
      |   intercept <- LogNormal(0,1).param
      |   _ <- Predictor.fromIntPair{ case (index, x) => Poisson(intercept + slopes(index) * x) }.fit(allData)
      | } yield (slopes(0), intercept)
-regLookup: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@60520a80
+regLookup: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@3c9c790c
 ```
 
-Plotting slope vs. intercept now, we first see that they do agree.
+Plotting slope vs. intercept now, we see that, even though these are two separate regressions, we get tighter bounds than before by letting the new data influence the shared parameter. It makes sense that we'd get more confidence on the intercept, since we have two different time series to learn from now; but because of the anti-correlation, that also leads to somewhat more confidence than before on the `slopes(0)` parameter as well.
 
 ```scala
-scala> plot2D(regr3.sample())
-    10.8 |                                                                                
-         |                 ·                                                              
-         |   ·             ·  ·      · · ·· ·                                             
-         |          ·   ·· ·· ·  · ·  ··     ·                                            
-         |·  ·   ·     ·   · ·  ········· ····· ·   ·                                     
-     8.9 |      ··      ················ ···· ······ ···   ·     ·                        
-         |      ·  ··· ································  ··                               
-         |        · ··   ·····································  ·                         
-         |          ····································· · ·······      ·                
-         |       ·      ·· ··········∘·∘·∘∘∘·∘∘∘∘·∘∘∘∘···········  ··  ·       ·          
-     7.0 |         ·    ·   ···········∘∘∘∘∘∘∘○∘○∘∘·∘∘·∘∘············  ··                 
-         |            ·   ··············∘·∘∘∘∘∘○○∘∘○∘∘∘∘∘∘··∘··········  ···      ·       
-         |        ·        ··············∘·∘∘∘∘○○○∘○○∘○∘○∘∘∘∘∘··············   ··         
-         |                     ··············∘∘∘∘∘∘○○∘○∘○∘∘∘∘···∘············ ·           
-         |                      ·················∘∘·∘∘∘∘∘∘∘∘∘∘∘∘·············· ···        
-     5.0 |                         · ···················∘·······················          
-         |                        ·     ·······································   ·       
-         |                             ·     ·· ································   ··  ·  
-         |                                       · · ··· ················· · ··     ·    ·
-         |                                   ·   ·    ·     ··  · ·   · · ··   ·  ·       
-     3.1 |                                                ·  ··   ··    ·                 
-         |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        2.64     2.79     2.93     3.08     3.23     3.38     3.53     3.67     3.82  
-
 scala> plot2D(regLookup.sample())
     11.4 |                                                                                
-         |               ·      ·  ·                                                      
-         |            ·                                                                   
-         |             ·  ·  ·  ·                                                         
-         |    ·   · · ·· ·· · · ·  ·  ···  ·                                              
-     9.3 |·      · · ·  ············ ······· · · ·   ·   ·   ·                            
-         |·    · ···· ·  ······················· ··· ·     ·                              
-         |        ·· ································ · · ··· · ·                         
-         |          ···· ··············∘·················· ·····                          
-         |      ·  ·   ················∘∘·∘∘∘∘∘∘················ ··   ··                  
-     7.2 |       ·   ··· ··········∘∘·∘·∘∘∘∘∘∘∘○∘∘∘∘∘∘∘···∘············                   
-         |       ·    ·  ············∘∘∘∘∘∘∘∘○∘○○∘∘○∘∘○∘∘∘·∘··················            
-         |                ···········∘∘∘∘∘∘∘∘○○∘○∘○○○○○∘∘∘○∘∘·∘··········· ····· ·        
-         |               ·    ··········∘∘·∘○∘∘∘○○○○○○○○○∘∘○∘∘∘∘∘·············     ·      
-         |                    ·   ········∘∘··∘∘∘∘∘∘∘∘∘∘∘∘∘∘∘∘∘∘∘·∘·············  ·       
-     5.1 |                         ·················∘∘∘∘∘·∘∘·∘∘∘··∘·········· ·· ·  ·     
-         |                             ·········································· ··   ·· 
-         |                              ·    ·· ······················· ·······  · ··     
-         |                               ·       · ·   ··· ······· ··· ······ ···  ·    · 
-         |                                              ·   ·  ·    ·  ··    ·       ·    
-     2.9 |                                             ··       ·         ·       ·      ·
+         |     ·                   ·                                                      
+         |                   ·            ·                                               
+         |              ·· ··  ··                                                         
+         |       ·  ·· ·· ·  ·   · · ·                                                    
+     9.3 |· ·  ·  · · ···  ··· ····· ······       ·                                       
+         |      · ·· ····················· ····· ····     ·                               
+         |  ·    ································ ······ ·· ·                             
+         |     · ··  ········································· · · ·   ·                  
+         |      · ··················∘··∘∘···∘·∘················· ·· · ·                   
+     7.2 | ·  · · ················∘·∘∘·∘∘∘∘∘∘∘∘∘∘∘∘∘················ ··· ·                
+         |    ·       ·············∘·∘∘∘∘∘○∘∘∘○○○∘∘∘○∘∘∘···∘···············               
+         |           · · ···········∘∘∘∘∘∘∘∘∘○○∘○○○○∘○○∘∘∘∘·∘∘·············  · ·          
+         |             ··  ·············∘∘∘∘∘○∘∘∘○∘○∘○○○∘∘∘∘∘·∘·············  ·  ··      ·
+         |               ·   ············∘∘··∘∘∘∘∘∘∘∘∘∘∘∘∘∘∘∘·∘∘···∘········· ·····    ·  
+     5.1 |                    · ·· ··············∘·∘∘∘∘·∘·∘·∘∘··∘··············· ···     ·
+         |                     ·  · ··· ········································· ·   · · 
+         |                            ··········· ···························· · ·  ··    
+         |                                    · ·· ·· ···············  ··  ·· · · ···     
+         |                                      ·   ·   · · · ·  ·········            ·   
+     3.0 |                                      ·             ·                           
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        2.68     2.82     2.96     3.10     3.23     3.37     3.51     3.65     3.79  
+        2.73     2.86     2.99     3.13     3.26     3.39     3.53     3.66     3.79  
 ```
 
-Mathematically, we see that, even though these are two separate regressions, we get tighter bounds than before by letting the new data influence the shared parameter. It makes sense that we'd get more confidence on the intercept, since we have two different time series to learn from now; but because of the anti-correlation, that also leads to somewhat more confidence than before on the `slope1` parameter as well.
 ## Learning More
 
 This tour has focused on the high-level API. If you want to understand more about what's going on under the hood, you might enjoy reading about [Real](real.md) or checking out some [implementation notes](impl.md). If you want to learn more about Bayesian modeling in general, [Cam Davidson Pilon's book][CDP] is an excellent resource - the examples are in Python, but porting them to Rainier is a good learning exercise. Over time, we hope to add more Rainier-specific documentation and community resources; for now, feel free to file a [GitHub issue][GISSUES] with any questions or problems.

--- a/docs/tour.md
+++ b/docs/tour.md
@@ -30,7 +30,7 @@ Rainier implements various familiar families of probability distributions like t
 
 ```scala
 scala> val normal: Distribution[Double] = Normal(0,1)
-normal: com.stripe.rainier.core.Distribution[Double] = com.stripe.rainier.core.Injection$$anon$1@3f2f9691
+normal: com.stripe.rainier.core.Distribution[Double] = com.stripe.rainier.core.Injection$$anon$1@793f05aa
 ```
 
 In Rainier, `Distribution` objects play three different roles. `Continuous` distributions (like `Normal`), implement `param`, and all distributions implement `fit` and `generator`. Each of these methods is central to one of the three stages of building a model in Rainier:
@@ -51,43 +51,43 @@ Let's use that same `Normal(0,1)` distribution as a prior for a new parameter:
 
 ```scala
 scala> val x = Normal(0,1).param
-x: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@5ef3e25f
+x: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@64674f1f
 ```
 
 You can see that the type of `x` is `RandomVariable[Real]`. `RandomVariable` pairs a type of value (in this case, a real number) with some knowledge of the relative probability density of different values of that type. We can use this knowledge to produce a sample of these possible values:
 
 ```scala
 scala> x.sample()
-res0: List[Double] = List(2.7320868146154833, -2.114482036120509, 1.8622401967684508, -2.1317031570134173, 1.4099652428520755, 1.4099652428520755, -1.9119610208674604, 1.5174995353655856, 1.5174995353655856, -1.3224056116513343, 1.1605088815846267, -1.059387184609826, 0.819204480401514, -0.826600300631543, 1.5740636261404948, -1.4522356859322578, 1.0088525762232425, -0.47095639978798864, 0.5494198693935901, -0.3336382551798249, 0.23636136930974416, -0.5895766586155893, 0.7738118483394821, 0.7738118483394821, -0.5862264157051207, 0.8181619383840418, -1.0154057558108898, -0.3260332232615033, -0.06800479011766747, 0.1089726524770406, 0.14764437975109945, -0.47610029166300893, 0.2799643641223927, -0.9914004408252017, 1.366414861041127, -1.5743852223344068, 1.829391...
+res0: List[Double] = List(-0.5451549207293471, 0.5421277783120733, -0.5386759590971426, 0.5425977102747024, -0.5432380062242386, 0.5428031270781379, -0.540758488908677, 0.5423203553611833, -0.541275250038389, 0.5419649332970861, -0.5400985831640157, 0.5424864004108134, -0.5426177965822958, 0.5427531873136975, -0.543682215089409, 0.5426446811127528, -0.5430239985865657, 0.5425667388895744, -0.5436428591205954, 0.5421322049718278, -0.5445119908153138, 0.5475045451457676, -0.5477853371358438, 0.5436557495535577, -0.5450719541877482, 0.5436895190545374, -0.5435295588241975, 0.5416791254200879, -0.5422073480199067, 0.5398119449584851, -0.537620094615634, 0.5402375168482485, -0.5424008370245201, 0.5414903293044941, -0.541839959202767, 0.5427210585246793, -0.544094567...
 ```
 
 Each element of the list above represents a single sample from the distribution over `x`. It's easier to understand these if we plot them as a histogram:
 
 ```scala
 scala> plot1D(x.sample())
-     230 |                                                                                
-         |                                          ·                                     
-         |                                      ∘   ○∘                                    
-         |                                    ·○○  ·○○∘      ·                            
-         |                             ·     ∘○○○  ○○○○      ○                            
-     170 |                            ∘○     ○○○○○ ○○○○      ○  ·     ·                   
-         |                       ○ ∘∘ ○○     ○○○○○ ○○○○      ○ ·○     ○                   
-         |                    ∘· ○○○○∘○○  ·  ○○○○○∘○○○○∘ ∘ ∘ ○○○○∘○·  ○                   
-         |                   ○○○ ○○○○○○○·∘○∘∘○○○○○○○○○○○ ○ ○○○○○○○○○○ ○                   
-         |                  ∘○○○·○○○○○○○○○○○○○○○○○○○○○○○○○ ○○○○○○○○○○○○○                  
-     110 |             ·   ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○   ∘             
-         |           · ○∘· ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○  ·○ ∘ ∘         
-         |         ·∘○○○○○ ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘∘○○∘○ ○         
-         |        ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·∘       
-         |       ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○       
-      50 |       ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○      
-         |      ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○      
-         |     ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘     
-         |    ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○ ·  
-         |  ·∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○  
-       0 |·∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘·
+     340 |                                                                                
+         |                                     · ·  ∘                                     
+         |                                     ○∘○  ○                                     
+         |                                     ○○○∘○○ ∘                                   
+         |                                   ∘∘○○○○○○○○∘                                  
+     250 |                                ···○○○○○○○○○○○ ○∘                               
+         |                                ○○○○○○○○○○○○○○○○○                               
+         |                             ·  ○○○○○○○○○○○○○○○○○ ∘                             
+         |                             ○∘∘○○○○○○○○○○○○○○○○○∘○                             
+         |                            ∘○○○○○○○○○○○○○○○○○○○○○○∘∘                           
+     170 |                            ○○○○○○○○○○○○○○○○○○○○○○○○○·                          
+         |                          ·○○○○○○○○○○○○○○○○○○○○○○○○○○○∘                         
+         |                       ∘·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○ ○                       
+         |                    ·  ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○ ·                     
+         |                    ○∘∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○                   
+      80 |                    ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○ ○                 
+         |                  ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·○·                
+         |               ··○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○               
+         |             ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○··            
+         |       ··∘·∘∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘··· ∘      
+       0 |·····∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘····
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-       -1.78    -1.38    -0.98    -0.59    -0.19     0.21     0.61     1.00     1.40  
+       -3.03    -2.35    -1.68    -1.00    -0.33     0.34     1.02     1.69     2.37  
 ```
 
 Since the only information we have about `x` so far is its `Normal` prior, this distribution unsurprisingly looks normal. Later we'll see how to update our beliefs about `x` based on observational data.
@@ -96,102 +96,102 @@ For now, though, let's explore what we can do just with priors. `RandomVariable`
 
 ```scala
 scala> val e_x = x.map(_.exp)
-e_x: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@548bca8e
+e_x: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@caf283f
 
 scala> plot1D(e_x.sample())
-    2600 |                                                                                
-         |·                                                                               
-         |○∘                                                                              
-         |○○                                                                              
-         |○○                                                                              
-    1900 |○○                                                                              
-         |○○                                                                              
-         |○○                                                                              
-         |○○·                                                                             
-         |○○○                                                                             
-    1300 |○○○                                                                             
-         |○○○                                                                             
-         |○○○                                                                             
-         |○○○·                                                                            
-         |○○○○                                                                            
-     600 |○○○○                                                                            
-         |○○○○∘                                                                           
-         |○○○○○∘                                                                          
-         |○○○○○○∘                                                                         
-         |○○○○○○○○∘                                                                       
-       0 |○○○○○○○○○○○∘∘·················································· ··· ·· ·  ·    ·
+     730 |                                                                                
+         | ∘                                                                              
+         | ○·                                                                             
+         | ○○                                                                             
+         | ○○                                                                             
+     550 | ○○∘   ·∘                                                                       
+         | ○○○  ·○○·                                                                      
+         | ○○○○·○○○○                                                                      
+         | ○○○○○○○○○∘                                                                     
+         | ○○○○○○○○○○                                                                     
+     360 | ○○○○○○○○○○·                                                                    
+         | ○○○○○○○○○○○                                                                    
+         | ○○○○○○○○○○○∘                                                                   
+         | ○○○○○○○○○○○○·                                                                  
+         |·○○○○○○○○○○○○○·                                                                 
+     180 |○○○○○○○○○○○○○○○                                                                 
+         |○○○○○○○○○○○○○○○∘∘∘ ·                                                            
+         |○○○○○○○○○○○○○○○○○○∘○∘∘·                                                         
+         |○○○○○○○○○○○○○○○○○○○○○○○○∘·∘·····                                                
+         |○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘∘∘∘∘∘··∘····                                   
+       0 |○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘∘∘∘·∘···············    ·· ·   ·
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        0.0      4.3      8.6      12.9     17.2     21.6     25.9     30.2     34.5  
+        0.13     0.98     1.82     2.67     3.51     4.36     5.21     6.05     6.90  
 ```
 
 Or we can create another `Normal` parameter and zip the two together to produce a 2D gaussian. Since there's nothing relating these two parameters to each other, you can see in the plot that they're completely independent.
 
 ```scala
 scala> val y = Normal(0,1).param
-y: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@65bd5883
+y: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@254800f7
 
 scala> val xy = x.zip(y)
-xy: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@18dad9e9
+xy: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@7bef595
 
 scala> plot2D(xy.sample())
-     3.9 |                                                                                
-         |                                        · · · ·                                 
-         |                       ·        ·      ··         · ·                           
-         |                     ·        ···· ·· · · ··   ·    ··· ··   ·                  
-         |             ·      ·  · · ··········· ···· ··· ··   · ···                      
-     2.0 |                 ··  ··· · ······························  ·                    
-         |            · ·   ········································· ·  ·                
-         |     ·     ··  ·  ················∘························· ··· ···  ·         
-         |      ·    · ·················∘···∘∘·∘∘∘·∘∘∘·∘∘·············· · · ·             
-         |           ·    ··············∘··∘∘∘∘∘∘∘○∘∘∘∘∘∘∘∘·∘·················      · ·   
-     0.1 |·          ··  ·············∘∘·∘∘∘∘∘○○○∘○○∘∘∘∘∘∘∘·∘··∘···············           
-         |·   ·    ················∘···∘∘∘∘∘○∘∘○○○○∘○∘○∘∘∘∘·∘∘·············· · ·  ·      ·
-         |      ··  ··  ·· ·············∘∘∘∘∘∘∘∘∘∘○○∘○∘∘∘∘∘∘·∘·∘······· ····· · ··        
-         |           · ···················∘·∘∘∘∘∘∘∘○∘∘∘∘∘∘·∘················· ·· ··       
-         |        ·  ···   ······ ···········∘·∘···∘··∘∘∘················· ···     ·      
-    -1.7 |       ·  ·   ····· ·················∘········∘··············· · ·         ·    
-         |                    ··· ································ · ···    ·     ·       
-         |                     ···· ·· ··· ·· ·········· ····· ·  ·       ·      ·        
-         |                        ·   · ···· ······· ·· · ·· · ·  ·    ·   ·  ·           
-         |                         ···     ·····   ··           ·                         
-    -3.6 |                        ·              · ·                                      
+     4.0 |                                                                                
+         |                                    ·   ·                                       
+         |               ·     ·  ·                          ·      ·                     
+         |                              ·    · ··   · ··          ·               ·      ·
+         |       ·           ·   ·   ·····  ············ ······      ·                    
+     2.0 |               ··    · · ··········· ···· ···················· · · ·  · ·       
+         |        ·  · · ·······  ····································· ·· · ·   ·        
+         |       · · ·  ···· ··············∘···∘·∘·······∘················ ·· ·  ·        
+         |      · ···· ·· ···········∘··∘·∘∘·∘∘∘··∘∘∘·∘∘∘∘∘∘······················        
+         |  ··· ··  ··· ·············∘·∘∘·∘∘∘∘∘∘·∘∘∘∘∘∘∘∘∘·∘∘∘·∘·∘···················  ·· 
+    -0.0 |      ······················∘∘∘∘∘∘∘∘∘∘○○∘○○∘○∘∘∘∘∘∘∘∘·················· ·· ·    
+         |·       ···· ··············∘∘∘∘∘∘∘○∘∘∘∘∘∘∘∘○∘∘∘○∘∘∘∘∘∘··············· ·  ···· ··
+         |      · ···················∘∘∘∘∘∘∘∘∘∘∘∘∘○∘∘∘○○·····∘·∘·∘···············      ·  
+         |      · ······  ················∘·∘·∘∘∘∘∘·∘∘∘··∘·∘··············· ·· · ··   ·   
+         | ·    ··  ·  ·· ·····················∘·····························    ·  ·     
+    -2.1 |             ··· ··  ··································· · ··· ·  · ·  ·        
+         |     ·      ··   · · ·· ·· ·········· ····  ········ ··  ···    ·  ·            
+         |                   ··  ·   ··  · · ··········  ····   ·             ·   ·       
+         |                                ·   · ·     ·             ·                     
+         |                              ·                      ·                          
+    -4.1 |             ·                               ·                                  
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        -4.1     -3.2     -2.3     -1.4     -0.4     0.5      1.4      2.3      3.2   
+       -3.44    -2.68    -1.92    -1.17    -0.41     0.35     1.10     1.86     2.62  
 ```
 
 Finally, we can use `flatMap` to create two parameters that *are* related to each other. In particular, we'll create a new parameter `z` that we believe to be very close to `x`: its prior is a `Normal` centered on `x` with a very small standard deviation. We'll then make a 2D plot of `(x,z)` to see the relationship.
 
 ```scala
 scala> val z = x.flatMap{a => Normal(a, 0.1).param}
-z: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@7286a2f0
+z: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@217c6f5c
 
 scala> val xz = x.zip(z)
-xz: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@186ac4b4
+xz: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@545be675
 
 scala> plot2D(xz.sample())
-     4.4 |                                                                                
-         |                                                                               ·
-         |                                                                      ·         
-         |                                                                     ···        
-         |                                                             ······             
-     2.5 |                                                          ······ ·              
-         |                                                      ·······                   
-         |                                                ··········                      
-         |                                            ··········                          
-         |                                         ···∘∘····                              
-     0.5 |                                    ···∘∘∘∘···                                  
-         |                                ···∘∘○∘···                                      
-         |                            ···∘○○∘····                                         
-         |                        ···∘∘∘∘····                                             
-         |                    ····∘∘∘···                                                  
-    -1.4 |                ·····∘····                                                      
-         |             ·········                                                          
-         |         ·········                                                              
-         |      ·······                                                                   
-         |   ·······                                                                      
-    -3.4 |· ·                                                                             
+     3.8 |                                                                                
+         |                                                                             ···
+         |                                                                      ·······   
+         |                                                                   ·······      
+         |                                                              ········          
+     1.8 |                                                           ········             
+         |                                                      ·········                 
+         |                                                 ····∘∘····                     
+         |                                              ···∘∘∘···                         
+         |                                          ··∘∘○∘∘···                            
+    -0.2 |                                      ···∘○○∘···                                
+         |                                  ···∘○∘∘···                                    
+         |                             ····∘∘∘∘···                                        
+         |                           ···∘∘····                                            
+         |                      ··········                                                
+    -2.1 |                   ·······                                                      
+         |               ········                                                         
+         |            ·······                                                             
+         |        ······                                                                  
+         |      ·                                                                         
+    -4.1 |·  ·                                                                            
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-       -3.25    -2.39    -1.52    -0.66     0.21     1.07     1.94     2.80     3.67  
+       -4.17    -3.28    -2.39    -1.50    -0.61     0.28     1.17     2.06     2.95  
 ```
 
 You can see that although we still sample from the full range of `x` values, for any given sample, `x` and `z` are quite close to each other.
@@ -216,7 +216,7 @@ val poisson9: RandomVariable[_] = Poisson(9).fit(sales)
 val poisson10: RandomVariable[_] = Poisson(10).fit(sales)
 ```
 
-A `RandomVariable`'s density is a rather opaque objects and, since it is almost never necessary to reach into a `RandomVariable` and get its current probability `density`, Rainier makes this hard to do. Taking on faith momentarily that
+A `RandomVariable`'s density is a rather opaque object and, since it is almost never necessary to reach into a `RandomVariable` and get its current probability `density`, Rainier makes this hard to do. Taking on faith momentarily that
 
 ```scala
 val poisson9density = -18.03523006575617
@@ -234,7 +234,7 @@ We can see here that our data is about 3x as likely to have come from a `Poisson
 
 ```scala
 scala> val poisson: RandomVariable[_] = e_x.flatMap{r => Poisson(r).fit(sales)}
-poisson: com.stripe.rainier.core.RandomVariable[_] = com.stripe.rainier.core.RandomVariable@12af2210
+poisson: com.stripe.rainier.core.RandomVariable[_] = com.stripe.rainier.core.RandomVariable@74e8f87
 ```
 
 Reaching under the hood for a second: our `poisson9`'s `density` had no parameters whereas now, our model's density is a function of the parameter value
@@ -247,14 +247,14 @@ scala> poisson.density().nVars
 res6: Int = 1
 ```
 
-As mentioned, the `density` itself is rather opaque so instead of manipulating it directly, we can sample the quantity we're actually interested in. To start with, let's try to sample the rate parameter of the Poisson, conditioned by our observed data. Here's almost the same thing we had above, recreated with the slightly friendlier `for` syntax, and yielding the `r` parameter at the end:
+Rather than manipulating the `density` directly, we can sample the quantity we're actually interested in. To start with, let's try to sample the rate parameter of the Poisson, conditioned on our observed data. Here's almost the same thing we had above, recreated with the slightly friendlier `for` syntax, and yielding the `r` parameter at the end:
 
 ```scala
 scala> val rate = for {
      |     r <- e_x
      |     poisson <- Poisson(r).fit(sales)
      | } yield r
-rate: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@60df0b8b
+rate: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@4bf3121d
 ```
 
 This is our first "full" model: we have a parameter with a log-normal prior, bundled into the `RandomVariable` named `e_x`; we use that parameter to initialize a `Poisson` noise distribution which we fit to our observations; and at the end, we output the same parameter (referenced by `r`) as the quantity we're interested in sampling from the posterior.
@@ -263,29 +263,29 @@ Let's plot the results!
 
 ```scala
 scala> plot1D(rate.sample())
-     390 |                                                                                
-         |                               ∘                                                
-         |                             ∘ ○                                                
-         |                           ○∘○ ○∘                                               
-         |                      ∘  ○○○○○∘○○                                               
-     290 |                     ∘○ ∘○○○○○○○○∘∘○                                            
-         |                     ○○·○○○○○○○○○○○○  ·                                         
-         |                    ·○○○○○○○○○○○○○○○  ○                                         
-         |                 ·○ ○○○○○○○○○○○○○○○○∘·○∘                                        
-         |                 ○○∘○○○○○○○○○○○○○○○○○○○○·                                       
-     190 |                 ○○○○○○○○○○○○○○○○○○○○○○○○  ·                                    
-         |                ∘○○○○○○○○○○○○○○○○○○○○○○○○ ·○                                    
-         |                ○○○○○○○○○○○○○○○○○○○○○○○○○∘○○                                    
-         |              ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘                                   
-         |            ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘                                 
-      90 |           ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○··                               
-         |           ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                               
-         |       ·∘∘∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘ ∘∘                           
-         |       ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○○∘∘                         
-         |   ∘ ○∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘·∘  ·                   
-       0 |·∘○○∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·∘∘·∘·· ·    ·   ·
+     430 |                                                                                
+         |                                ∘                                               
+         |                               ·○                                               
+         |                              ○○○                                               
+         |                             ○○○○ · ○·                                          
+     320 |                             ○○○○∘○○○○                                          
+         |                         · ○○○○○○○○○○○·∘                                        
+         |                        ·○·○○○○○○○○○○○○○                                        
+         |                        ○○○○○○○○○○○○○○○○∘ ○                                     
+         |                        ○○○○○○○○○○○○○○○○○∘○                                     
+     210 |                       ○○○○○○○○○○○○○○○○○○○○··                                   
+         |                     ○·○○○○○○○○○○○○○○○○○○○○○○                                   
+         |                   ∘·○○○○○○○○○○○○○○○○○○○○○○○○  ∘                                
+         |                   ○○○○○○○○○○○○○○○○○○○○○○○○○○ ∘○                                
+         |                   ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○   ∘                            
+     100 |                · ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○ ∘○                            
+         |               ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·○○                            
+         |             ∘∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○·                         
+         |∘            ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○ ·                       
+         |○      ∘·· ∘ ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○····                   
+       0 |○  ·  ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○○∘∘·· ·····  ··
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        5.20     5.95     6.70     7.45     8.19     8.94     9.69    10.44    11.19  
+        4.41     5.28     6.15     7.02     7.90     8.77     9.64    10.51    11.38  
 ```
 
 Looks like our daily rate is probably somewhere between 6 and 9, which corresponds well to the steep 3x dropoff we saw before between 9 and 10.
@@ -336,42 +336,42 @@ scala> val prediction = for {
      |     r <- e_x
      |     poisson <- Poisson(r).fit(sales)
      | } yield poisson.generator
-prediction: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@1514c8d1
+prediction: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@238bfb48
 ```
 
 This is almost the same model as `rate` above, but instead of taking the real-valued `r` rate parameter as the output, we're producing poisson-distributed integers. The samples look like this:
 
 ```scala
 scala> prediction.sample()
-res9: List[Int] = List(8, 15, 3, 10, 6, 7, 6, 10, 6, 6, 8, 3, 10, 7, 5, 7, 9, 5, 14, 1, 8, 9, 10, 7, 4, 8, 8, 9, 10, 8, 3, 10, 7, 6, 8, 8, 7, 5, 7, 4, 9, 1, 12, 7, 10, 7, 6, 6, 3, 7, 7, 10, 7, 9, 6, 9, 10, 7, 9, 9, 12, 5, 8, 10, 6, 7, 11, 6, 7, 4, 8, 6, 5, 5, 8, 10, 8, 7, 7, 12, 9, 7, 6, 10, 8, 7, 11, 14, 5, 8, 5, 7, 9, 2, 9, 6, 10, 14, 5, 13, 13, 4, 5, 7, 17, 8, 10, 6, 7, 8, 14, 5, 5, 10, 4, 6, 6, 11, 9, 6, 8, 8, 7, 8, 3, 10, 11, 4, 10, 9, 11, 9, 5, 11, 2, 6, 5, 5, 7, 7, 5, 10, 8, 8, 7, 12, 15, 12, 7, 9, 11, 6, 4, 7, 7, 7, 5, 9, 7, 6, 15, 6, 8, 4, 10, 5, 11, 6, 10, 4, 10, 9, 8, 6, 9, 6, 12, 10, 5, 13, 4, 6, 9, 3, 13, 12, 6, 7, 6, 14, 9, 5, 11, 6, 7, 10, 6, 7, 8, 2, 11, 2, 7, 11, 4, 7, 8, 10, 12, 7, 11, 8, 5, 7, 11, 11, 6, 7, 8, 9, 9, 9, 3, 3, 12, 8, 6, 8, 5, 1...
+res9: List[Int] = List(9, 14, 7, 11, 8, 5, 13, 8, 10, 8, 9, 6, 9, 4, 9, 10, 6, 7, 7, 11, 4, 5, 7, 11, 11, 6, 12, 5, 6, 9, 10, 7, 3, 13, 7, 8, 4, 10, 11, 11, 9, 6, 5, 5, 9, 5, 10, 9, 13, 7, 4, 3, 7, 3, 12, 0, 10, 7, 11, 7, 10, 5, 6, 11, 8, 10, 7, 10, 8, 7, 8, 9, 14, 10, 5, 4, 6, 13, 15, 7, 5, 10, 7, 3, 4, 7, 9, 9, 4, 11, 7, 3, 6, 8, 8, 7, 8, 9, 8, 8, 7, 11, 7, 7, 6, 7, 4, 11, 2, 4, 9, 6, 11, 4, 7, 14, 5, 9, 6, 10, 3, 9, 8, 9, 13, 13, 3, 6, 7, 8, 5, 8, 4, 3, 17, 9, 10, 11, 6, 2, 3, 5, 6, 6, 5, 8, 9, 10, 5, 11, 6, 8, 10, 8, 7, 6, 15, 8, 5, 5, 8, 5, 14, 9, 4, 9, 12, 6, 10, 1, 7, 5, 13, 7, 7, 11, 11, 10, 14, 9, 7, 10, 6, 3, 11, 9, 4, 2, 7, 10, 9, 6, 16, 4, 9, 10, 12, 8, 5, 3, 6, 15, 7, 10, 7, 9, 7, 10, 10, 11, 11, 8, 9, 7, 5, 8, 6, 2, 4, 7, 8, 7, 10, 3, 10, 6, 10, 9...
 ```
 Or, if we plot them, like this:
 
 ```scala
 scala> plot1D(prediction.sample())
-    1360 |                                                                                
-         |                    ·   ○                                                       
-         |                    ○   ○  ∘                                                    
-         |                    ○   ○  ○                                                    
-         |                 ·  ○   ○  ○                                                    
-    1020 |                 ○  ○   ○  ○   ○                                                
-         |                 ○  ○   ○  ○   ○                                                
-         |                 ○  ○   ○  ○   ○                                                
-         |                 ○  ○   ○  ○   ○  ∘                                             
-         |                 ○  ○   ○  ○   ○  ○                                             
-     680 |             ∘   ○  ○   ○  ○   ○  ○                                             
-         |             ○   ○  ○   ○  ○   ○  ○   ·                                         
-         |             ○   ○  ○   ○  ○   ○  ○   ○                                         
-         |             ○   ○  ○   ○  ○   ○  ○   ○                                         
-         |             ○   ○  ○   ○  ○   ○  ○   ○  ∘                                      
-     340 |          ·  ○   ○  ○   ○  ○   ○  ○   ○  ○                                      
-         |          ○  ○   ○  ○   ○  ○   ○  ○   ○  ○                                      
-         |          ○  ○   ○  ○   ○  ○   ○  ○   ○  ○   ∘                                  
-         |      ∘   ○  ○   ○  ○   ○  ○   ○  ○   ○  ○   ○  ·                               
-         |      ○   ○  ○   ○  ○   ○  ○   ○  ○   ○  ○   ○  ○  ·                            
-       0 |·  ○  ○   ○  ○   ○  ○   ○  ○   ○  ○   ○  ○   ○  ○  ○   ∘  ∘   ·  ·   ·  ·   ·  ·
+    1390 |                                                                                
+         |                         ○                                                      
+         |                         ○  ∘                                                   
+         |                     ∘   ○  ○                                                   
+         |                     ○   ○  ○                                                   
+    1040 |                     ○   ○  ○   ∘                                               
+         |                  ∘  ○   ○  ○   ○                                               
+         |                  ○  ○   ○  ○   ○                                               
+         |                  ○  ○   ○  ○   ○   ∘                                           
+         |                  ○  ○   ○  ○   ○   ○                                           
+     690 |              ∘   ○  ○   ○  ○   ○   ○                                           
+         |              ○   ○  ○   ○  ○   ○   ○                                           
+         |              ○   ○  ○   ○  ○   ○   ○  ○                                        
+         |              ○   ○  ○   ○  ○   ○   ○  ○                                        
+         |          ·   ○   ○  ○   ○  ○   ○   ○  ○   ∘                                    
+     340 |          ○   ○   ○  ○   ○  ○   ○   ○  ○   ○                                    
+         |          ○   ○   ○  ○   ○  ○   ○   ○  ○   ○                                    
+         |          ○   ○   ○  ○   ○  ○   ○   ○  ○   ○   ○                                
+         |       ∘  ○   ○   ○  ○   ○  ○   ○   ○  ○   ○   ○  ·                             
+         |       ○  ○   ○   ○  ○   ○  ○   ○   ○  ○   ○   ○  ○   ·                         
+       0 |·  ∘   ○  ○   ○   ○  ○   ○  ○   ○   ○  ○   ○   ○  ○   ○  ∘   ·   ·  ·       ·  ·
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        0.0      2.6      5.2      7.8      10.4     13.0     15.6     18.2     20.8  
+        0.0      2.5      5.0      7.5      9.9      12.4     14.9     17.4     19.9  
 ```
 
 ## `Likelihood` and `Predictor`
@@ -419,7 +419,7 @@ scala> val prior = for {
      |     slope <- LogNormal(0,1).param
      |     intercept <- LogNormal(0,1).param
      |     } yield (slope, intercept)
-prior: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@4bac3106
+prior: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@5657d3c3
 ```
 
 Now, for any given day `i`, we want to check the number of sales against `Poisson(intercept + slope*i)`. We could write some kind of recursive flatMap to build and fit each of these different distribution objects in turn, but this is a common enough pattern that Rainier already has something built in for it: `Predictor`. `Predictor` is not a `Distribution`, but instead wraps a function from `X => Distribution[Y]` for some `(X,Y)`; you can use this any time you have a dependent variable of type `Y` that you're modeling with some independent variables jointly represented as `X`.
@@ -433,7 +433,7 @@ scala> val regr = for {
      |                     Poisson(intercept + slope*i)
      |                 }.fit(data)
      | } yield (slope, intercept)
-regr: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@2f02e317
+regr: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@55dc5bef
 ```
 
 As before, we're starting out by just sampling the parameters. By plotting them, we can see that the model's confidence in the intercept, in particular, is pretty low: although it's most likely to be somewhere around 8, it could be anywhere from 3 to 13 or even higher. Second, as you'd hope, the two parameters are anti-correlated:
@@ -441,29 +441,29 @@ a smaller intercept would imply a higher slope, and vice versa.
 
 ```scala
 scala> plot2D(regr.sample())
-    15.3 |                                                                                
-         | ·               ·                                                              
-         |    ··    ·  ·  ·    ·                                                          
-         |       · ·  · · ··   ·   ·   ·                                                  
-         |      ·· ·· ·· ·· ····  ······· · ·                                             
-    12.1 |        ·  ························· ·                                          
-         |·        ··· ·····························   ·                                  
-         |    ·   ····· ··························· ·  ·   ·    ·                         
-         |         · · ·································· · ···    ·                      
-         |       ·   ·················∘∘∘∘∘∘···················  ·                        
-     8.9 |               ·············∘∘∘∘∘∘∘∘∘○∘∘∘∘∘∘············  ·                     
-         |                    ·········∘∘∘∘∘∘○○∘∘○∘∘∘∘∘·∘∘··············                  
-         |                   ···· ········∘∘∘∘∘○○○∘○○∘∘○∘∘∘·∘··············               
-         |                        · ··········∘∘∘∘∘∘○○○∘∘∘∘∘∘∘·∘·········· ··· ··         
-         |                          ···············∘∘∘∘∘∘∘∘∘∘∘∘·∘·············       ··   
-     5.8 |                         · ·   ···············∘∘∘∘∘·∘∘················ ··       
-         |                                 ·································· ···· ·      
-         |                                      · ·························· ····· ·      
-         |                                          · ··· · ·······················      ·
-         |                                         ·         · ··  ·    · · · ··  ·       
-     2.6 |                                                          ·       ·  ·   ·      
+    15.2 |                                                                                
+         |·            ·                                                                  
+         |    ·       ·      ·        ·                                                   
+         |    ·   ·   ··  ··  · ·    ·  ·                                                 
+         |·  ·  · ··········· ····· ·      ·                                              
+    12.0 |·    ····················· ··  ·  ·· ·                                          
+         |     ·· · · ························  ··                                        
+         |        ·· ································ ·    ·                              
+         |     · ·  · ·············∘··∘··············  ··  ·                              
+         |         ···············∘·∘∘∘∘∘∘∘∘∘·∘·············· ·                           
+     8.8 |              · ·········∘∘∘∘∘○∘∘∘∘∘∘∘∘·············· · ·                       
+         |           · ·············∘∘∘∘○○○○○○∘○○∘∘∘∘···············                      
+         |                 ···········∘·∘∘∘∘○∘∘○○○○○∘○∘∘·∘·········  ·  ·                 
+         |                    · ···········∘∘∘∘∘∘○○○○∘∘∘∘∘∘········ ·· ····    ·          
+         |                    ·   · ··········∘∘∘∘∘∘∘∘∘∘∘∘∘∘··········· · · ·             
+     5.6 |                          · ···············∘∘················· ···· ·           
+         |                           ·  ·  ·· ·····························     ·         
+         |                                 ·· ·  · · ··················· ·· ·  ····       
+         |                                       ·· · ··  · ·· ·····  ·······   ·         
+         |                                                        ··   ··· ·             ·
+     2.4 |                                                      ·   ·   ·                 
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        2.41     2.58     2.75     2.92     3.08     3.25     3.42     3.59     3.75  
+        2.44     2.62     2.80     2.98     3.16     3.33     3.51     3.69     3.87  
 ```
 
 Alternatively, as in the earlier example, we could try to predict what will happen tomorrow. This is similar to calling `poisson.generator` before, but this time, we use the `predict` method on `Predictor`, which takes the covariate (the day, in this case), and returns a `Generator` for the dependent variable (the number of sales). Putting it all together, it looks like this:
@@ -476,36 +476,36 @@ scala> val regr2 = for {
      |                     Poisson(intercept + slope*i)
      |                 }.fit(data)
      | } yield predictor.predict(21)
-regr2: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@1b5381ad
+regr2: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@4ecf3c5c
 ```
 
 Plotting this gives us a prediction which incorporates both the natural noise of a Poisson distribution and our uncertainty about its underlying parameterization.
 
 ```scala
 scala> plot1D(regr2.sample())
-     460 |                                                                                
-         |                                         ∘                                      
-         |                                   ∘ ∘ ∘ ○○                                     
-         |                                   ○ ○○○ ○○∘ ○                                  
-         |                                  ○○·○○○ ○○○ ○                                  
-     340 |                                · ○○○○○○ ○○○∘○                                  
-         |                               ·○ ○○○○○○ ○○○○○  ○                               
-         |                              ○○○ ○○○○○○ ○○○○○○ ○                               
-         |                              ○○○ ○○○○○○ ○○○○○○ ○ ∘                             
-         |                            ∘·○○○ ○○○○○○ ○○○○○○ ○○○                             
-     230 |                            ○○○○○ ○○○○○○ ○○○○○○ ○○○                             
-         |                            ○○○○○ ○○○○○○ ○○○○○○ ○○○○○                           
-         |                           ∘○○○○○ ○○○○○○ ○○○○○○ ○○○○○ ·                         
-         |                           ○○○○○○ ○○○○○○ ○○○○○○ ○○○○○ ○∘                        
-         |                        ·∘ ○○○○○○ ○○○○○○ ○○○○○○ ○○○○○ ○○∘                       
-     110 |                        ○○ ○○○○○○ ○○○○○○ ○○○○○○ ○○○○○ ○○○·                      
-         |                      ·○○○ ○○○○○○ ○○○○○○ ○○○○○○ ○○○○○ ○○○○·                     
-         |                     ∘○○○○ ○○○○○○ ○○○○○○ ○○○○○○ ○○○○○ ○○○○○○ ·                  
-         |                  ○∘ ○○○○○ ○○○○○○ ○○○○○○ ○○○○○○ ○○○○○ ○○○○○○ ○○                 
-         |               ∘ ·○○ ○○○○○ ○○○○○○ ○○○○○○ ○○○○○○ ○○○○○ ○○○○○○ ○○○∘○·             
-       0 |·   ·· ···∘∘· ○○○○○○ ○○○○○ ○○○○○○ ○○○○○○ ○○○○○○ ○○○○○ ○○○○○○ ○○○○○○ ○○·∘· ······
+     450 |                                                                                
+         |                              ·∘                                                
+         |                            ·○○○· ·∘                                            
+         |                            ○○○○○○○○                                            
+         |                            ○○○○○○○○∘ ○                                         
+     340 |                         ·· ○○○○○○○○○∘○                                         
+         |                         ○○ ○○○○○○○○○○○                                         
+         |                        ∘○○ ○○○○○○○○○○○○                                        
+         |                       ·○○○ ○○○○○○○○○○○○ ∘                                      
+         |                       ○○○○ ○○○○○○○○○○○○ ○○∘                                    
+     220 |                     ··○○○○ ○○○○○○○○○○○○ ○○○                                    
+         |                    ○○○○○○○ ○○○○○○○○○○○○ ○○○                                    
+         |                   ○○○○○○○○ ○○○○○○○○○○○○ ○○○○○·                                 
+         |                   ○○○○○○○○ ○○○○○○○○○○○○ ○○○○○○                                 
+         |                  ○○○○○○○○○ ○○○○○○○○○○○○ ○○○○○○·                                
+     110 |                 ·○○○○○○○○○ ○○○○○○○○○○○○ ○○○○○○○··                              
+         |               ·○○○○○○○○○○○ ○○○○○○○○○○○○ ○○○○○○○○○ ·                            
+         |               ○○○○○○○○○○○○ ○○○○○○○○○○○○ ○○○○○○○○○∘○                            
+         |              ∘○○○○○○○○○○○○ ○○○○○○○○○○○○ ○○○○○○○○○○○·∘                          
+         |          ·∘∘ ○○○○○○○○○○○○○ ○○○○○○○○○○○○ ○○○○○○○○○○○○○ ○○○                      
+       0 |······∘∘○○○○○ ○○○○○○○○○○○○○ ○○○○○○○○○○○○ ○○○○○○○○○○○○○ ○○○○∘······· · ·· ·· ·  ·
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        40.0     47.7     55.3     63.0     70.6     78.3     86.0     93.6    101.3  
+        44.0     52.3     60.7     69.0     77.3     85.7     94.0    102.4    110.7  
 ```
 
 Finally, let's close with a small and somewhat contrived example of a hierarchical model, where we have two separate regressions that share a parameter. For the sake of the example, let's assume that we have a second sales dataset, much like the first, where we know they had the same rate at the start of the observations, but may have grown at different rates - so their intercepts will be equal but their slopes will not. Here's the data:
@@ -525,7 +525,7 @@ scala> val regr3 =  for {
      |     _ <- Predictor.fromInt{ i => Poisson(intercept + slope0 * i) }.fit(data)
      |     _ <- Predictor.fromInt{ i => Poisson(intercept + slope1 * i) }.fit(data2)
      | } yield (slope0, intercept)
-regr3: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@58cf4bc7
+regr3: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@1ceb19c1
 ```
 
 or we can use Rainier's `Lookup` to package the two slopes into a single `RandomVariable` from which we can lookup the one we want. This means that our predictor now has to take both the index of the model to which the data belongs as well as the actual observation as input.
@@ -539,36 +539,36 @@ scala> val regLookup = for {
      |   intercept <- LogNormal(0,1).param
      |   _ <- Predictor.fromIntPair{ case (index, x) => Poisson(intercept + slopes(index) * x) }.fit(allData)
      | } yield (slopes(0), intercept)
-regLookup: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@7160a98d
+regLookup: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@14160c76
 ```
 
 Plotting slope vs. intercept now, we see that, even though these are two separate regressions, we get tighter bounds than before by letting the new data influence the shared parameter. It makes sense that we'd get more confidence on the intercept, since we have two different time series to learn from now; but because of the anti-correlation, that also leads to somewhat more confidence than before on the `slopes(0)` parameter as well.
 
 ```scala
 scala> plot2D(regLookup.sample())
-    10.7 |                                                                                
-         |                         ·                                                      
-         |·           ·  ····   ··                                                        
-         |             · · · ··· ····  · · ··    ·                                        
-         |        ·  ······· ··············· ··   ··  ·                                   
-     8.8 |       ·        ·························· ·   ·                                
-         |      ·   ··  ······························· ·    ·      ·                     
-         |       ·      ··································  · ·                           
-         |             ·················∘∘∘·∘∘················  ·· ·                      
-         |                ············∘·∘∘∘∘∘∘∘∘∘∘·∘············· ·····  ·                
-     6.9 |            · · · ··········∘·∘∘∘∘○∘○○○∘∘∘∘∘∘················ ·                 
-         |                   ···········∘∘∘∘○∘∘∘○○○∘∘∘∘∘∘∘·∘········  · ·· ·              
-         |             ·  · ·· ············∘∘∘∘○○○○∘∘○∘○∘·∘∘··············   ·            
-         |                   · ··············∘∘∘∘∘∘∘∘∘∘∘∘∘∘·············   ··      ·      
-         |                ·     ··· · ···········∘∘∘∘∘∘∘∘∘·∘··················· ·         
-     5.0 |                         · ····················∘················                
-         |                         ·     ··· ··························· ·· ····          
-         |                              ···   ······························ ·            
-         |                                       ·· ·········· ············               
-         |                                             · ···     · · ·  · ·               
-     3.0 |                                                       ·      ·      ·         ·
+    11.7 |                                                                                
+         |                    ·                                                           
+         |                                                                                
+         | ·                                                                              
+         |       ·· ··  ·         ·   ·     ··                                            
+     9.5 |           · · ···  · · · ··   ··   ·                                           
+         |· ·   ·· ··· · ········  ·········  ····  ···                                   
+         |      ·· · ······························   ··                                  
+         | ·  ······································· ·   ·· ·                            
+         |·    · ·· ·········································· ·                          
+     7.4 |      ·   ················∘∘∘∘∘∘∘·∘························                     
+         |    ·     · ············∘∘∘∘∘∘∘∘∘∘∘∘∘∘∘∘∘∘···∘··········· ·  ·                  
+         |          ··  ···········∘∘∘∘∘∘○∘∘○∘○∘∘∘∘∘∘∘∘∘∘∘·············· ·                
+         |     ·    · ·· ·············∘∘∘∘∘∘∘○∘○○○∘∘∘○∘∘∘∘·∘············ ····· ·  ·       
+         |             · ··············∘·∘∘∘∘∘∘∘○○∘○○∘○∘∘∘∘∘∘···············   ··   ·  ·  
+     5.3 |                   · ···············∘·∘∘·∘∘∘∘∘∘∘∘·····∘············  ·          
+         |                    · ····· ·················∘···················· ·  ·     ·   
+         |                        ·   ····· ······························ ···  ·    ·    
+         |                     ·       ·   · ··· ··· ·········· ············  ····  ·    ·
+         |                                ·    ·  ·   ··· · · ······· ··   · ·     ·      
+     3.1 |                                                        ···          ·   ·      
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        2.62     2.78     2.94     3.09     3.25     3.41     3.56     3.72     3.88  
+        2.73     2.87     3.01     3.15     3.28     3.42     3.56     3.70     3.84  
 ```
 
 ## Learning More

--- a/docs/tour.md
+++ b/docs/tour.md
@@ -30,7 +30,7 @@ Rainier implements various familiar families of probability distributions like t
 
 ```scala
 scala> val normal: Distribution[Double] = Normal(0,1)
-normal: com.stripe.rainier.core.Distribution[Double] = com.stripe.rainier.core.Injection$$anon$1@369e8d17
+normal: com.stripe.rainier.core.Distribution[Double] = com.stripe.rainier.core.Injection$$anon$1@17d0cd9d
 ```
 
 In Rainier, `Distribution` objects play three different roles. `Continuous` distributions (like `Normal`), implement `param`, and all distributions implement `fit` and `generator`. Each of these methods is central to one of the three stages of building a model in Rainier:
@@ -51,43 +51,43 @@ Let's use that same `Normal(0,1)` distribution as a prior for a new parameter:
 
 ```scala
 scala> val x = Normal(0,1).param
-x: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@7cff1544
+x: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@551c7d93
 ```
 
 You can see that the type of `x` is `RandomVariable[Real]`. `RandomVariable` pairs a type of value (in this case, a real number) with some knowledge of the relative probability density of different values of that type. We can use this knowledge to produce a sample of these possible values:
 
 ```scala
 scala> x.sample()
-res0: List[Double] = List(1.0789727641139946, -1.0553093839118644, 0.9723748750490253, 0.9723748750490253, -0.9603034968271834, 1.0768114428738016, -1.1247694864281526, 1.2529584415303971, -1.2102358458863696, 1.1906618333223538, -1.1010481737241804, 1.189633360634739, -1.228617170322838, 1.1178584597228283, -1.062429983199118, 1.093919341464783, -1.0190941838880936, 0.9342536325380304, -0.8992733368149997, 0.7688382377967731, -0.6834118973226806, 0.5416394052441835, -0.44677266563724793, 0.5248886112836716, -0.5502756722446693, 0.4734690290354755, -0.40028800194872294, 0.34258597136189106, -0.3732580029472242, 0.34310595686341183, -0.44770606816055514, 0.44470975743430263, -0.3363536041575017, 0.2510462366708255, -0.26377719195600396, 0.3628966071333155, -0.32...
+res0: List[Double] = List(0.4340295670534234, -0.24385097254448418, -0.21128971715509381, 0.09468740412159904, 0.09468740412159904, 0.03591053955232293, -0.22286713963453408, -0.034357974561333826, -0.1162993540737618, 0.07617256423393193, 0.12110418419664137, 0.02343973044750758, 0.26267286865770734, -0.3693362951415913, 0.327282959233593, -0.12916094442830506, 0.02752481381708316, -0.34731236052279435, 0.23717101598215562, -0.19123727473350832, 0.09393379098985855, -0.16700560856930796, 0.19761051268227106, -0.04970365183204439, 0.20642275440900915, -0.7553659178749728, 0.8609297548638928, -1.222620656687856, 1.2655461590032402, -1.1970564684044651, 1.0039695295159023, -1.171713522598317, 1.1081846951822159, -1.1699070624671495, 1.4184145332904783, -1.5862599...
 ```
 
 Each element of the list above represents a single sample from the distribution over `x`. It's easier to understand these if we plot them as a histogram:
 
 ```scala
 scala> plot1D(x.sample())
-     430 |                                                                                
-         |                                       ∘   ∘                                    
-         |                                   ○ · ○  ∘○                                    
-         |                                   ○∘○○○ ·○○·                                   
-         |                                 ○∘○○○○○·○○○○                                   
-     320 |                               ∘ ○○○○○○○○○○○○○                                  
-         |                               ○∘○○○○○○○○○○○○○ ○                                
-         |                              ○○○○○○○○○○○○○○○○∘○                                
-         |                              ○○○○○○○○○○○○○○○○○○∘                               
-         |                             ○○○○○○○○○○○○○○○○○○○○·                              
-     210 |                           ·∘○○○○○○○○○○○○○○○○○○○○○                              
-         |                           ○○○○○○○○○○○○○○○○○○○○○○○○∘                            
-         |                          ·○○○○○○○○○○○○○○○○○○○○○○○○○·                           
-         |                          ○○○○○○○○○○○○○○○○○○○○○○○○○○○                           
-         |                        ·∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○                          
-     100 |                       ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘                         
-         |                      ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·                       
-         |                      ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○··                     
-         |                   ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                     
-         |                 ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·∘                   
-       0 |··   ········∘∘·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○··∘·······    ··
+     260 |                                                                                
+         |                            ·                       ·                           
+         |                            ○·            ·        ·○                           
+         |                           ○○○  ··  ○○·   ○○  ∘   ○○○                           
+         |                       ·   ○○○  ○○  ○○○ ∘·○○∘ ○· ∘○○○·                          
+     190 |                       ○  ○○○○·○○○ ○○○○○○○○○○ ○○○○○○○○                          
+         |                      ∘○  ○○○○○○○○○○○○○○○○○○○○○○○○○○○○  ·∘                      
+         |                     ·○○∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·                     
+         |                     ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘                    
+         |                    ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                    
+     130 |                    ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                    
+         |                    ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                    
+         |                    ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                    
+         |                    ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                    
+         |              ∘    ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·    ∘              
+      60 |              ○    ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○    ○              
+         |              ○· ○∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○  ○              
+         |       ∘○    ∘○○·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○ ○○○    ○∘       
+         |      ∘○○·   ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○   ·○○·      
+         |·· ∘··○○○○ ∘·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘∘·○○○○∘··· ∘
+       0 |○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        -4.1     -3.2     -2.2     -1.3     -0.3     0.6      1.5      2.5      3.4   
+       -3.05    -2.37    -1.68    -0.99    -0.31     0.38     1.06     1.75     2.43  
 ```
 
 Since the only information we have about `x` so far is its `Normal` prior, this distribution unsurprisingly looks normal. Later we'll see how to update our beliefs about `x` based on observational data.
@@ -96,102 +96,102 @@ For now, though, let's explore what we can do just with priors. `RandomVariable`
 
 ```scala
 scala> val e_x = x.map(_.exp)
-e_x: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@633333be
+e_x: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@27e8e02f
 
 scala> plot1D(e_x.sample())
-    4200 |                                                                                
+    3600 |                                                                                
          |∘                                                                               
          |○                                                                               
          |○                                                                               
          |○                                                                               
-    3100 |○                                                                               
-         |○                                                                               
-         |○                                                                               
-         |○                                                                               
-         |○                                                                               
-    2100 |○·                                                                              
+    2700 |○                                                                               
          |○○                                                                              
          |○○                                                                              
          |○○                                                                              
-         |○○·                                                                             
-    1000 |○○○                                                                             
+         |○○                                                                              
+    1800 |○○                                                                              
+         |○○                                                                              
+         |○○                                                                              
          |○○○                                                                             
-         |○○○∘                                                                            
-         |○○○○·                                                                           
-         |○○○○○··                                                                         
-       0 |○○○○○○○∘∘·∘·························· ···  ···  ·       · ··     ·    ·        ·
+         |○○○                                                                             
+     900 |○○○                                                                             
+         |○○○·                                                                            
+         |○○○○                                                                            
+         |○○○○∘                                                                           
+         |○○○○○∘                                                                          
+       0 |○○○○○○○○∘·················  ·······  ·   ·  ··                                 ·
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        0.0      6.9      13.7     20.6     27.4     34.3     41.1     48.0     54.8  
+        0.0      6.1      12.2     18.3     24.4     30.4     36.5     42.6     48.7  
 ```
 
 Or we can create another `Normal` parameter and zip the two together to produce a 2D gaussian. Since there's nothing relating these two parameters to each other, you can see in the plot that they're completely independent.
 
 ```scala
 scala> val y = Normal(0,1).param
-y: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@3fdff9f5
+y: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@42d94a7e
 
 scala> val xy = x.zip(y)
-xy: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@635660e7
+xy: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@6735dd25
 
 scala> plot2D(xy.sample())
-     3.7 |                                                                                
-         |                    ·                                                           
-         |                                 · ·   ·  ··   ·                                
-         |                           ·· · ···· ···· ··  · ···  ·                          
-         |               ·   · · ······ ·························    ·                    
-     1.9 |                 ·  · ··································      ·  ·              
-         |               ·   ·· ································· ·· ·                    
-         |            ···   ················∘·∘··∘················· ····     ·            
-         |·     ·   ·     ··· ·········∘···∘·∘·∘∘··∘○∘∘∘·············· ·  ·· ·    ·    ·  
-         |      ·       ··· ·············∘∘∘∘∘○○∘∘○∘∘∘∘∘·∘∘∘················              
-     0.1 |      ·        ··············∘∘∘∘∘○○∘○○○∘○∘∘∘∘∘·∘··∘······· ··· ··              
-         |           · ··· ·········∘∘∘∘·∘∘∘∘∘○○○∘∘∘∘∘∘∘∘∘···············     ·  ·       ·
-         |     ·  ··     ·············∘··∘∘∘∘∘∘∘∘∘∘○∘○∘∘∘∘∘··············· ·   ·          
-         |  ·         · ··············∘∘∘∘∘∘∘∘∘∘∘∘∘○∘∘∘∘∘·················                
-         |         ·   ····· ············∘·∘·∘∘∘∘∘∘·∘∘·················    ·     ·   ··   
-    -1.7 |               · ·····················∘······················       · ·         
-         |               ···  ·································· ···· ·                   
-         |            ·    ···   ·  ···························· ···                      
-         |                  ·    · · ···· ······· ·······   ·                             
-         |                      ···  ·   ··· ·· ·· · · ·  ·  · ·                          
-    -3.5 |                       ·             ·    ·                                     
+     3.6 |                                                                                
+         |                               ··   ·     ·     · · ·                           
+         |                         ·      · ··  · ···   ·     ·                           
+         |                      ·    ·  ·  ···   ··  ··· ·  · ·      ·                    
+         |            · ·   ·  ···· ··  ·························                         
+     1.8 |        ··    · ····  ····································  ·  ·   ·            
+         |      ··    · · ·········································· ····· ···            
+         |       ·  ·· ·······················∘·∘······∘················· ·· ·            
+         |   ··     ··· ··················∘∘·∘·∘∘·∘··∘∘····················· · ··         
+         |      ·    ·················∘·∘∘∘∘∘○∘∘∘∘∘∘∘∘∘∘∘∘············ ······· · ·  ·     
+    -0.0 |·          ················∘∘·∘∘∘∘∘∘∘∘○○∘∘∘∘∘∘∘∘∘··∘············· ··   ·       ·
+         |       ·   ·················∘∘∘∘∘∘∘∘∘○∘∘∘○∘∘∘∘·∘∘·∘··········· ·····  ··        
+         |  ··      ·  · ··············∘∘·∘∘·∘·∘∘∘∘·∘∘·∘∘∘···∘··········· ······          
+         | ·  · ···  ·  ···················∘·∘∘∘∘∘∘∘∘∘∘∘·∘················ · · ·   ·      
+         |      ·  ·  ·· ························∘····∘··················· ·· ··          
+    -1.8 | ·       ·    ··  ········································· ···  ··   ··        
+         |         ·     · ·· ···· ······························ ··   · ·                
+         |             ·· ·· · ··· ·  ······················ ·····  ·      ·    ·         
+         |                          ··· ····  · ····· ·   ··· · ·  ·       ·              
+         |                ·       · ·· ·· ·  ·  ·  ··                                     
+    -3.7 |                           ·   ·   ·   ·  ·     ·                               
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        -4.3     -3.3     -2.3     -1.3     -0.3     0.7      1.7      2.7      3.7   
+       -3.71    -2.86    -2.00    -1.15    -0.29     0.56     1.41     2.27     3.12  
 ```
 
 Finally, we can use `flatMap` to create two parameters that *are* related to each other. In particular, we'll create a new parameter `z` that we believe to be very close to `x`: its prior is a `Normal` centered on `x` with a very small standard deviation. We'll then make a 2D plot of `(x,z)` to see the relationship.
 
 ```scala
 scala> val z = x.flatMap{a => Normal(a, 0.1).param}
-z: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@70795ade
+z: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@53429220
 
 scala> val xz = x.zip(z)
-xz: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@220f0f41
+xz: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@9e992a0
 
 scala> plot2D(xz.sample())
-     3.9 |                                                                                
-         |                                                                               ·
-         |                                                                       ·······  
-         |                                                                   · ·····      
-         |                                                                ········        
-     2.0 |                                                          ·········             
-         |                                                       ········ ·               
-         |                                                  ·····∘····                    
-         |                                              ···∘∘∘∘···                        
-         |                                          ···∘∘∘∘····                           
-     0.1 |                                      ···∘○○∘···                                
-         |                                 ····∘○○∘···                                    
-         |                               ··∘∘∘∘∘··                                        
-         |                          ····∘∘∘···                                            
-         |                       ····∘····                                                
-    -1.9 |                   ·········                                                    
-         |              ·········                                                         
-         |            ········                                                            
-         |         ······                                                                 
-         |    · ····                                                                      
-    -3.8 |··  ·                                                                           
+     3.8 |                                                                                
+         |                                                                            ·  ·
+         |                                                                        ·····  ·
+         |                                                                    ······      
+         |                                                               ·······          
+     1.9 |                                                          ·········             
+         |                                                      ··········                
+         |                                                  ····∘·····                    
+         |                                              ···∘∘∘···                         
+         |                                         ····∘∘○∘···                            
+     0.0 |                                     ···∘○○∘∘····                               
+         |                                 ···∘∘○○∘···                                    
+         |                              ···∘○∘∘···                                        
+         |                          ···∘∘∘∘···                                            
+         |                      ········· ·                                               
+    -1.9 |                  ··········                                                    
+         |               ········                                                         
+         |            ·······                                                             
+         |       ········                                                                 
+         |  · ·· ···                                                                      
+    -3.8 |·                                                                               
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-       -3.90    -3.04    -2.18    -1.31    -0.45     0.41     1.27     2.13     3.00  
+       -3.86    -3.01    -2.15    -1.30    -0.45     0.40     1.25     2.10     2.95  
 ```
 
 You can see that although we still sample from the full range of `x` values, for any given sample, `x` and `z` are quite close to each other.
@@ -216,7 +216,7 @@ val poisson9: RandomVariable[_] = Poisson(9).fit(sales)
 val poisson10: RandomVariable[_] = Poisson(10).fit(sales)
 ```
 
-Although it's almost never necessary, we can reach into any `RandomVariable` and get its current probability `density`:
+Although it's almost never necessary, we can reach into any `RandomVariable` and get its current probability `densityValue`:
 
 ```scala
 scala> poisson9.densityValue
@@ -237,14 +237,14 @@ We can see here that our data is about 3x as likely to have come from a `Poisson
 
 ```scala
 scala> val poisson: RandomVariable[_] = e_x.flatMap{r => Poisson(r).fit(sales)}
-poisson: com.stripe.rainier.core.RandomVariable[_] = com.stripe.rainier.core.RandomVariable@596b5ee2
+poisson: com.stripe.rainier.core.RandomVariable[_] = com.stripe.rainier.core.RandomVariable@4b32ffb3
 ```
 
-By the way: before, when we looked at `poisson9.densityValue`, the model had no parameters and so we got a constant value back. Now, since the model's density is a function of the parameter value, we get something more opaque back. This is why inspecting `density` is not normally useful.
+By the way: before, when we looked at `poisson9.densityValue`, the model had no parameters and so we got a constant value back. Now, since the model's density is a function of the parameter value, we get something more opaque back. This is why inspecting the density is not normally useful.
 
 ```scala
 scala> poisson.densityValue
-res7: com.stripe.rainier.compute.Real = com.stripe.rainier.compute.Line@6214f757
+res7: com.stripe.rainier.compute.Real = com.stripe.rainier.compute.Line@1858a7f2
 ```
 
 Instead, we can sample the quantity we're actually interested in. To start with, let's try to sample the rate parameter of the Poisson, conditioned by our observed data. Here's almost the same thing we had above, recreated with the slightly friendlier `for` syntax, and yielding the `r` parameter at the end:
@@ -255,7 +255,7 @@ scala> val rate = for {
      |     r <- e_x
      |     poisson <- Poisson(r).fit(sales)
      | } yield r
-rate: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@3a4dcc6e
+rate: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@4776e111
 ```
 
 This is our first "full" model: we have a parameter with a log-normal prior, bundled into the `RandomVariable` named `e_x`; we use that parameter to initialize a `Poisson` noise distribution which we fit to our observations; and at the end, we output the same parameter (referenced by `r`) as the quantity we're interested in sampling from the posterior.
@@ -264,29 +264,29 @@ Let's plot the results!
 
 ```scala
 scala> plot1D(rate.sample())
-     370 |                                                                                
-         |                                ∘                                               
-         |                                ○      ∘                                        
-         |                                ○    · ○                                        
-         |                           ·   ∘○∘·· ○ ○                                        
-     270 |                           ○· ·○○○○○·○ ○                                        
-         |                        ·∘·○○ ○○○○○○○○○○                                        
-         |                        ○○○○○○○○○○○○○○○○○ ∘ ·                                   
-         |                       ○○○○○○○○○○○○○○○○○○ ○∘○  ·                                
-         |                       ○○○○○○○○○○○○○○○○○○ ○○○ ∘○                                
-     180 |                    ∘  ○○○○○○○○○○○○○○○○○○○○○○∘○○·                               
-         |                    ○○∘○○○○○○○○○○○○○○○○○○○○○○○○○○ ·                             
-         |                   ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·○                             
-         |               ·· ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                             
-         |               ○○ ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                             
-      90 |               ○○∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘ ··                         
-         |              ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘                        
-         |            ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                      
-         |          ○·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘∘∘○                  
-         |        ∘·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○∘ ··            
-       0 |· ·○·○∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○○○···○·······
+     380 |                                                                                
+         |                        ∘ · ∘ ·                                                 
+         |                       ·○ ○ ○○○  ○                                              
+         |                      ·○○ ○○○○○○∘○·                                             
+         |                      ○○○○○○○○○○○○○ ∘                                           
+     280 |                      ○○○○○○○○○○○○○∘○∘                                          
+         |                     ○○○○○○○○○○○○○○○○○                                          
+         |                    ∘○○○○○○○○○○○○○○○○○·                                         
+         |                  ○ ○○○○○○○○○○○○○○○○○○○·○                                       
+         |                  ○∘○○○○○○○○○○○○○○○○○○○○○∘∘                                     
+     190 |                  ○○○○○○○○○○○○○○○○○○○○○○○○○                                     
+         |                 ○○○○○○○○○○○○○○○○○○○○○○○○○○                                     
+         |                ·○○○○○○○○○○○○○○○○○○○○○○○○○○∘·                                   
+         |             · ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                                   
+         |             ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                                   
+      90 |             ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○ ·                                
+         |            ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                               
+         |          ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘∘ ·                           
+         |        ∘·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○ ∘·                        
+         |      ·∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘                       
+       0 |··○∘∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘·○∘∘∘····· ··· ·    ·
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        4.90     5.62     6.34     7.05     7.77     8.49     9.20     9.92    10.64  
+        4.70     5.59     6.48     7.36     8.25     9.14    10.02    10.91    11.80  
 ```
 
 Looks like our daily rate is probably somewhere between 6 and 9, which corresponds well to the steep 3x dropoff we saw before between 9 and 10.
@@ -337,42 +337,42 @@ scala> val prediction = for {
      |     r <- e_x
      |     poisson <- Poisson(r).fit(sales)
      | } yield poisson.generator
-prediction: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@21c38ca1
+prediction: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@651140f7
 ```
 
 This is almost the same model as `rate` above, but instead of taking the real-valued `r` rate parameter as the output, we're producing poisson-distributed integers. The samples look like this:
 
 ```scala
 scala> prediction.sample()
-res10: List[Int] = List(8, 7, 5, 4, 5, 7, 3, 10, 13, 11, 4, 7, 12, 6, 10, 10, 7, 5, 5, 9, 3, 5, 5, 8, 10, 14, 3, 9, 8, 15, 6, 4, 9, 5, 11, 9, 5, 6, 5, 8, 4, 11, 11, 8, 7, 11, 6, 6, 9, 7, 7, 6, 6, 14, 11, 14, 8, 5, 9, 5, 5, 8, 9, 4, 7, 0, 11, 9, 10, 7, 5, 9, 9, 7, 6, 13, 5, 5, 8, 9, 5, 12, 3, 9, 5, 12, 10, 3, 7, 8, 9, 11, 7, 15, 7, 15, 4, 7, 5, 8, 9, 11, 9, 9, 9, 5, 7, 13, 6, 6, 9, 4, 12, 12, 8, 7, 6, 12, 7, 13, 14, 2, 4, 5, 7, 5, 3, 10, 10, 10, 10, 7, 10, 7, 12, 10, 7, 5, 7, 8, 7, 6, 8, 8, 9, 9, 4, 10, 9, 5, 6, 14, 5, 7, 9, 3, 6, 1, 9, 8, 5, 7, 9, 10, 8, 14, 11, 8, 9, 7, 12, 8, 8, 9, 12, 5, 13, 7, 4, 8, 11, 12, 6, 6, 11, 3, 5, 5, 5, 7, 7, 7, 5, 10, 8, 8, 5, 12, 9, 2, 16, 7, 1, 11, 5, 7, 8, 7, 15, 8, 5, 6, 8, 4, 7, 10, 4, 5, 8, 4, 7, 11, 9, 3, 11, 8, 6, 7, 5, 5,...
+res10: List[Int] = List(3, 5, 10, 2, 6, 8, 8, 5, 12, 5, 5, 10, 6, 9, 9, 5, 3, 17, 11, 11, 5, 12, 8, 9, 10, 9, 6, 6, 7, 6, 11, 5, 5, 7, 7, 5, 5, 11, 5, 5, 10, 6, 7, 6, 2, 7, 7, 11, 7, 8, 4, 8, 6, 4, 7, 7, 6, 10, 12, 2, 7, 7, 7, 10, 9, 4, 7, 1, 14, 12, 2, 7, 6, 7, 12, 5, 6, 9, 3, 15, 9, 7, 8, 3, 6, 11, 8, 6, 9, 12, 3, 9, 5, 8, 8, 6, 10, 6, 8, 4, 12, 6, 15, 8, 10, 6, 8, 7, 13, 5, 8, 9, 13, 11, 3, 7, 5, 4, 11, 14, 9, 9, 4, 4, 6, 10, 10, 7, 7, 8, 12, 11, 7, 7, 11, 6, 6, 12, 7, 6, 3, 10, 3, 11, 2, 5, 6, 7, 9, 4, 6, 9, 7, 10, 10, 3, 10, 2, 5, 13, 10, 10, 4, 8, 5, 8, 10, 16, 5, 4, 10, 8, 7, 8, 6, 4, 12, 10, 11, 4, 7, 8, 5, 7, 4, 8, 7, 6, 5, 8, 5, 4, 8, 9, 12, 10, 9, 8, 11, 15, 1, 7, 7, 5, 6, 7, 4, 4, 4, 5, 3, 12, 9, 12, 9, 12, 11, 9, 5, 8, 11, 5, 9, 5, 8, 12, 8, 7, 9, ...
 ```
 Or, if we plot them, like this:
 
 ```scala
 scala> plot1D(prediction.sample())
-    1360 |                                                                                
-         |                       ○                                                        
-         |                   ∘   ○  ○                                                     
-         |                   ○   ○  ○                                                     
-         |                   ○   ○  ○                                                     
-    1020 |                ∘  ○   ○  ○  ○                                                  
-         |                ○  ○   ○  ○  ○                                                  
-         |                ○  ○   ○  ○  ○                                                  
-         |                ○  ○   ○  ○  ○   ○                                              
-         |                ○  ○   ○  ○  ○   ○                                              
-     680 |             ·  ○  ○   ○  ○  ○   ○                                              
-         |             ○  ○  ○   ○  ○  ○   ○  ·                                           
-         |             ○  ○  ○   ○  ○  ○   ○  ○                                           
-         |             ○  ○  ○   ○  ○  ○   ○  ○                                           
-         |         ·   ○  ○  ○   ○  ○  ○   ○  ○  ·                                        
-     340 |         ○   ○  ○  ○   ○  ○  ○   ○  ○  ○                                        
-         |         ○   ○  ○  ○   ○  ○  ○   ○  ○  ○   ·                                    
-         |         ○   ○  ○  ○   ○  ○  ○   ○  ○  ○   ○                                    
-         |      ∘  ○   ○  ○  ○   ○  ○  ○   ○  ○  ○   ○  ∘                                 
-         |      ○  ○   ○  ○  ○   ○  ○  ○   ○  ○  ○   ○  ○  ∘                              
-       0 |·  ∘  ○  ○   ○  ○  ○   ○  ○  ○   ○  ○  ○   ○  ○  ○   ○  ·  ·   ·  ·  ·         ·
+    1410 |                                                                                
+         |                          ○   ·                                                 
+         |                          ○   ○                                                 
+         |                      ∘   ○   ○                                                 
+         |                      ○   ○   ○                                                 
+    1060 |                      ○   ○   ○   ∘                                             
+         |                  ∘   ○   ○   ○   ○                                             
+         |                  ○   ○   ○   ○   ○                                             
+         |                  ○   ○   ○   ○   ○                                             
+         |                  ○   ○   ○   ○   ○  ∘                                          
+     700 |                  ○   ○   ○   ○   ○  ○                                          
+         |               ∘  ○   ○   ○   ○   ○  ○   ∘                                      
+         |               ○  ○   ○   ○   ○   ○  ○   ○                                      
+         |               ○  ○   ○   ○   ○   ○  ○   ○                                      
+         |               ○  ○   ○   ○   ○   ○  ○   ○   ·                                  
+     350 |           ∘   ○  ○   ○   ○   ○   ○  ○   ○   ○                                  
+         |           ○   ○  ○   ○   ○   ○   ○  ○   ○   ○                                  
+         |           ○   ○  ○   ○   ○   ○   ○  ○   ○   ○   ○                              
+         |       ∘   ○   ○  ○   ○   ○   ○   ○  ○   ○   ○   ○   ·                          
+         |       ○   ○   ○  ○   ○   ○   ○   ○  ○   ○   ○   ○   ○  ·                       
+       0 |·  ∘   ○   ○   ○  ○   ○   ○   ○   ○  ○   ○   ○   ○   ○  ○   ∘   ·   ·   ·  ·   ·
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        0.0      2.7      5.4      8.1      10.8     13.6     16.3     19.0     21.7  
+        0.0      2.4      4.7      7.1      9.5      11.9     14.2     16.6     19.0  
 ```
 
 ## `Likelihood` and `Predictor`
@@ -420,7 +420,7 @@ scala> val prior = for {
      |     slope <- LogNormal(0,1).param
      |     intercept <- LogNormal(0,1).param
      |     } yield (slope, intercept)
-prior: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@3a9415d7
+prior: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@3d38578f
 ```
 
 Now, for any given day `i`, we want to check the number of sales against `Poisson(intercept + slope*i)`. We could write some kind of recursive flatMap to build and fit each of these different distribution objects in turn, but this is a common enough pattern that Rainier already has something built in for it: `Predictor`. `Predictor` is not a `Distribution`, but instead wraps a function from `X => Distribution[Y]` for some `(X,Y)`; you can use this any time you have a dependent variable of type `Y` that you're modeling with some independent variables jointly represented as `X`.
@@ -434,7 +434,7 @@ scala> val regr = for {
      |                     Poisson(intercept + slope*i)
      |                 }.fit(data)
      | } yield (slope, intercept)
-regr: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@735d021f
+regr: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@28c8cc57
 ```
 
 As before, we're starting out by just sampling the parameters. By plotting them, we can see that the model's confidence in the intercept, in particular, is pretty low: although it's most likely to be somewhere around 8, it could be anywhere from 3 to 13 or even higher. Second, as you'd hope, the two parameters are anti-correlated:
@@ -442,29 +442,29 @@ a smaller intercept would imply a higher slope, and vice versa.
 
 ```scala
 scala> plot2D(regr.sample())
-    14.9 |                                                                                
-         | ·      ·    ·     ·                                                            
-         |     ·      ·  · ·  ·  ·                                                        
-         |        ··· ·  ·····  ··   ··  ·                                                
-         |·     · · ·  ··· ········· ·· ·                                                 
-    11.9 |       ······················· ···  ·      ·                                    
-         |     ·  ···· ······················· ·······                                    
-         |         ·· ································  ··                                
-         |            ··············∘∘∘∘∘·············· ····                              
-         |              · ··········∘∘∘∘∘∘∘∘∘∘∘·∘···········    ·                         
-     8.8 |                ···········∘∘∘∘∘∘○∘○○∘∘∘∘············ ·· ·                      
-         |              ·     ·······∘∘∘∘∘∘∘○○○○∘○∘∘∘∘∘·∘·········· ··                    
-         |                  ·  ···········∘∘∘∘○○○○○○○∘∘∘∘∘∘·········  ·                   
-         |                       ··········∘∘∘∘∘○∘○∘∘∘∘∘∘∘∘∘········· ··                  
-         |                           · ·········∘∘∘∘∘∘∘∘∘∘∘∘∘∘········· · · ·             
-     5.7 |                            ···············∘∘∘∘·∘·················              
-         |                                ·· ·················∘············ ··            
-         |                                ·    · ··························   ·  ·        
-         |                                             ····· · ············· ·   ·        
-         |                                                ·· ·   ··    ·   ·             ·
-     2.7 |                                                          ·     ··              
+    14.6 |                                                                                
+         |        ·    ·     ·                                                            
+         | ·     ·  ·       ·    ··   ·                                                   
+         | ···   ·   ·· ····· ···  ·· · ·                                                 
+         |·       ·· · ·················  ··   ·                                          
+    11.7 |   ·· ···· ······················ · ··                                          
+         |    ·  ·· ································ ·  ·                                 
+         |      · ··································· ··   ·  ·                           
+         |      · ·· ············∘∘∘∘···∘∘·∘·················  ·                          
+         |        ·  ·············∘∘∘∘∘∘∘∘○∘∘∘∘∘··∘∘······· · ···  ·                      
+     8.8 |         ·  · ···········∘∘∘∘∘○∘∘∘○∘∘∘∘∘∘∘∘∘··············    ·                 
+         |             · · · ·········∘∘○∘∘∘○○○∘○○∘○∘∘∘∘············ ··  ·   ·            
+         |                     ··········∘∘∘○∘○○○○○∘○○∘∘∘∘∘··∘··········  ··              
+         |                    ·············∘∘∘∘∘○○∘○○○○○∘○∘○∘············  · ···          
+         |                      ·· · · ·······∘∘∘∘∘∘∘∘∘∘∘∘∘∘∘∘·∘············       ·      
+     6.0 |                            ·············∘∘∘∘∘∘·∘∘∘∘··∘∘················        
+         |                                ················∘··∘·∘············· · ··  ·     
+         |                           ·          ·· ······························· ·      
+         |                                   · ·  ·· ·····························   · · ·
+         |                                          ·  ·       ··   ···· ····· ·       ·  
+     3.1 |                                                       ·    ··      ·      ·    
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        2.37     2.56     2.74     2.93     3.12     3.30     3.49     3.68     3.86  
+        2.47     2.63     2.79     2.95     3.11     3.27     3.42     3.58     3.74  
 ```
 
 Alternatively, as in the earlier example, we could try to predict what will happen tomorrow. This is similar to calling `poisson.generator` before, but this time, we use the `predict` method on `Predictor`, which takes the covariate (the day, in this case), and returns a `Generator` for the dependent variable (the number of sales). Putting it all together, it looks like this:
@@ -477,36 +477,36 @@ scala> val regr2 = for {
      |                     Poisson(intercept + slope*i)
      |                 }.fit(data)
      | } yield predictor.predict(21)
-regr2: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@754b7f65
+regr2: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@189747f0
 ```
 
 Plotting this gives us a prediction which incorporates both the natural noise of a Poisson distribution and our uncertainty about its underlying parameterization.
 
 ```scala
 scala> plot1D(regr2.sample())
-     470 |                                                                                
-         |                                ∘∘                                              
-         |                                ○○·∘                                            
-         |                               ·○○○○∘ ∘                                         
-         |                               ○○○○○○ ○○                                        
-     350 |                            ·  ○○○○○○○○○  ·                                     
-         |                            ○○∘○○○○○○○○○ ○○                                     
-         |                          · ○○○○○○○○○○○○ ○○                                     
-         |                         ∘○ ○○○○○○○○○○○○ ○○○                                    
-         |                         ○○ ○○○○○○○○○○○○ ○○○ ·                                  
-     230 |                         ○○ ○○○○○○○○○○○○ ○○○○○                                  
-         |                       ··○○ ○○○○○○○○○○○○ ○○○○○∘                                 
-         |                       ○○○○ ○○○○○○○○○○○○ ○○○○○○·                                
-         |                     ·○○○○○ ○○○○○○○○○○○○ ○○○○○○○                                
-         |                     ○○○○○○ ○○○○○○○○○○○○ ○○○○○○○○∘                              
-     110 |                   ·○○○○○○○ ○○○○○○○○○○○○ ○○○○○○○○○·                             
-         |                  ○○○○○○○○○ ○○○○○○○○○○○○ ○○○○○○○○○○∘                            
-         |                ·∘○○○○○○○○○ ○○○○○○○○○○○○ ○○○○○○○○○○○○·                          
-         |              ··○○○○○○○○○○○ ○○○○○○○○○○○○ ○○○○○○○○○○○○○ ∘·                       
-         |           ·∘ ○○○○○○○○○○○○○ ○○○○○○○○○○○○ ○○○○○○○○○○○○○ ○○○∘·                    
-       0 |·· ·······∘○○ ○○○○○○○○○○○○○ ○○○○○○○○○○○○ ○○○○○○○○○○○○○ ○○○○○○∘·∘··· ·· ·       ·
+     430 |                                                                                
+         |                              · ∘ ·∘ ·                                          
+         |                              ○·○○○○ ○∘·∘                                       
+         |                            ∘ ○○○○○○ ○○○○                                       
+         |                            ○ ○○○○○○ ○○○○∘                                      
+     320 |                           ∘○ ○○○○○○ ○○○○○                                      
+         |                          ·○○ ○○○○○○ ○○○○○○                                     
+         |                          ○○○ ○○○○○○ ○○○○○○∘                                    
+         |                         ○○○○ ○○○○○○ ○○○○○○○  ∘                                 
+         |                        ∘○○○○ ○○○○○○ ○○○○○○○ ○○                                 
+     210 |                       ·○○○○○ ○○○○○○ ○○○○○○○ ○○○                                
+         |                     · ○○○○○○ ○○○○○○ ○○○○○○○ ○○○                                
+         |                     ○ ○○○○○○ ○○○○○○ ○○○○○○○ ○○○○                               
+         |                   ∘·○ ○○○○○○ ○○○○○○ ○○○○○○○ ○○○○·                              
+         |                  ∘○○○ ○○○○○○ ○○○○○○ ○○○○○○○ ○○○○○○ ·                           
+     100 |                  ○○○○ ○○○○○○ ○○○○○○ ○○○○○○○ ○○○○○○ ○·                          
+         |                 ·○○○○ ○○○○○○ ○○○○○○ ○○○○○○○ ○○○○○○ ○○∘                         
+         |                ·○○○○○ ○○○○○○ ○○○○○○ ○○○○○○○ ○○○○○○ ○○○·                        
+         |             ○ ·○○○○○○ ○○○○○○ ○○○○○○ ○○○○○○○ ○○○○○○ ○○○○○∘                      
+         |          ·∘∘○ ○○○○○○○ ○○○○○○ ○○○○○○ ○○○○○○○ ○○○○○○ ○○○○○○ ○○∘                  
+       0 |·· ···∘ ∘○○○○○ ○○○○○○○ ○○○○○○ ○○○○○○ ○○○○○○○ ○○○○○○ ○○○○○○ ○○○○○∘· ·∘····   ·  ·
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        42.0     50.3     58.7     67.0     75.3     83.7     92.0    100.4    108.7  
+        44.0     51.8     59.5     67.3     75.1     82.9     90.6     98.4    106.2  
 ```
 
 Finally, let's close with a small and somewhat contrived example of a hierarchical model, where we have two separate regressions that share a parameter. For the sake of the example, let's assume that we have a second sales dataset, much like the first, where we know they had the same rate at the start of the observations, but may have grown at different rates - so their intercepts will be equal but their slopes will not. Here's the data:
@@ -526,7 +526,7 @@ scala> val regr3 =  for {
      |     _ <- Predictor.fromInt{ i => Poisson(intercept + slope0 * i) }.fit(data)
      |     _ <- Predictor.fromInt{ i => Poisson(intercept + slope1 * i) }.fit(data2)
      | } yield (slope0, intercept)
-regr3: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@44bc3e7d
+regr3: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@2a1bf115
 ```
 
 or we can use Rainier's `Lookup` to package the two slopes into a single `RandomVariable` from which we can lookup the one we want. This means that our predictor now has to take both the index of the model to which the data belongs as well as the actual observation as input.
@@ -540,36 +540,36 @@ scala> val regr4 = for {
      |   intercept <- LogNormal(0,1).param
      |   _ <- Predictor.fromIntPair{ case (index, x) => Poisson(intercept + slopes(index) * x) }.fit(allData)
      | } yield (slopes(0), intercept)
-regr4: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@157080fc
+regr4: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@2cfaf2dc
 ```
 
 Plotting slope vs. intercept now, we see that, even though these are two separate regressions, we get tighter bounds than before by letting the new data influence the shared parameter. It makes sense that we'd get more confidence on the intercept, since we have two different time series to learn from now; but because of the anti-correlation, that also leads to somewhat more confidence than before on the `slopes(0)` parameter as well.
 
 ```scala
 scala> plot2D(regr4.sample())
-    11.1 |                                                                                
-         |           ·                                                                    
-         |·   ·      ·                                                                    
-         |      ··    ·      · ·         ·                                                
-         | ·  ·   · · ··  ···   ·   · ··  ·               ·                               
-     9.1 |···  · ··   ·· ······· · ······· ·  ···   ·                                     
-         |   ·  ······· ······················ ······      ·                              
-         |  ·   ··· ······································ ·  ·· ··               ·       
-         |·     ············································ ···                          
-         |     · ···············∘···∘·∘∘·∘∘∘·∘···················· ··· ·   · ·           ·
-     7.0 |      ·  · ················∘∘∘∘∘∘∘○∘∘∘·∘····················· · ·               
-         |   · ··    ·  ··········∘···∘∘∘∘∘∘∘∘∘∘∘○∘∘∘∘∘∘∘················· · ·· ·         
-         |       · ··   ····· ··········∘∘∘∘∘∘∘∘∘∘○∘∘∘∘∘∘∘·∘·············· · ·     · ·    
-         |     ·     · ·   ··············∘·∘∘∘∘○∘∘∘○∘∘∘∘∘∘∘∘∘···∘·············· · ·       
-         |    ·         ·  ···· ···············∘∘∘∘∘∘·∘∘∘∘∘∘················· ·    · ·    
-     5.0 |                ·         ····················∘∘··∘∘··∘··········· ·····   ···  
-         |            ·        ·· · · ·· ········································ ··     ·
-         |                               ·  · ······························ ···   ·      
-         |                                   ·   · ····· ········ ··  ···   ·   · ·  ·    
-         |                                    ·      · ·    · ··     ·   ·    ·  ·  ·     
-     3.0 |                                                                              · 
+    11.5 |                                                                                
+         |            ··                                                                  
+         |           ·    ···                                                             
+         |       ···     · ·                                                              
+         |        ·  · ·      ·· ·    ····                                                
+     9.3 | ·       ·· ···· ···········  ····   ·                                          
+         |   ·       ·· ························ ·· ·     · ·                             
+         |·        · ···· ··························· ··· ···                             
+         |        ·  ··· ······································     ··                    
+         |           ·················∘··∘∘∘∘∘··∘················  · ·     ·              
+     7.2 |    ·   ·  ··············∘··∘∘∘∘∘∘∘∘∘∘∘∘∘∘∘∘·∘·············· · · ·              
+         |         ·    ·· ··········∘∘∘·∘∘∘∘∘○∘○○○∘∘○∘∘∘·∘············· ·· ·             
+         |             ··· ··········∘∘∘∘∘∘∘∘○○∘∘○○○∘∘∘○○∘∘∘················· ····        
+         |            ··  · · ··········∘·∘·∘∘∘∘○○○○○○○∘○○∘∘∘∘∘········· ···  ···· ·      
+         |                   · ···············∘·∘∘∘∘∘∘∘∘∘∘∘∘∘·∘∘∘∘··············  ··  ·   
+     5.1 |                      ·  ···················∘∘·∘∘∘∘··∘·················· ···    
+         |                      ·    ·· · ····································· ···    ·  
+         |                             ·  ·· ··  ································· ·    · 
+         |                                  ·  ··  · ···· ·········· ······ ··  ·        ·
+         |                                          ·    · ·· ·  ·· ·    ······  ·        
+     2.9 |                                               ·    · · · ·      ·     ·        
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        2.77     2.89     3.02     3.15     3.27     3.40     3.52     3.65     3.78  
+        2.68     2.82     2.96     3.10     3.23     3.37     3.51     3.65     3.79  
 ```
 
 ## Learning More

--- a/docs/tour.md
+++ b/docs/tour.md
@@ -30,7 +30,7 @@ Rainier implements various familiar families of probability distributions like t
 
 ```scala
 scala> val normal: Distribution[Double] = Normal(0,1)
-normal: com.stripe.rainier.core.Distribution[Double] = com.stripe.rainier.core.Injection$$anon$1@15c24fcc
+normal: com.stripe.rainier.core.Distribution[Double] = com.stripe.rainier.core.Injection$$anon$1@7253eb2a
 ```
 
 In Rainier, `Distribution` objects play three different roles. `Continuous` distributions (like `Normal`), implement `param`, and all distributions implement `fit` and `generator`. Each of these methods is central to one of the three stages of building a model in Rainier:
@@ -51,43 +51,43 @@ Let's use that same `Normal(0,1)` distribution as a prior for a new parameter:
 
 ```scala
 scala> val x = Normal(0,1).param
-x: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@45c3008c
+x: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@b2d0943
 ```
 
 You can see that the type of `x` is `RandomVariable[Real]`. `RandomVariable` pairs a type of value (in this case, a real number) with some knowledge of the relative probability density of different values of that type. We can use this knowledge to produce a sample of these possible values:
 
 ```scala
 scala> x.sample()
-res0: List[Double] = List(-0.43253382588457706, 0.5892894557211501, -0.6353399103897628, 0.19067075381236842, -0.11085036420275429, 0.57554282880804, 0.01580203026043847, -0.08841379304657587, 0.3124592628751317, -0.19748500965841992, 0.30867770403649986, -0.21389190432752686, 0.21972603234688232, -0.18536010734252378, -0.045673644406192704, 0.13053100004776463, 0.4707496269575522, -0.43457694069077074, 0.573396300597938, -0.17910577499140512, 0.23906018960012337, -0.14410091158531368, 0.2063157204869559, 0.06383960976094682, -0.07367376487830038, -0.07784745978261931, -0.47115275850904625, 0.7982382171085747, -0.8564248863983386, 1.0185111828659643, -0.8137454492145673, 0.9440661348350199, -0.9950291783846661, 1.003234639666012, -1.1461440920757524, 1.43053598...
+res0: List[Double] = List(0.7213668558017945, -0.5078214024317078, 0.531292046325315, -0.55848000289016, 0.36167369679489214, -0.37660283559841884, 0.3253573362820674, -0.42560296041627765, 0.3937737948617706, -0.39657132710220916, 0.36536141883005274, -0.32163770600589503, 0.3035313028564322, -0.2307281758826154, 0.2267489961769043, -0.20443125521560027, 0.07257087455666555, -0.10153264544830753, 0.2178616829045299, -0.26100875365982645, 0.2093664119227987, -0.24473854529374572, 0.17728167529249172, -0.12281826813696173, 0.04172764114483507, -0.09259797421135885, 0.0493152917439903, -0.10400265230062078, 0.10356298784663787, -0.2422249120796085, 0.18774324808422027, -0.14381221976943637, 0.09185446778991313, -0.13646427675880268, 0.050318370570520354, 0.089812...
 ```
 
 Each element of the list above represents a single sample from the distribution over `x`. It's easier to understand these if we plot them as a histogram:
 
 ```scala
 scala> plot1D(x.sample())
-     330 |                                                                                
-         |                                              ∘                                 
-         |                                ∘∘∘  ○      ·∘○  ·                              
-         |                             ·○ ○○○ ∘○   ·  ○○○○ ○                              
-         |                             ○○○○○○·○○ ○∘○○∘○○○○∘○                              
-     250 |                            ∘○○○○○○○○○ ○○○○○○○○○○○                              
-         |                           ∘○○○○○○○○○○∘○○○○○○○○○○○·                             
-         |                           ○○○○○○○○○○○○○○○○○○○○○○○○                             
-         |                           ○○○○○○○○○○○○○○○○○○○○○○○○                             
-         |                         ·∘○○○○○○○○○○○○○○○○○○○○○○○○∘∘                           
-     160 |                         ○○○○○○○○○○○○○○○○○○○○○○○○○○○○                           
-         |                         ○○○○○○○○○○○○○○○○○○○○○○○○○○○○                           
-         |                         ○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○                         
-         |                       ∘·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·                        
-         |                   ·∘∘∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘··                     
-      80 |                   ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                     
-         |                  ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘                   
-         |               ∘ ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·∘                 
-         |             ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·∘∘·             
-         |          ∘○·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘            
-       0 |··∘····∘○∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘∘·∘·······
+     360 |                                                                                
+         |                                        ∘                                       
+         |                                    ·   ○ ∘                                     
+         |                                 ∘  ○   ○ ○ ○                                   
+         |                                 ○ ·○○○∘○·○·○∘ ·                                
+     270 |                               ∘ ○∘○○○○○○○○○○○○○∘                               
+         |                               ○ ○○○○○○○○○○○○○○○○ ·                             
+         |                              ∘○○○○○○○○○○○○○○○○○○○○                             
+         |                              ○○○○○○○○○○○○○○○○○○○○○  ·                          
+         |                            ○ ○○○○○○○○○○○○○○○○○○○○○∘ ○                          
+     180 |                          ··○○○○○○○○○○○○○○○○○○○○○○○○·○·                         
+         |                         ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                         
+         |                       ∘·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘                        
+         |                       ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                      
+         |                      ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                      
+      90 |                      ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘                     
+         |                    ·∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘·                   
+         |                  ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘∘                 
+         |               ·∘·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘  ∘             
+         |           · ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○○  ·          
+       0 |··  ····∘·∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘·∘∘···  ·
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-       -3.22    -2.48    -1.74    -1.00    -0.26     0.48     1.22     1.96     2.70  
+       -3.35    -2.60    -1.86    -1.11    -0.37     0.38     1.13     1.87     2.62  
 ```
 
 Since the only information we have about `x` so far is its `Normal` prior, this distribution unsurprisingly looks normal. Later we'll see how to update our beliefs about `x` based on observational data.
@@ -96,102 +96,102 @@ For now, though, let's explore what we can do just with priors. `RandomVariable`
 
 ```scala
 scala> val e_x = x.map(_.exp)
-e_x: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@18d006b
+e_x: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@1676ef88
 
 scala> plot1D(e_x.sample())
-    2100 |                                                                                
-         |·                                                                               
-         |○                                                                               
-         |○                                                                               
-         |○                                                                               
-    1500 |○ ○                                                                             
+    2200 |                                                                                
+         | ·                                                                              
+         | ○                                                                              
+         | ○·                                                                             
+         | ○○                                                                             
+    1600 |∘○○                                                                             
          |○○○                                                                             
          |○○○                                                                             
          |○○○                                                                             
          |○○○                                                                             
-    1000 |○○○○                                                                            
+    1100 |○○○·                                                                            
          |○○○○                                                                            
          |○○○○                                                                            
          |○○○○                                                                            
          |○○○○                                                                            
-     500 |○○○○∘                                                                           
-         |○○○○○                                                                           
-         |○○○○○○··                                                                        
-         |○○○○○○○○·∘                                                                      
-         |○○○○○○○○○○○∘·                                                                   
-       0 |○○○○○○○○○○○○○○○∘∘∘∘∘∘······························ ····· ········· ····· ·  · ·
+     500 |○○○○○                                                                           
+         |○○○○○∘                                                                          
+         |○○○○○○·                                                                         
+         |○○○○○○○·                                                                        
+         |○○○○○○○○∘·                                                                      
+       0 |○○○○○○○○○○○∘∘∘∘∘∘∘∘··∘··························  ·· ·   ··  ·  ·  ·   ·  ·  · ·
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        0.0      3.1      6.2      9.2      12.3     15.4     18.4     21.5     24.6  
+        0.0      3.5      6.9      10.4     13.9     17.3     20.8     24.2     27.7  
 ```
 
 Or we can create another `Normal` parameter and zip the two together to produce a 2D gaussian. Since there's nothing relating these two parameters to each other, you can see in the plot that they're completely independent.
 
 ```scala
 scala> val y = Normal(0,1).param
-y: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@4065d09e
+y: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@2df1e38b
 
 scala> val xy = x.zip(y)
-xy: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@1cb86a9b
+xy: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@49e9c0ef
 
 scala> plot2D(xy.sample())
-     4.4 |                                                                                
-         |                                            ·                                   
-         |                               ·        ··   ·                                  
-         |                             ·   ·   · ·    ·                                   
-         |                        · ·      ··   ·· ·   · ·    ·   ·    ·                  
-     2.3 |           ·    · ··  ·  ···· ··········· ·  ······ ·  · · ·         ·          
-         |        ·        ···· ······················· · ········· ······     ·          
-         |         ·  · ··  ········································· ·· ···  ·           
-         |      ·  ·· ·······················∘·······························             
-         |  ··  · ·· ···················∘··∘···∘·∘∘∘∘∘∘∘∘∘············· ·· · · ·· ·       
-     0.2 |    ·  ······· ·······∘····∘∘·∘··∘∘∘∘∘∘○∘∘∘·∘∘·∘···∘············ ·······        
-         |     ·· ·················∘∘∘∘∘∘∘∘∘∘○∘∘○∘○∘∘·∘∘∘·∘···················    ·       
-         |· ··    ·····················∘∘·∘∘∘∘∘∘∘∘·∘∘∘∘∘∘∘·····················     ·     
-         |     ·· ·  ··· ·············∘·∘∘∘··∘·∘∘∘∘∘∘∘·∘······················       ·   ·
-         |·     · · ·· ······················∘···∘∘·∘·············· ········ ··           
-    -1.9 |        ·  · ··············································  ·· ·               
-         |            · ···· ·· ·· ························· ·· ······ ·                  
-         |                · ····  · · ···· ··········· · · ···· ···  ··         ·         
-         |                            ·  ··   ··· ·  ·  ·    ·  ·                         
-         |                               ··                                               
-    -4.0 |                                         ·                                      
+     4.2 |                                                                                
+         |                              ·  ··                                             
+         |                                                      ·                         
+         |                            ·   · ··  ··      ·               ·                 
+         |                   ·       · · · ·  ····  ·  ·  ···     ·    ·                  
+     2.3 |                      ·  ············  ··············· ···   ·   ·              
+         |                  · ··· ····························· ·· ··· ·  ·               
+         |     ·          ·  ······ ··································· ··· · ··  ··      
+         |          · ·· ·  ····················∘∘··················· · ·         ·       
+         |         ·   · ···················∘∘∘·∘∘∘∘·∘∘∘∘··∘··············· ··            
+     0.3 |           · ·  · ··········∘·∘∘·∘∘∘∘○∘∘·∘∘∘∘∘∘∘∘··················             
+         |    ·     ·    · ···········∘∘∘∘∘∘∘∘∘∘○○∘○∘○∘∘∘∘∘∘∘············ ···            ·
+         |·           · ·················∘∘∘∘∘○○∘○○○○∘∘○∘·∘∘·∘······· ·· ·     ·          
+         |     ·       · ·  ·············∘∘∘∘∘∘∘∘∘∘∘∘∘∘∘∘∘∘∘∘············· ···    ·       
+         |          ·     ···············∘·∘·∘∘·∘∘∘∘∘∘∘··∘··············    ·             
+    -1.6 |           ··   ···· ······················∘················  ··   ·       ·    
+         |                  ·· · ········································  ·              
+         |               ·    ·· ································  ··                     
+         |               ·     ·  ···   ······ ··········· ··  ·· · ·                     
+         |           ·            ·   · ··   ····  ·  ·      ·               ·            
+    -3.5 |      ·                                ·      · ··         ·                    
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-       -3.51    -2.69    -1.87    -1.04    -0.22     0.60     1.43     2.25     3.07  
+        -4.4     -3.4     -2.4     -1.4     -0.5     0.5      1.5      2.5      3.5   
 ```
 
 Finally, we can use `flatMap` to create two parameters that *are* related to each other. In particular, we'll create a new parameter `z` that we believe to be very close to `x`: its prior is a `Normal` centered on `x` with a very small standard deviation. We'll then make a 2D plot of `(x,z)` to see the relationship.
 
 ```scala
 scala> val z = x.flatMap{a => Normal(a, 0.1).param}
-z: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@728b98bf
+z: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@568e7186
 
 scala> val xz = x.zip(z)
-xz: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@269fe62a
+xz: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@4f56bb48
 
 scala> plot2D(xz.sample())
-     3.8 |                                                                                
-         |                                                                              ··
-         |                                                                         ·····  
-         |                                                                     ·······    
-         |                                                                 ········       
-     1.7 |                                                            ·········           
-         |                                                       ·········                
-         |                                                   ···∘∘∘····                   
-         |                                              ····∘∘∘∘··                        
-         |                                           ··∘○○∘∘··                            
-    -0.3 |                                       ··∘○○∘∘···                               
-         |                                   ··∘∘○∘∘··                                    
-         |                               ···∘∘∘····                                       
-         |                           ·········                                            
-         |                       ·········                                                
-    -2.4 |                  · ········                                                    
-         |                ········                                                        
-         |          ········                                                              
-         |         ··· ·                                                                  
-         |        ·                                                                       
-    -4.4 |·                                                                               
+     3.7 |                                                                                
+         |                                                                          ···· ·
+         |                                                                      ······    
+         |                                                                  ········      
+         |                                                              ········          
+     1.6 |                                                         ·········              
+         |                                                     ··········                 
+         |                                                 ···∘∘∘···                      
+         |                                             ···∘∘∘····                         
+         |                                         ···∘○○∘··                              
+    -0.5 |                                     ···∘∘∘···                                  
+         |                                ····∘∘∘∘···                                     
+         |                            ······∘···                                          
+         |                         ·········                                              
+         |                      ········                                                  
+    -2.6 |                   ······                                                       
+         |              · ·····                                                           
+         |           ·····                                                                
+         |           ·                                                                    
+         |                                                                                
+    -4.7 |·                                                                               
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-       -4.43    -3.54    -2.65    -1.76    -0.87     0.01     0.90     1.79     2.68  
+        -4.7     -3.7     -2.8     -1.8     -0.9     0.0      1.0      1.9      2.8   
 ```
 
 You can see that although we still sample from the full range of `x` values, for any given sample, `x` and `z` are quite close to each other.
@@ -215,7 +215,7 @@ scala> val rate = for {
      |     r <- e_x
      |     poisson <- Poisson(r).fit(sales)
      | } yield r
-rate: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@2d325f9f
+rate: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.compute.Real] = com.stripe.rainier.core.RandomVariable@64b1257e
 ```
 
 This is our first "full" model: we have a parameter with a log-normal prior bundled into the `RandomVariable` named `e_x`; we use that parameter to initialize a `Poisson` noise distribution which we fit to our observations; and at the end, we output the same parameter (referenced by `r`) as the quantity we're interested in sampling from the posterior.
@@ -224,29 +224,29 @@ Let's plot the results!
 
 ```scala
 scala> plot1D(rate.sample())
-     440 |                                                                                
-         |                            ∘                                                   
-         |                            ○                                                   
-         |                            ○○                                                  
-         |                          ∘∘○○     ∘·                                           
-     330 |                         ∘○○○○ ∘ ··○○                                           
-         |                       ∘ ○○○○○○○ ○○○○○                                          
-         |                      ·○∘○○○○○○○∘○○○○○                                          
-         |                      ○○○○○○○○○○○○○○○○                                          
-         |                     ○○○○○○○○○○○○○○○○○·                                         
-     220 |                    ∘○○○○○○○○○○○○○○○○○○○∘ ○                                     
-         |                  ··○○○○○○○○○○○○○○○○○○○○○ ○                                     
-         |                  ○○○○○○○○○○○○○○○○○○○○○○○·○∘                                    
-         |                 ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○                                   
-         |               ·∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘                                  
-     110 |              ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘·                                
-         |              ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                               
-         |            ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘∘                             
-         |          ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘· ·                         
-         |       ··∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘∘                       
-       0 |· ··∘∘∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘○····· ··· ·     ·
+     400 |                                                                                
+         |                         ·∘ ∘                                                   
+         |                         ○○·○○ ∘·                                               
+         |                         ○○○○○ ○○                                               
+         |                        ∘○○○○○∘○○∘                                              
+     300 |                      ∘∘○○○○○○○○○○∘                                             
+         |                      ○○○○○○○○○○○○○· ∘                                          
+         |                    ∘○○○○○○○○○○○○○○○∘○                                          
+         |                   ·○○○○○○○○○○○○○○○○○○                                          
+         |                   ○○○○○○○○○○○○○○○○○○○                                          
+     200 |                ··○○○○○○○○○○○○○○○○○○○○○                                         
+         |                ○○○○○○○○○○○○○○○○○○○○○○○∘○                                       
+         |               ∘○○○○○○○○○○○○○○○○○○○○○○○○○ ∘                                     
+         |              ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○                                     
+         |             ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘ ·                                  
+     100 |           · ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○                                 
+         |           ○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○  ∘                              
+         |         ∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·○∘                             
+         |      · ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○·∘                           
+         |  ○· ·○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘·∘ ·                      
+       0 |∘○○○∘○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○○∘∘·······∘··  · ·   ·
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        4.70     5.56     6.42     7.28     8.14     9.01     9.87    10.73    11.59  
+        4.83     5.71     6.58     7.46     8.34     9.21    10.09    10.96    11.84  
 ```
 
 Looks like our daily rate is probably somewhere between 6 and 9, and is in fact much more likely to be around 9 than 10.
@@ -298,40 +298,40 @@ scala> val prediction = for {
      |     r <- e_x
      |     poisson <- Poisson(r).fit(sales)
      | } yield poisson.generator
-prediction: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@a49ffaa
+prediction: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@1cab1233
 ```
 
 This is almost the same model as `rate` above, but instead of taking the real-valued `r` rate parameter as the output, we're producing poisson-distributed integers. The samples look like this:
 
 ```scala
 scala> prediction.sample()
-res7: List[Int] = List(6, 7, 13, 6, 9, 6, 9, 7, 6, 12, 9, 6, 1, 10, 10, 11, 3, 4, 9, 4, 7, 7, 6, 4, 8, 10, 7, 9, 11, 11, 9, 5, 10, 12, 6, 5, 15, 10, 6, 10, 11, 8, 10, 15, 9, 4, 4, 10, 6, 11, 7, 7, 9, 7, 9, 7, 10, 7, 10, 5, 5, 12, 6, 13, 7, 8, 8, 12, 12, 4, 5, 5, 7, 9, 6, 5, 14, 6, 9, 3, 6, 6, 11, 6, 9, 7, 11, 11, 9, 8, 7, 10, 11, 7, 7, 9, 8, 6, 7, 10, 5, 9, 8, 4, 6, 7, 8, 5, 6, 3, 10, 9, 8, 14, 12, 4, 10, 7, 8, 12, 10, 10, 5, 5, 9, 13, 9, 4, 11, 9, 8, 12, 5, 6, 2, 9, 6, 6, 5, 8, 6, 12, 11, 8, 6, 5, 3, 6, 6, 7, 4, 6, 13, 8, 6, 2, 8, 6, 12, 5, 2, 5, 3, 3, 9, 7, 4, 6, 12, 11, 7, 10, 7, 10, 13, 9, 1, 9, 8, 10, 4, 7, 18, 5, 5, 3, 11, 4, 8, 7, 5, 5, 8, 9, 5, 11, 9, 6, 5, 10, 8, 9, 7, 8, 5, 8, 9, 11, 10, 12, 8, 10, 8, 5, 4, 8, 8, 6, 12, 6, 9, 9, 7, 5, 9, 9, 7, 5, 6, 1...
+res7: List[Int] = List(9, 9, 5, 8, 5, 13, 4, 6, 4, 7, 4, 4, 7, 12, 9, 6, 8, 6, 8, 2, 6, 7, 9, 7, 5, 6, 7, 5, 12, 10, 8, 7, 9, 6, 11, 3, 7, 4, 3, 10, 13, 5, 15, 6, 7, 14, 4, 6, 11, 3, 15, 9, 2, 8, 11, 1, 7, 8, 7, 6, 12, 5, 6, 8, 8, 8, 9, 6, 13, 4, 9, 7, 7, 6, 6, 12, 10, 13, 8, 11, 8, 7, 14, 4, 4, 10, 13, 8, 6, 8, 14, 9, 9, 4, 10, 12, 5, 8, 5, 10, 6, 8, 4, 6, 7, 7, 10, 5, 8, 11, 5, 6, 8, 5, 5, 10, 8, 8, 5, 6, 4, 4, 3, 7, 6, 7, 5, 8, 7, 9, 5, 4, 2, 7, 10, 9, 12, 6, 9, 7, 8, 8, 6, 10, 4, 8, 4, 5, 12, 7, 8, 13, 8, 6, 5, 8, 7, 12, 5, 13, 6, 13, 6, 5, 12, 10, 3, 6, 6, 9, 8, 6, 7, 8, 5, 6, 7, 7, 1, 9, 5, 9, 8, 8, 6, 10, 8, 6, 11, 12, 4, 9, 5, 9, 4, 4, 6, 4, 12, 7, 7, 21, 9, 10, 5, 9, 4, 11, 8, 6, 4, 10, 4, 7, 6, 10, 6, 9, 7, 14, 9, 10, 3, 9, 5, 5, 7, 6, 12, 9, 12, 16, ...
 ```
 Or, if we plot them, like this:
 
 ```scala
 scala> plot1D(prediction.sample())
-    1330 |                                                                                
+    1390 |                                                                                
          |                          ○                                                     
+         |                      ·   ○   ○                                                 
          |                      ○   ○   ○                                                 
-         |                      ○   ○   ○   ·                                             
-         |                      ○   ○   ○   ○                                             
-    1000 |                  ∘   ○   ○   ○   ○                                             
+         |                      ○   ○   ○                                                 
+    1040 |                      ○   ○   ○   ∘                                             
+         |                  ·   ○   ○   ○   ○                                             
          |                  ○   ○   ○   ○   ○                                             
+         |                  ○   ○   ○   ○   ○  ∘                                          
          |                  ○   ○   ○   ○   ○  ○                                          
-         |                  ○   ○   ○   ○   ○  ○                                          
-         |               ·  ○   ○   ○   ○   ○  ○                                          
-     660 |               ○  ○   ○   ○   ○   ○  ○                                          
+     690 |               ∘  ○   ○   ○   ○   ○  ○                                          
          |               ○  ○   ○   ○   ○   ○  ○   ·                                      
          |               ○  ○   ○   ○   ○   ○  ○   ○                                      
          |               ○  ○   ○   ○   ○   ○  ○   ○                                      
          |               ○  ○   ○   ○   ○   ○  ○   ○   ∘                                  
-     330 |           ○   ○  ○   ○   ○   ○   ○  ○   ○   ○                                  
-         |           ○   ○  ○   ○   ○   ○   ○  ○   ○   ○                                  
+     340 |           ∘   ○  ○   ○   ○   ○   ○  ○   ○   ○                                  
+         |           ○   ○  ○   ○   ○   ○   ○  ○   ○   ○   ·                              
          |           ○   ○  ○   ○   ○   ○   ○  ○   ○   ○   ○                              
-         |       ∘   ○   ○  ○   ○   ○   ○   ○  ○   ○   ○   ○   ·                          
-         |   ·   ○   ○   ○  ○   ○   ○   ○   ○  ○   ○   ○   ○   ○  ·                       
-       0 |·  ○   ○   ○   ○  ○   ○   ○   ○   ○  ○   ○   ○   ○   ○  ○   ○   ∘   ·   ·  ·   ·
+         |       ·   ○   ○  ○   ○   ○   ○   ○  ○   ○   ○   ○   ·                          
+         |       ○   ○   ○  ○   ○   ○   ○   ○  ○   ○   ○   ○   ○  ·                       
+       0 |·  ○   ○   ○   ○  ○   ○   ○   ○   ○  ○   ○   ○   ○   ○  ○   ∘   ∘   ·   ·  ·   ·
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
         0.0      2.4      4.7      7.1      9.5      11.9     14.2     16.6     19.0  
 ```
@@ -381,7 +381,7 @@ scala> val prior = for {
      |     slope <- LogNormal(0,1).param
      |     intercept <- LogNormal(0,1).param
      |     } yield (slope, intercept)
-prior: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@7d51a6df
+prior: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@6f695aa0
 ```
 
 Now, for any given day `i`, we want to check the number of sales against `Poisson(intercept + slope*i)`. We could write some kind of recursive flatMap to build and fit each of these different distribution objects in turn, but this is a common enough pattern that Rainier already has something built in for it: `Predictor`. `Predictor` is not a `Distribution`, but instead wraps a function from `X => Distribution[Y]` for some `(X,Y)`; you can use this any time you have a dependent variable of type `Y` that you're modeling with some independent variables jointly represented as `X`.
@@ -395,7 +395,7 @@ scala> val regr = for {
      |                     Poisson(intercept + slope*i)
      |                 }.fit(data)
      | } yield (slope, intercept)
-regr: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@5d7d8059
+regr: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@4bdccf83
 ```
 
 As before, we're starting out by just sampling the parameters. By plotting them, we can see that the model's confidence in the intercept, in particular, is pretty low: although it's most likely to be somewhere around 8, it could be anywhere from 3 to 13 or even higher. Second, as you'd hope, the two parameters are anti-correlated:
@@ -403,29 +403,29 @@ a smaller intercept would imply a higher slope, and vice versa.
 
 ```scala
 scala> plot2D(regr.sample())
-    15.3 |                                                                                
-         |                     ·                                                          
-         |          ·  ·                                                                  
-         |·    ·  ·    ·  ·· ····   · ·                                                   
-         |        ··   ···· ··· ····  ·  ···  ·                                           
-    12.2 |               ····· ············· · ·    ·                                     
-         |        ·  · ·························· ·· ···                                  
-         |               ····························  ···  ·                             
-         |             · ·················∘·············  ·       ·                       
-         |               ·············∘∘∘∘·∘∘∘··∘·············                            
-     9.1 |             ·  ············∘·∘∘∘∘∘∘○∘○○∘∘∘···············                      
-         |                    · ·········∘∘∘∘○∘○○○○○○∘∘∘∘···········  ·                   
-         |                  ··  · · ·······∘∘∘○○○○○○○○∘○∘∘∘∘······· ····  ·               
-         |                        ····· ·····∘∘∘∘∘○○∘○○○○∘∘∘∘·∘·········· · ·             
-         |                        ·    · ·······∘∘∘∘∘∘∘∘○○○∘∘∘∘∘∘··········· ·            
-     6.0 |                            · ·  ···········∘∘∘∘∘∘∘∘∘∘∘∘·········· ·     ·      
-         |                                   ··············∘··∘∘∘··············     ·     
-         |                                     ··  ·························· ·· ·        
-         |                                            ··· ······················          
-         |                                              ·    ·   ······  ··      ·   ·   ·
-     2.9 |                                                       · · · ·  · · ·           
+    15.1 |                                                                                
+         |·   ·      ··  ·                                                                
+         |             ··  ·  ·                                                           
+         |   ··   ·  ····· · ···  ··                                                      
+         |   ·  ·   ·  ············ ·······                                               
+    11.9 |  ·  ·  ·· ························  ··  ·                                      
+         |         · · ···························      ·                                 
+         |        ·   ·······························    · ·                              
+         |           ·  ················∘················· ··                             
+         |             ················∘∘∘∘∘∘·∘··············· ·  ·                       
+     8.7 |                 ···········∘·∘∘∘○∘∘∘∘∘∘∘∘∘··············                       
+         |                   ··· ······∘∘∘∘∘∘∘∘○○○○∘∘∘∘∘∘∘∘········ ·  ·                  
+         |                   ·  ···········∘∘∘∘∘∘○∘○∘○○∘∘∘∘··∘···········   ·             
+         |                         ···········∘∘∘∘∘∘∘∘○∘∘∘○∘∘∘∘·········   ·  ·· ·        
+         |                           ············∘··∘∘∘·∘∘∘∘∘∘∘··············· · ··       
+     5.6 |                            ·   ········································        
+         |                                  ··· ·································         
+         |                                        · ························· ···  ·      
+         |                                             ·  ·· ·  ··········· ···· ·        
+         |                                               ·      ·   ·      ·    · ·       
+     2.4 |                                               ·                         ·     ·
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        2.30     2.49     2.68     2.86     3.05     3.24     3.43     3.61     3.80  
+        2.39     2.56     2.74     2.91     3.09     3.26     3.43     3.61     3.78  
 ```
 
 Alternatively, as in the earlier example, we could try to predict what will happen tomorrow. This is similar to calling `poisson.generator` before, but this time, we use the `predict` method on `Predictor`, which takes the covariate (the day, in this case), and returns a `Generator` for the dependent variable (the number of sales). Putting it all together, it looks like this:
@@ -438,7 +438,7 @@ scala> val regr2 = for {
      |                     Poisson(intercept + slope*i)
      |                 }.fit(data)
      | } yield predictor.predict(21)
-regr2: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@60c9bede
+regr2: com.stripe.rainier.core.RandomVariable[com.stripe.rainier.core.Generator[Int]] = com.stripe.rainier.core.RandomVariable@7cce4353
 ```
 
 Plotting this gives us a prediction which incorporates both the natural noise of a Poisson distribution and our uncertainty about its underlying parameterization.
@@ -446,26 +446,26 @@ Plotting this gives us a prediction which incorporates both the natural noise of
 ```scala
 scala> plot1D(regr2.sample())
      470 |                                                                                
-         |                                  ∘  ·                                          
-         |                               ·  ○○ ○                                          
-         |                               ○  ○○ ○                                          
-         |                              ∘○ ○○○○○   ·                                      
-     350 |                             ·○○ ○○○○○○○ ○                                      
-         |                             ○○○ ○○○○○○○ ○∘∘                                    
-         |                           ∘ ○○○ ○○○○○○○ ○○○                                    
-         |                           ○○○○○ ○○○○○○○ ○○○·                                   
-         |                         ○○○○○○○ ○○○○○○○ ○○○○·                                  
-     230 |                         ○○○○○○○ ○○○○○○○ ○○○○○○                                 
-         |                       · ○○○○○○○ ○○○○○○○ ○○○○○○·                                
-         |                      ○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ·                              
-         |                     ·○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○∘                             
-         |                    ·○○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○                             
-     110 |                   ○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○○○                           
-         |                 ·○○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○                          
-         |                 ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○                         
-         |               ∘ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○∘ ○                      
-         |            ·∘○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○∘∘·                  
-       0 |········ ∘○○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○∘○ ······· ·· ·  ·
+         |                                 ·∘                                             
+         |                                 ○○                                             
+         |                               · ○○ ○○                                          
+         |                               ○ ○○∘○○∘○                                        
+     350 |                             ∘ ○ ○○○○○○○  ○                                     
+         |                            ∘○○○ ○○○○○○○ ·○∘                                    
+         |                            ○○○○ ○○○○○○○ ○○○                                    
+         |                          ·○○○○○ ○○○○○○○ ○○○·                                   
+         |                         ·○○○○○○ ○○○○○○○ ○○○○                                   
+     230 |                         ○○○○○○○ ○○○○○○○ ○○○○○·                                 
+         |                      ∘∘ ○○○○○○○ ○○○○○○○ ○○○○○○·                                
+         |                      ○○ ○○○○○○○ ○○○○○○○ ○○○○○○○                                
+         |                    ··○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○·                             
+         |                    ○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○                             
+     110 |                   ∘○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○○∘                           
+         |                 · ○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○○○∘∘                         
+         |                 ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○∘                        
+         |              ∘· ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ∘·                     
+         |           ··○○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○○∘··                 
+       0 |· ·····∘ ∘∘○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○○ ○○○○○○∘ ○······    ·  ·
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
         43.0     50.9     58.8     66.7     74.5     82.4     90.3     98.2    106.1  
 ```
@@ -477,48 +477,88 @@ scala> val data2 = List((0,9), (1,2), (2,3), (3,17), (4,21), (5,12), (6,21), (7,
 data2: List[(Int, Int)] = List((0,9), (1,2), (2,3), (3,17), (4,21), (5,12), (6,21), (7,19), (8,21), (9,18), (10,25), (11,27), (12,33), (13,23), (14,28), (15,45), (16,35), (17,45), (18,47), (19,54), (20,40))
 ```
 
-It's straightforward to set up two separate slopes, two separate predictors, but the same interecept. We'll still just sample the first slope so we can compare to the previous model. We _could_ write out the parameters of the models separately and fit each one to its respective data, but this is a bit tedious, so we can use Rainier's `Lookup` to do it more succinctly.
+It's straightforward to set up two separate slopes, two separate predictors, but the same intercept. We'll still just sample the first slope so we can compare to the previous model. We can write out the two slopes and predictors manually
+
+```scala
+scala> val regr3 =  for {
+     |     slope0 <- LogNormal(0,1).param
+     |     slope1 <- LogNormal(0,1).param
+     |     intercept <- LogNormal(0,1).param
+     |     _ <- Predictor.fromInt{ i => Poisson(intercept + slope0 * i) }.fit(data)
+     |     _ <- Predictor.fromInt{ i => Poisson(intercept + slope1 * i) }.fit(data2)
+     | } yield (slope0, intercept)
+regr3: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@bfbbc8f
+```
+
+or we can use Rainier's `Lookup` to package the two slopes into a single `RandomVariable` from which we can lookup the one we want. This means that our predictor now has to take both the index of the model to which the data belongs as well as the actual observation as input.
 
 ```scala
 scala> val allData = data.map{ case (x,y) => ((0, x), y) } ++ data2.map{ case (x, y) => ((1, x), y) }
 allData: List[((Int, Int), Int)] = List(((0,0),8), ((0,1),12), ((0,2),16), ((0,3),20), ((0,4),21), ((0,5),31), ((0,6),23), ((0,7),33), ((0,8),31), ((0,9),33), ((0,10),36), ((0,11),42), ((0,12),39), ((0,13),56), ((0,14),55), ((0,15),63), ((0,16),52), ((0,17),66), ((0,18),52), ((0,19),80), ((0,20),71), ((1,0),9), ((1,1),2), ((1,2),3), ((1,3),17), ((1,4),21), ((1,5),12), ((1,6),21), ((1,7),19), ((1,8),21), ((1,9),18), ((1,10),25), ((1,11),27), ((1,12),33), ((1,13),23), ((1,14),28), ((1,15),45), ((1,16),35), ((1,17),45), ((1,18),47), ((1,19),54), ((1,20),40))
 
-scala> val regr3 = for {
+scala> val regLookup = for {
      |   slopes <- RandomVariable.fill(2)(LogNormal(0,1).param).map(Lookup(_))
      |   intercept <- LogNormal(0,1).param
-     |   _ <- Predictor.from[(Int, Int), Int, (Real, Real), Real]{ case (i,x) => Poisson(intercept + slopes(i) * x) }.fit(allData)
+     |   _ <- Predictor.fromIntPair{ case (index, x) => Poisson(intercept + slopes(index) * x) }.fit(allData)
      | } yield (slopes(0), intercept)
-regr3: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@2ff2a1b
+regLookup: com.stripe.rainier.core.RandomVariable[(com.stripe.rainier.compute.Real, com.stripe.rainier.compute.Real)] = com.stripe.rainier.core.RandomVariable@60520a80
 ```
-Here, `i` indexes which model we're feeding the data to and `x` is the x-value of the observation. Plotting slope vs intercept now, we can see that, even though these are two separate regressions, we get tighter bounds than before by letting the new data influence the shared parameter. It makes sense that we'd get more confidence on the intercept, since we have two different time series to learn from now; but because of the anti-correlation, that also leads to somewhat more confidence than before on the `slope1` parameter as well.
+
+Plotting slope vs. intercept now, we first see that they do agree.
 
 ```scala
 scala> plot2D(regr3.sample())
-    11.4 |                                                                                
-         |                     ·                                                          
-         |  ···             ·                                                             
-         |   ·    · ·        ··                                                           
-         |     · · · · · ·  ··   · ··    ·                                                
-     9.3 |·     ·· ·· ··············  · · ·   ·· ·                                        
-         |  ··   · ··················· ·· · ·· ·  ··          ·                           
-         |···  ····································  ·   ··                               
-         |     ············································ ·                             
-         |  ··  ················∘·····∘∘∘·∘··················   ·                         
-     7.1 |    ·· ·· ···········∘∘∘∘∘∘∘∘·∘∘∘·∘∘∘·∘∘··············    ·                     
-         |       ···· ·······∘·∘·∘∘∘∘∘∘∘○○∘∘○∘∘∘∘∘∘∘············ ·  ·    ·                
-         |     ·   ·  ············∘∘∘∘∘∘∘○∘○○○∘∘∘∘○∘∘·∘·········· ··· ·· ·                
-         |    · · ·    ·············∘∘∘∘∘∘∘∘∘∘∘∘∘∘∘○○∘∘∘∘∘·∘···········   ··              
-         |            · ·  ··············∘∘∘∘∘∘∘○∘∘∘∘∘∘∘∘···················             ·
-     5.0 |               ·······················∘··∘∘·∘∘∘···················   ·   ·      
-         |                       ······································· · ·    ··        
-         |                         ·  ································· ··  ·             
-         |                               ··    ······ ·········· ······  ·  ·             
-         |                                     ·   ·· ·  ·· ····· · ··           ·        
-     2.9 |                                                       ·            ·           
+    10.8 |                                                                                
+         |                 ·                                                              
+         |   ·             ·  ·      · · ·· ·                                             
+         |          ·   ·· ·· ·  · ·  ··     ·                                            
+         |·  ·   ·     ·   · ·  ········· ····· ·   ·                                     
+     8.9 |      ··      ················ ···· ······ ···   ·     ·                        
+         |      ·  ··· ································  ··                               
+         |        · ··   ·····································  ·                         
+         |          ····································· · ·······      ·                
+         |       ·      ·· ··········∘·∘·∘∘∘·∘∘∘∘·∘∘∘∘···········  ··  ·       ·          
+     7.0 |         ·    ·   ···········∘∘∘∘∘∘∘○∘○∘∘·∘∘·∘∘············  ··                 
+         |            ·   ··············∘·∘∘∘∘∘○○∘∘○∘∘∘∘∘∘··∘··········  ···      ·       
+         |        ·        ··············∘·∘∘∘∘○○○∘○○∘○∘○∘∘∘∘∘··············   ··         
+         |                     ··············∘∘∘∘∘∘○○∘○∘○∘∘∘∘···∘············ ·           
+         |                      ·················∘∘·∘∘∘∘∘∘∘∘∘∘∘∘·············· ···        
+     5.0 |                         · ···················∘·······················          
+         |                        ·     ·······································   ·       
+         |                             ·     ·· ································   ··  ·  
+         |                                       · · ··· ················· · ··     ·    ·
+         |                                   ·   ·    ·     ··  · ·   · · ··   ·  ·       
+     3.1 |                                                ·  ··   ··    ·                 
          |--------|--------|--------|--------|--------|--------|--------|--------|--------
-        2.76     2.90     3.05     3.19     3.33     3.47     3.62     3.76     3.90  
+        2.64     2.79     2.93     3.08     3.23     3.38     3.53     3.67     3.82  
+
+scala> plot2D(regLookup.sample())
+    11.4 |                                                                                
+         |               ·      ·  ·                                                      
+         |            ·                                                                   
+         |             ·  ·  ·  ·                                                         
+         |    ·   · · ·· ·· · · ·  ·  ···  ·                                              
+     9.3 |·      · · ·  ············ ······· · · ·   ·   ·   ·                            
+         |·    · ···· ·  ······················· ··· ·     ·                              
+         |        ·· ································ · · ··· · ·                         
+         |          ···· ··············∘·················· ·····                          
+         |      ·  ·   ················∘∘·∘∘∘∘∘∘················ ··   ··                  
+     7.2 |       ·   ··· ··········∘∘·∘·∘∘∘∘∘∘∘○∘∘∘∘∘∘∘···∘············                   
+         |       ·    ·  ············∘∘∘∘∘∘∘∘○∘○○∘∘○∘∘○∘∘∘·∘··················            
+         |                ···········∘∘∘∘∘∘∘∘○○∘○∘○○○○○∘∘∘○∘∘·∘··········· ····· ·        
+         |               ·    ··········∘∘·∘○∘∘∘○○○○○○○○○∘∘○∘∘∘∘∘·············     ·      
+         |                    ·   ········∘∘··∘∘∘∘∘∘∘∘∘∘∘∘∘∘∘∘∘∘∘·∘·············  ·       
+     5.1 |                         ·················∘∘∘∘∘·∘∘·∘∘∘··∘·········· ·· ·  ·     
+         |                             ·········································· ··   ·· 
+         |                              ·    ·· ······················· ·······  · ··     
+         |                               ·       · ·   ··· ······· ··· ······ ···  ·    · 
+         |                                              ·   ·  ·    ·  ··    ·       ·    
+     2.9 |                                             ··       ·         ·       ·      ·
+         |--------|--------|--------|--------|--------|--------|--------|--------|--------
+        2.68     2.82     2.96     3.10     3.23     3.37     3.51     3.65     3.79  
 ```
 
+Mathematically, we see that, even though these are two separate regressions, we get tighter bounds than before by letting the new data influence the shared parameter. It makes sense that we'd get more confidence on the intercept, since we have two different time series to learn from now; but because of the anti-correlation, that also leads to somewhat more confidence than before on the `slope1` parameter as well.
 ## Learning More
 
 This tour has focused on the high-level API. If you want to understand more about what's going on under the hood, you might enjoy reading about [Real](real.md) or checking out some [implementation notes](impl.md). If you want to learn more about Bayesian modeling in general, [Cam Davidson Pilon's book][CDP] is an excellent resource - the examples are in Python, but porting them to Rainier is a good learning exercise. Over time, we hope to add more Rainier-specific documentation and community resources; for now, feel free to file a [GitHub issue][GISSUES] with any questions or problems.

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Predictor.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Predictor.scala
@@ -56,6 +56,10 @@ object Predictor {
   def fromInt[Y, B](fn: Real => Distribution.Aux[Y, B]): Predictor[Int, Y] =
     from[Int, Y, Real, B](fn)
 
+  def fromIntPair[Y, B](
+      fn: ((Real, Real)) => Distribution.Aux[Y, B]): Predictor[(Int, Int), Y] =
+    from[(Int, Int), Y, (Real, Real), B](fn)
+
   def fromDouble[Y, B](
       fn: Real => Distribution.Aux[Y, B]): Predictor[Double, Y] =
     from[Double, Y, Real, B](fn)

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/RandomVariable.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/RandomVariable.scala
@@ -127,6 +127,25 @@ class RandomVariable[+T](val value: T, val targets: Set[Target]) {
       def gradient(index: Int) = outputs(index + 1)
     }
 
+  def densityValue(values: Map[Variable, Double] = Map.empty): Real = {
+    val rvVars = targetGroup.variables.sortBy(_.toString)
+    val (inputVars, inputVals) = values.toList.sortBy(_._1.toString).unzip
+    (rvVars, inputVars) match {
+      case (Nil, _) => targetGroup.base
+      case (rVs, iVs) if rVs == iVs =>
+        val den = density()
+        den.update(inputVals.toArray)
+        den.density
+      case _ => 0.0
+    }
+  }
+
+  def densityValue(value: Double): Real =
+    targetGroup.variables.headOption match {
+      case Some(v) => densityValue(Map(v -> value))
+      case _       => 0.0
+    }
+
   //this is really just here to allow destructuring in for{}
   def withFilter(fn: T => Boolean): RandomVariable[T] =
     if (fn(value))

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/RandomVariable.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/RandomVariable.scala
@@ -127,24 +127,7 @@ class RandomVariable[+T](val value: T, val targets: Set[Target]) {
       def gradient(index: Int) = outputs(index + 1)
     }
 
-  def densityValue(values: Map[Variable, Double] = Map.empty): Real = {
-    val rvVars = targetGroup.variables.sortBy(_.toString)
-    val (inputVars, inputVals) = values.toList.sortBy(_._1.toString).unzip
-    (rvVars, inputVars) match {
-      case (Nil, _) => targetGroup.base
-      case (rVs, iVs) if rVs == iVs =>
-        val den = density()
-        den.update(inputVals.toArray)
-        den.density
-      case _ => 0.0
-    }
-  }
-
-  def densityValue(value: Double): Real =
-    targetGroup.variables.headOption match {
-      case Some(v) => densityValue(Map(v -> value))
-      case _       => 0.0
-    }
+  lazy val densityValue: Real = targetGroup.base
 
   //this is really just here to allow destructuring in for{}
   def withFilter(fn: T => Boolean): RandomVariable[T] =

--- a/rainier-docs/src/main/tut/real.md
+++ b/rainier-docs/src/main/tut/real.md
@@ -119,7 +119,7 @@ This, of course, isn't a very exciting function - it just multiplies two numbers
 
 ## Tracing
 
-```tut
+```tut:silent
 import com.stripe.rainier.trace._
 ```
 

--- a/rainier-docs/src/main/tut/tour.md
+++ b/rainier-docs/src/main/tut/tour.md
@@ -1,10 +1,8 @@
 # A Tour of Rainier's Core
 
-Hello! This document will provide a quick tour through the most important parts of Rainier's core.
-If you'd like to follow along with this tour, `sbt "project rainierCore" console` will get you to a Scala REPL.
+Hello! This document will provide a quick tour through the most important parts of Rainier's core. If you'd like to follow along with this tour, `sbt "project rainierCore" console` will get you to a Scala REPL.
 
-The `rainier.core` package defines some key traits like `Distribution`, `RandomVariable`, `Likelihood`, and `Predictor`.
-Let's import it, along with a `repl` package that gives us some useful utilities.
+The `rainier.core` package defines some key traits like `Distribution`, `RandomVariable`, `Likelihood`, and `Predictor`. Let's import it, along with a `repl` package that gives us some useful utilities.
 
 ```tut:silent
 import com.stripe.rainier.core._
@@ -12,10 +10,8 @@ import com.stripe.rainier.repl._
 import com.stripe.rainier.compute._
 ```
 
-Together, those traits let you define Bayesian models in Rainier.
-To throw you a little bit into the deep end, here's a simple linear regression that we'll return to later.
-This probably won't entirely make sense yet. That's ok.
-Hopefully it will serve as a bit of a roadmap that put the rest of the tour in context as we build up to it.
+Together, those traits let you define Bayesian models in Rainier. To throw you a little bit into the deep end, here's a simple linear regression that we'll return to later.
+This probably won't entirely make sense yet. That's ok. Hopefully it will serve as a bit of a roadmap that put the rest of the tour in context as we build up to it.
 
 ```tut
 val data =  List((0,8), (1,12), (2,16), (3,20), (4,21), (5,31), (6,23), (7,33), (8,31), (9,33), (10,36), (11,42), (12,39), (13,56), (14,55), (15,63), (16,52), (17,66), (18,52), (19,80), (20,71))
@@ -31,27 +27,17 @@ model.sample(10)
 
 ## Distribution
 
-The starting point for almost any work in Rainier will be some object that implements
-`rainier.core.Distribution[T]`.
+The starting point for almost any work in Rainier will be some object that implements `rainier.core.Distribution[T]`.
 
-Rainier implements various familiar families of probability distributions like
-the [Normal](https://en.wikipedia.org/wiki/Normal_distribution) distribution,
-the [Uniform][UC] distribution,
-and the [Poisson](https://en.wikipedia.org/wiki/Poisson_distribution) distribution.
-You will find these three in [Continuous.scala](/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala)
-and [Discrete.scala](/rainier-core/src/main/scala/com/stripe/rainier/core/Discrete.scala) -
-along with a few more, and we'll keep adding them as the need arises.
-
-You construct a distribution from its parameters, usually with the `apply` method on the object representing its family.
-So for example, this is a normal distribution with a mean of 0 and a standard deviation of 1:
+Rainier implements various familiar families of probability distributions like the [Normal](https://en.wikipedia.org/wiki/Normal_distribution) distribution,
+the [Uniform][UC] distribution, and the [Poisson](https://en.wikipedia.org/wiki/Poisson_distribution) distribution.
+You will find these three in [Continuous.scala](/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala) and [Discrete.scala](/rainier-core/src/main/scala/com/stripe/rainier/core/Discrete.scala) - along with a few more, and we'll keep adding them as the need arises. You construct a distribution from its parameters, usually with the `apply` method on the object representing its family. So for example, this is a normal distribution with a mean of 0 and a standard deviation of 1:
 
 ```tut
 val normal: Distribution[Double] = Normal(0,1)
 ```
 
-In Rainier, `Distribution` objects play three different roles.
-`Continuous` distributions (like `Normal`), implement `param`, and all distributions implement `fit` and `generator`.
-Each of these methods is central to one of the three stages of building a model in Rainier:
+In Rainier, `Distribution` objects play three different roles. `Continuous` distributions (like `Normal`), implement `param`, and all distributions implement `fit` and `generator`. Each of these methods is central to one of the three stages of building a model in Rainier:
 
 * defining your parameters and their priors
 * fitting the parameters to some observed data and
@@ -61,17 +47,12 @@ We'll start by exploring each of these in turn.
 
 ## `param` and `RandomVariable`
 
-Every model in Rainier has some parameters whose values are unknown
-(if that's not true for your model, you don't need an inference library!).
+Every model in Rainier has some parameters whose values are unknown (if that's not true for your model, you don't need an inference library!).
 The first step in constructing a model is to set up these parameters.
 
-You create a parameter by calling `param` on the distribution that represents
-the prior for that parameter. `param` is only implemented for continuous distributions
-(which extend `Continuous`, which extends `Distribution[Double]`).
-As you might be able to tell from those types:
-in Rainier, all parameters are continuous real scalar values.
-There's no support for discrete model parameters, and there's no support (or need)
-for explicit vectorization.
+You create a parameter by calling `param` on the distribution that represents the prior for that parameter. `param` is only implemented for continuous distributions
+(which extend `Continuous`, which extends `Distribution[Double]`). As you might be able to tell from those types:
+in Rainier, all parameters are continuous real scalar values. There's no support for discrete model parameters, and there's no support (or need) for explicit vectorization.
 
 Let's use that same `Normal(0,1)` distribution as a prior for a new parameter:
 
@@ -79,38 +60,28 @@ Let's use that same `Normal(0,1)` distribution as a prior for a new parameter:
 val x = Normal(0,1).param
 ```
 
-You can see that the type of `x` is `RandomVariable[Real]`.
-`RandomVariable` pairs a type of value (in this case, a real number)
-with some knowledge of the relative probability density of different values of that type.
-We can use this knowledge to produce a sample of these possible values:
+You can see that the type of `x` is `RandomVariable[Real]`. `RandomVariable` pairs a type of value (in this case, a real number) with some knowledge of the relative probability density of different values of that type. We can use this knowledge to produce a sample of these possible values:
 
 ```tut
 x.sample()
 ```
 
-Each element of the list above represents a single sample from the distribution over `x`.
-It's easier to understand these if we plot them as a histogram:
+Each element of the list above represents a single sample from the distribution over `x`. It's easier to understand these if we plot them as a histogram:
 
 ```tut
 plot1D(x.sample())
 ```
 
-Since the only information we have about `x` so far is its `Normal` prior, this distribution unsurprisingly looks  normal.
-Later we'll see how to update our beliefs about `x` based on observational data.
+Since the only information we have about `x` so far is its `Normal` prior, this distribution unsurprisingly looks normal. Later we'll see how to update our beliefs about `x` based on observational data.
 
-For now, though, let's explore what we can do just with priors.
-`RandomVariable` has more than just `sample`:
-you can use the familiar collection methods like `map`, `flatMap`, and `zip`
-to transform and combine the parameters you create.
-For example, we can create a log-normal distribution just by mapping over `e^x`:
+For now, though, let's explore what we can do just with priors. `RandomVariable` has more than just `sample`: you can use the familiar collection methods like `map`, `flatMap`, and `zip` to transform and combine the parameters you create. For example, we can create a log-normal distribution just by mapping over `e^x`:
 
 ```tut
 val e_x = x.map(_.exp)
 plot1D(e_x.sample())
 ```
 
-Or we can create another `Normal` parameter and zip the two together to produce a 2D gaussian.
-Since there's nothing relating these two parameters to each other, you can see in the plot that they're completely independent.
+Or we can create another `Normal` parameter and zip the two together to produce a 2D gaussian. Since there's nothing relating these two parameters to each other, you can see in the plot that they're completely independent.
 
 ```tut
 val y = Normal(0,1).param
@@ -118,10 +89,7 @@ val xy = x.zip(y)
 plot2D(xy.sample())
 ```
 
-Finally, we can use `flatMap` to create two parameters that *are* related to each other.
-In particular, we'll create a new parameter `z` that we believe to be very close to `x`:
-its prior is a `Normal` centered on `x` with a very small standard deviation.
-We'll then make a 2D plot of `(x,z)` to see the relationship.
+Finally, we can use `flatMap` to create two parameters that *are* related to each other. In particular, we'll create a new parameter `z` that we believe to be very close to `x`: its prior is a `Normal` centered on `x` with a very small standard deviation. We'll then make a 2D plot of `(x,z)` to see the relationship.
 
 ```tut
 val z = x.flatMap{a => Normal(a, 0.1).param}
@@ -129,47 +97,21 @@ val xz = x.zip(z)
 plot2D(xz.sample())
 ```
 
-You can see that although we still sample from the full range of `x` values,
-for any given sample, `x` and `z` are quite close to each other.
+You can see that although we still sample from the full range of `x` values, for any given sample, `x` and `z` are quite close to each other.
 
-A note about the `Real` type: you may have noticed that, for example,
-`x` is a `RandomVariable[Real]` or that `normal.mean` was a `Real`. What's that?
-`Real` is a special numeric type used by Rainier to represent your model's parameter values,
-and any values derived from those parameters (if you do arithmetic on a `Real`, you get back another `Real`).
-It's also the type that all the distribution objects like `Normal` expect to be parameterized with,
-so that you can chain things together like we did for `z` -
-though you can also use regular `Int` or `Double` values here and they'll get wrapped automatically.
-`Real` is, by design, an extremely restricted type:
-it only supports the 4 basic arithmetic operations, `log`, and `exp`.
-Restricting it in this way helps keep Rainier models as efficient to perform inference on as possible.
-At sampling time, however, any `Real` outputs are converted to `Double` so that you can work with them from there.
+A note about the `Real` type: you may have noticed that, for example, `x` is a `RandomVariable[Real]` or that `normal.mean` was a `Real`. What's that? `Real` is a special numeric type used by Rainier to represent your model's parameter values, and any values derived from those parameters (if you do arithmetic on a `Real`, you get back another `Real`). It's also the type that all the distribution objects like `Normal` expect to be parameterized with, so that you can chain things together like we did for `z` - though you can also use regular `Int` or `Double` values here and they'll get wrapped automatically. `Real` is, by design, an extremely restricted type: it only supports the 4 basic arithmetic operations, `log`, and `exp`. Restricting it in this way helps keep Rainier models as efficient to perform inference on as possible. At sampling time, however, any `Real` outputs are converted to `Double` so that you can work with them from there.
 
 ## `fit`
 
-Just like every Rainier model has one more more parameters with priors,
-every Rainier model uses some observational data to update our belief about
-the values of those parameters (again, if your model doesn't have this, you're probably using the wrong library).
+Just like every Rainier model has one more more parameters with priors, every Rainier model uses some observational data to update our belief about the values of those parameters (again, if your model doesn't have this, you're probably using the wrong library).
 
-Let's say that we have some data that represents the last week's worth of sales
-on a website, at (we believe) a constant daily rate, and we'd like to know
-how many sales we might get tomorrow.
-Here's our data:
+Let's say that we have some data that represents the last week's worth of sales on a website, at (we believe) a constant daily rate, and we'd like to know how many sales we might get tomorrow. Here's our data:
 
 ```tut:silent
 val sales = List(4, 4, 7, 11, 8, 12, 10)
 ```
 
-We can model the number of sales we get on each day as a Poisson distribution
-parameterized by the underlying rate.
-Looking at the data, we might guess that it came from a `Poisson(9)` or `Poisson(10)`.
-In Rainier, we define our model and it fit to the observed data.
-Since we want our rate to be a positive number,
-and expect it to be more likely to be on the small side than the large side,
-the log-normal parameter we created earlier as `e_x` seems like a reasonable choice.
-We use `flatMap` to chain the creation of the parameter with the creation and
-fit of the `Poisson` distribution.
-Although we _can_ do this with explicit `flatMaps` and `maps`,
-it's much neater with `for{...}` syntax.
+We can model the number of sales we get on each day as a Poisson distribution parameterized by the underlying rate. Looking at the data, we might guess that it came from a `Poisson(9)` or `Poisson(10)`. In Rainier, we define our model and it fit to the observed data. Since we want our rate to be a positive number, and expect it to be more likely to be on the small side than the large side, the log-normal parameter we created earlier as `e_x` seems like a reasonable choice. We use `flatMap` to chain the creation of the parameter with the creation and fit of the `Poisson` distribution. Although we _can_ do this with explicit `flatMaps` and `maps`, it's much neater with `for{...}` syntax.
 
 ```tut
 val rate = for {
@@ -178,9 +120,7 @@ val rate = for {
 } yield r
 ```
 
-This is our first "full" model: we have a parameter with a log-normal prior bundled into the `RandomVariable` named `e_x`;
-we use that parameter to initialize a `Poisson` noise distribution which we fit to our observations;
-and at the end, we output the same parameter (referenced by `r`) as the quantity we're interested in sampling from the posterior.
+This is our first "full" model: we have a parameter with a log-normal prior bundled into the `RandomVariable` named `e_x`; we use that parameter to initialize a `Poisson` noise distribution which we fit to our observations; and at the end, we output the same parameter (referenced by `r`) as the quantity we're interested in sampling from the posterior.
 
 Let's plot the results!
 
@@ -188,29 +128,17 @@ Let's plot the results!
 plot1D(rate.sample())
 ```
 
-Looks like our daily rate is probably somewhere between 6 and 9,
-and is in fact much more likely to be around 9 than 10.
+Looks like our daily rate is probably somewhere between 6 and 9, and is in fact much more likely to be around 9 than 10.
 
 ## A mathematical digression
 
 Please feel free to skip this section if it's not helping you.
 
-One thing that sometimes confuses people at this stage is,
-what is the line with `fit` actually doing?
-It seems to return some value `poisson` that we just ignore.
-(That object, by the way, is just the `Poisson(r)` distribution object that we used
-to do the `fit`.)
-And yet the line is clearly doing something, because sampling from `rate` gives quite different results from just sampling directly from `e_x`.
+One thing that sometimes confuses people at this stage is, what is the line with `fit` actually doing? It seems to return some value `poisson` that we just ignore. (That object, by the way, is just the `Poisson(r)` distribution object that we used to do the `fit`.) And yet the line is clearly doing something, because sampling from `rate` gives quite different results from just sampling directly from `e_x`.
 
-The key is to remember that a `RandomVariable` has two parts: a `value` and a `density`.
-Mathematically, you should think of these as two different *functions* of the same latent parameter space `Q`.
-That is, you should think of `value` as being some deterministic function `f = F(q)`,
-and `density` as being the (unnormalized) probability function `P(Q=q)`.
+The key is to remember that a `RandomVariable` has two parts: a `value` and a `density`. Mathematically, you should think of these as two different *functions* of the same latent parameter space `Q`. That is, you should think of `value` as being some deterministic function `f = F(q)`, and `density` as being the (unnormalized) probability function `P(Q=q)`.
 
-When we `map` or `flatMap` a `RandomVariable` (whether explicitly or inside a `for` construct),
-the object we see and work with (like, the `r` above) is the `value` object.
-And we can see in the definition of `rate` that it's just passing that value object through to the end;
-it should end up with the same `value` function as the prior, `e_x`. And indeed, it does:
+When we `map` or `flatMap` a `RandomVariable` (whether explicitly or inside a `for` construct), the object we see and work with (like, the `r` above) is the `value` object. And we can see in the definition of `rate` that it's just passing that value object through to the end; it should end up with the same `value` function as the prior, `e_x`. And indeed, it does:
 
 ```tut
 e_x.value == rate.value
@@ -218,32 +146,17 @@ e_x.value == rate.value
 
 So, for the same input in the latent parameter space, `e_x` and `rate` will produce the same output.
 
-However, when we `flatMap`, behind the scenes we're also working with the `density` object.
-Specifically, when we start with one `RandomVariable` (like `e_x`),
-and use `flatMap` to flatten another `RandomVariable` into it (like the result of `fit`),
-the resulting `RandomVariable` (like `rate`) will have a `density` that *combines*
-the densities of the other two `RandomVariable`s.
-Put another way, `flatMap` is the Bayesian update operation:
-you're putting in a prior, coming up with a likelihood, and getting back the posterior.
-That's what the `fit` line is doing: constructing a likelihood function that we can incorporate into our posterior density.
-And if we look at the densities, we'll see that they are indeed different:
+However, when we `flatMap`, behind the scenes we're also working with the `density` object. Specifically, when we start with one `RandomVariable` (like `e_x`), and use `flatMap` to flatten another `RandomVariable` into it (like the result of `fit`), the resulting `RandomVariable` (like `rate`) will have a `density` that *combines* the densities of the other two `RandomVariable`s. Put another way, `flatMap` is the Bayesian update operation: you're putting in a prior, coming up with a likelihood, and getting back the posterior. That's what the `fit` line is doing: constructing a likelihood function that we can incorporate into our posterior density. And if we look at the densities, we'll see that they are indeed different:
 
 ```tut
 e_x.density == rate.density
 ```
 
-So although `F(q)` has not changed, `P(Q=q)` *has* changed;
-which means that `P(F(q)=f)` has also changed, and it's that change which we're observing
-when we see that sampling values of `F` produces different results in the two cases.
+So although `F(q)` has not changed, `P(Q=q)` *has* changed; which means that `P(F(q)=f)` has also changed, and it's that change which we're observing when we see that sampling values of `F` produces different results in the two cases.
 
 ## `generator` and `Generator`
 
-Sampling from the rate parameter is nice, but what we originally said is that
-we wanted to predict how many sales to expect tomorrow.
-As we just discussed in the digression, we got a `poisson` value back from `fit` but didn't do anything with it.
-This value is just the distribution we used for the `fit`, that is, `Poisson(r)`.
-Now, instead of fitting data *to* that distribution, we want to generate data *from* that distribution.
-One idea might be to do that with `param`, that is, with something like this:
+Sampling from the rate parameter is nice, but what we originally said is that we wanted to predict how many sales to expect tomorrow. As we just discussed in the digression, we got a `poisson` value back from `fit` but didn't do anything with it. This value is just the distribution we used for the `fit`, that is, `Poisson(r)`. Now, instead of fitting data *to* that distribution, we want to generate data *from* that distribution. One idea might be to do that with `param`, that is, with something like this:
 
 ```scala
 //This code won't compile
@@ -254,18 +167,10 @@ for {
 } yield prediction
 ```
 
-This has a couple of problems.
-First, it seems conceptually wrong to think of a prediction as a parameter:
-there is no true value of "how many sales will we have tomorrow" for us to infer,
-and we have no observational data that can influence our belief about its value;
-once we've derived the rate parameter, the prediction is purely generative.
-Second, as a practical matter, Rainier only supports continuous parameters,and
-here we need to generate discrete values, so `poisson.param` won't, in fact, compile.
+This has a couple of problems. First, it seems conceptually wrong to think of a prediction as a parameter: there is no true value of "how many sales will we have tomorrow" for us to infer, and we have no observational data that can influence our belief about its value; once we've derived the rate parameter, the prediction is purely generative.
+Second, as a practical matter, Rainier only supports continuous parameters,and here we need to generate discrete values, so `poisson.param` won't, in fact, compile.
 
-Luckily, all distributions, continious or discrete, implement `generator`,
-which gives us what we need: a way to randomly generate new values from a distribution as part of the sampling process.
-Every `Distribution[T]` can give us a `Generator[T]`, and if we sample from a `RandomVariable[Generator[T]]`,
-we will get values of type `T`.
+Luckily, all distributions, continious or discrete, implement `generator`, which gives us what we need: a way to randomly generate new values from a distribution as part of the sampling process. Every `Distribution[T]` can give us a `Generator[T]`, and if we sample from a `RandomVariable[Generator[T]]`, we will get values of type `T`.
 (You can think of `Real` as being a special case that acts in this sense like a `Generator[Double]`).
 
 Here's one way we could implement what we're looking for:
@@ -277,10 +182,7 @@ val prediction = for {
 } yield poisson.generator
 ```
 
-This is almost the same model as `rate` above,
-but instead of taking the real-valued `r` rate parameter as the output,
-we're producing poisson-distributed integers.
-The samples look like this:
+This is almost the same model as `rate` above, but instead of taking the real-valued `r` rate parameter as the output, we're producing poisson-distributed integers. The samples look like this:
 
 ```tut
 prediction.sample()
@@ -293,10 +195,7 @@ plot1D(prediction.sample())
 
 ## `Likelihood` and `Predictor`
 
-What if, instead of assuming that our website's sales are constant over time,
-we assume that they're growing at a constant rate?
-We might have data like the following, organized in (day, sales) pairs.
-(You may recognize this data from the start of the tour.)
+What if, instead of assuming that our website's sales are constant over time, we assume that they're growing at a constant rate? We might have data like the following, organized in (day, sales) pairs. (You may recognize this data from the start of the tour.)
 
 ```tut
 val data =  List((0,8), (1,12), (2,16), (3,20), (4,21), (5,31), (6,23), (7,33), (8,31), (9,33), (10,36), (11,42), (12,39), (13,56), (14,55), (15,63), (16,52), (17,66), (18,52), (19,80), (20,71))
@@ -308,10 +207,7 @@ Plotting the data gives a clear sense of the trend:
 plot2D(data)
 ```
 
-How should we model this? We'll need to know what the rate was on day 0 (the intercept),
-as well as how fast the rate increases each day (the slope).
-We know they're both positive and not too large, so let's keep using log-normal priors.
-(This time we can just use the builtin `LogNormal` instead of deriving it ourselves).
+How should we model this? We'll need to know what the rate was on day 0 (the intercept), as well as how fast the rate increases each day (the slope). We know they're both positive and not too large, so let's keep using log-normal priors. (This time we can just use the builtin `LogNormal` instead of deriving it ourselves).
 
 ```tut
 val prior = for {
@@ -320,12 +216,7 @@ val prior = for {
     } yield (slope, intercept)
 ```
 
-Now, for any given day `i`, we want to check the number of sales against `Poisson(intercept + slope*i)`.
-We could write some kind of recursive flatMap to build and fit each of these different distribution objects in turn,
-but this is a common enough pattern that Rainier already has something built in for it: `Predictor`.
-`Predictor` is not a `Distribution`, but instead wraps a function from `X => Distribution[Y]` for some `(X,Y)`;
-you can use this any time you have a dependent variable of type `Y` that you're modeling
-with some independent variables jointly represented as `X`.
+Now, for any given day `i`, we want to check the number of sales against `Poisson(intercept + slope*i)`. We could write some kind of recursive flatMap to build and fit each of these different distribution objects in turn, but this is a common enough pattern that Rainier already has something built in for it: `Predictor`. `Predictor` is not a `Distribution`, but instead wraps a function from `X => Distribution[Y]` for some `(X,Y)`; you can use this any time you have a dependent variable of type `Y` that you're modeling with some independent variables jointly represented as `X`.
 
 Like `Distribution`, `Predictor` implements `fit` (in fact, they both extend the `Likelihood` trait which provides that method). So we can extend the previous model to create and use a `Predictor` like this:
 
@@ -338,20 +229,14 @@ val regr = for {
 } yield (slope, intercept)
 ```
 
-As before, we're starting out by just sampling the parameters.
-By plotting them, we can see that the model's confidence in the intercept, in particular, is pretty low:
-although it's most likely to be somewhere around 8, it could be anywhere from 3 to 13 or even higher.
-Second, as you'd hope, the two parameters are anti-correlated:
+As before, we're starting out by just sampling the parameters. By plotting them, we can see that the model's confidence in the intercept, in particular, is pretty low: although it's most likely to be somewhere around 8, it could be anywhere from 3 to 13 or even higher. Second, as you'd hope, the two parameters are anti-correlated:
 a smaller intercept would imply a higher slope, and vice versa.
 
 ```tut
 plot2D(regr.sample())
 ```
 
-Alternatively, as in the earlier example, we could try to predict what will happen tomorrow.
-This is similar to calling `poisson.generator` before, but this time, we use the `predict` method on `Predictor`,
-which takes the covariate (the day, in this case), and returns a `Generator` for the dependent variable (the number of sales).
-Putting it all together, it looks like this:
+Alternatively, as in the earlier example, we could try to predict what will happen tomorrow. This is similar to calling `poisson.generator` before, but this time, we use the `predict` method on `Predictor`, which takes the covariate (the day, in this case), and returns a `Generator` for the dependent variable (the number of sales). Putting it all together, it looks like this:
 
 ```tut
 val regr2 = for {
@@ -363,30 +248,19 @@ val regr2 = for {
 } yield predictor.predict(21)
 ```
 
-Plotting this gives us a prediction which incorporates both the natural noise of a Poisson distribution
-and our uncertainty about its underlying parameterization.
+Plotting this gives us a prediction which incorporates both the natural noise of a Poisson distribution and our uncertainty about its underlying parameterization.
 
 ```tut
 plot1D(regr2.sample())
 ```
 
-Finally, let's close with a small and somewhat contrived example of a hierarchical model,
-where we have two separate regressions that share a parameter.
-For the sake of the example, let's assume that we have a second sales dataset,
-much like the first, where we know they had the same rate at the start of the observations,
-but may have grown at different rates - so their intercepts will be equal but their slopes will not.
-Here's the data:
+Finally, let's close with a small and somewhat contrived example of a hierarchical model, where we have two separate regressions that share a parameter. For the sake of the example, let's assume that we have a second sales dataset, much like the first, where we know they had the same rate at the start of the observations, but may have grown at different rates - so their intercepts will be equal but their slopes will not. Here's the data:
 
 ```tut
 val data2 = List((0,9), (1,2), (2,3), (3,17), (4,21), (5,12), (6,21), (7,19), (8,21), (9,18), (10,25), (11,27), (12,33), (13,23), (14,28), (15,45), (16,35), (17,45), (18,47), (19,54), (20,40))
 ```
 
-It's straightforward to set up two separate slopes, two separate predictors,
-but the same interecept.
-We'll still just sample the first slope so we can compare to the previous model.
-We _could_ write out the parameters of the models separately and fit each one
-to its respective data, but this is a bit tedious,
-so we can use Rainier's `Lookup` to do it more succinctly.
+It's straightforward to set up two separate slopes, two separate predictors, but the same interecept. We'll still just sample the first slope so we can compare to the previous model. We _could_ write out the parameters of the models separately and fit each one to its respective data, but this is a bit tedious, so we can use Rainier's `Lookup` to do it more succinctly.
 
 ```tut
 val allData = data.map{ case (x,y) => ((0, x), y) } ++ data2.map{ case (x, y) => ((1, x), y) }
@@ -396,14 +270,7 @@ val regr3 = for {
   _ <- Predictor.from[(Int, Int), Int, (Real, Real), Real]{ case (i,x) => Poisson(intercept + slopes(i) * x) }.fit(allData)
 } yield (slopes(0), intercept)
 ```
-Here, `i` indexes the model and `x` is the x-value of the observation.
-Plotting slope vs intercept now, we can see that,
-even though these are two separate regressions,
-we get tighter bounds than before by letting the new data influence the shared parameter.
-It makes sense that we'd get more confidence on the intercept,
-since we have two different time series to learn from now;
-but because of the anti-correlation, that also leads to somewhat more confidence
-than before on the `slope1` parameter as well.
+Here, `i` indexes the model and `x` is the x-value of the observation. Plotting slope vs intercept now, we can see that, even though these are two separate regressions, we get tighter bounds than before by letting the new data influence the shared parameter. It makes sense that we'd get more confidence on the intercept, since we have two different time series to learn from now; but because of the anti-correlation, that also leads to somewhat more confidence than before on the `slope1` parameter as well.
 
 ```tut
 plot2D(regr3.sample())
@@ -411,15 +278,7 @@ plot2D(regr3.sample())
 
 ## Learning More
 
-This tour has focused on the high-level API.
-If you want to understand more about what's going on under the hood,
-you might enjoy reading about [Real](real.md) or checking out some
-[implementation notes](impl.md).
-If you want to learn more about Bayesian modeling in general,
-[Cam Davidson Pilon's book][CDP] is an excellent resource - the examples are in Python,
-but porting them to Rainier is a good learning exercise.
-Over time, we hope to add more Rainier-specific documentation and community resources;
-for now, feel free to file a [GitHub issue][GISSUES] with any questions or problems.
+This tour has focused on the high-level API. If you want to understand more about what's going on under the hood, you might enjoy reading about [Real](real.md) or checking out some [implementation notes](impl.md). If you want to learn more about Bayesian modeling in general, [Cam Davidson Pilon's book][CDP] is an excellent resource - the examples are in Python, but porting them to Rainier is a good learning exercise. Over time, we hope to add more Rainier-specific documentation and community resources; for now, feel free to file a [GitHub issue][GISSUES] with any questions or problems.
 
 [CDP]: http://camdavidsonpilon.github.io/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers/
 [GISSUES]: https://github.com/stripe/rainier/issues

--- a/rainier-docs/src/main/tut/tour.md
+++ b/rainier-docs/src/main/tut/tour.md
@@ -10,7 +10,7 @@ import com.stripe.rainier.repl._
 import com.stripe.rainier.compute._
 ```
 
-Together, those traits let you define bayesian models in Rainier. To throw you a little bit into the deep end, here's a simple linear regression that we'll return to later. This probably won't entirely make sense yet. That's ok. Hopefully it will serve as a bit of a roadmap that put the rest of the tour in context as we build up to it. 
+Together, those traits let you define Bayesian models in Rainier. To throw you a little bit into the deep end, here's a simple linear regression that we'll return to later. This probably won't entirely make sense yet. That's ok. Hopefully it will serve as a bit of a roadmap that put the rest of the tour in context as we build up to it. 
 
 ```scala
 val data =  List((0,8), (1,12), (2,16), (3,20), (4,21), (5,31), (6,23), (7,33), (8,31), (9,33), (10,36), (11,42), (12,39), (13,56), (14,55), (15,63), (16,52), (17,66), (18,52), (19,80), (20,71))
@@ -167,7 +167,7 @@ e_x.value == rate.value
 
 So, for the same input in the latent parameter space, `e_x` and `rate` will produce the same output.
 
-However, when we `flatMap`, behind the scenes we're also working with the `density` object. Specifically, when we start with one `RandomVariable` (like `e_x`), and use `flatMap` to flatten another `RandomVariable` into it (like the result of `fit`), the resulting `RandomVariable` (like `rate`) will have a `density` that *combines* the densities of the other two `RandomVariable`s. Put another way, `flatMap` is the bayesian update operation: you're putting in a prior, coming up with a likelihood, and getting back the posterior. That's what the `fit` line is doing: constructing a likelihood function that we can incorporate into our posterior density. And if we look at the densities, we'll see that they are indeed different:
+However, when we `flatMap`, behind the scenes we're also working with the `density` object. Specifically, when we start with one `RandomVariable` (like `e_x`), and use `flatMap` to flatten another `RandomVariable` into it (like the result of `fit`), the resulting `RandomVariable` (like `rate`) will have a `density` that *combines* the densities of the other two `RandomVariable`s. Put another way, `flatMap` is the Bayesian update operation: you're putting in a prior, coming up with a likelihood, and getting back the posterior. That's what the `fit` line is doing: constructing a likelihood function that we can incorporate into our posterior density. And if we look at the densities, we'll see that they are indeed different:
 
 ```tut
 e_x.density == rate.density

--- a/rainier-docs/src/main/tut/tour.md
+++ b/rainier-docs/src/main/tut/tour.md
@@ -10,8 +10,7 @@ import com.stripe.rainier.repl._
 import com.stripe.rainier.compute._
 ```
 
-Together, those traits let you define Bayesian models in Rainier. To throw you a little bit into the deep end, here's a simple linear regression that we'll return to later.
-This probably won't entirely make sense yet. That's ok. Hopefully it will serve as a bit of a roadmap that put the rest of the tour in context as we build up to it.
+Together, those traits let you define Bayesian models in Rainier. To throw you a little bit into the deep end, here's a simple linear regression that we'll return to later. This probably won't entirely make sense yet. That's ok. Hopefully it will serve as a bit of a roadmap that put the rest of the tour in context as we build up to it.
 
 ```tut
 val data =  List((0,8), (1,12), (2,16), (3,20), (4,21), (5,31), (6,23), (7,33), (8,31), (9,33), (10,36), (11,42), (12,39), (13,56), (14,55), (15,63), (16,52), (17,66), (18,52), (19,80), (20,71))
@@ -29,9 +28,7 @@ model.sample(10)
 
 The starting point for almost any work in Rainier will be some object that implements `rainier.core.Distribution[T]`.
 
-Rainier implements various familiar families of probability distributions like the [Normal](https://en.wikipedia.org/wiki/Normal_distribution) distribution,
-the [Uniform][UC] distribution, and the [Poisson](https://en.wikipedia.org/wiki/Poisson_distribution) distribution.
-You will find these three in [Continuous.scala](/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala) and [Discrete.scala](/rainier-core/src/main/scala/com/stripe/rainier/core/Discrete.scala) - along with a few more, and we'll keep adding them as the need arises. You construct a distribution from its parameters, usually with the `apply` method on the object representing its family. So for example, this is a normal distribution with a mean of 0 and a standard deviation of 1:
+Rainier implements various familiar families of probability distributions like the [Normal](https://en.wikipedia.org/wiki/Normal_distribution) distribution, the [Uniform][UC] distribution, and the [Poisson](https://en.wikipedia.org/wiki/Poisson_distribution) distribution. You will find these three in [Continuous.scala](/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala) and [Discrete.scala](/rainier-core/src/main/scala/com/stripe/rainier/core/Discrete.scala) - along with a few more, and we'll keep adding them as the need arises. You construct a distribution from its parameters, usually with the `apply` method on the object representing its family. So for example, this is a normal distribution with a mean of 0 and a standard deviation of 1:
 
 ```tut
 val normal: Distribution[Double] = Normal(0,1)
@@ -47,12 +44,9 @@ We'll start by exploring each of these in turn.
 
 ## `param` and `RandomVariable`
 
-Every model in Rainier has some parameters whose values are unknown (if that's not true for your model, you don't need an inference library!).
-The first step in constructing a model is to set up these parameters.
+Every model in Rainier has some parameters whose values are unknown (if that's not true for your model, you don't need an inference library!). The first step in constructing a model is to set up these parameters.
 
-You create a parameter by calling `param` on the distribution that represents the prior for that parameter. `param` is only implemented for continuous distributions
-(which extend `Continuous`, which extends `Distribution[Double]`). As you might be able to tell from those types:
-in Rainier, all parameters are continuous real scalar values. There's no support for discrete model parameters, and there's no support (or need) for explicit vectorization.
+You create a parameter by calling `param` on the distribution that represents the prior for that parameter. `param` is only implemented for continuous distributions(which extend `Continuous`, which extends `Distribution[Double]`). As you might be able to tell from those types: in Rainier, all parameters are continuous real scalar values. There's no support for discrete model parameters, and there's no support (or need) for explicit vectorization.
 
 Let's use that same `Normal(0,1)` distribution as a prior for a new parameter:
 
@@ -134,7 +128,7 @@ Looks like our daily rate is probably somewhere between 6 and 9, and is in fact 
 
 Please feel free to skip this section if it's not helping you.
 
-One thing that sometimes confuses people at this stage is, what is the line with `fit` actually doing? It seems to return some value `poisson` that we just ignore. (That object, by the way, is just the `Poisson(r)` distribution object that we used to do the `fit`.) And yet the line is clearly doing something, because sampling from `rate` gives quite different results from just sampling directly from `e_x`.
+One thing that sometimes confuses people at this stage is, what is the line with `fit` actually doing? It seems to return a `poisson` object that we just ignore. (That object, by the way, is just the `Poisson(r)` distribution object that we used to do the `fit`.) And yet the line is clearly doing something, because sampling from `rate` gives quite different results from just sampling directly from `e_x`.
 
 The key is to remember that a `RandomVariable` has two parts: a `value` and a `density`. Mathematically, you should think of these as two different *functions* of the same latent parameter space `Q`. That is, you should think of `value` as being some deterministic function `f = F(q)`, and `density` as being the (unnormalized) probability function `P(Q=q)`.
 

--- a/rainier-docs/src/main/tut/tour.md
+++ b/rainier-docs/src/main/tut/tour.md
@@ -296,7 +296,7 @@ or we can use Rainier's `Lookup` to package the two slopes into a single `Random
 
 ```tut
 val allData = data.map{ case (x,y) => ((0, x), y) } ++ data2.map{ case (x, y) => ((1, x), y) }
-val regLookup = for {
+val regr4 = for {
   slopes <- RandomVariable.fill(2)(LogNormal(0,1).param).map(Lookup(_))
   intercept <- LogNormal(0,1).param
   _ <- Predictor.fromIntPair{ case (index, x) => Poisson(intercept + slopes(index) * x) }.fit(allData)
@@ -306,7 +306,7 @@ val regLookup = for {
 Plotting slope vs. intercept now, we see that, even though these are two separate regressions, we get tighter bounds than before by letting the new data influence the shared parameter. It makes sense that we'd get more confidence on the intercept, since we have two different time series to learn from now; but because of the anti-correlation, that also leads to somewhat more confidence than before on the `slopes(0)` parameter as well.
 
 ```tut
-plot2D(regLookup.sample())
+plot2D(regr4.sample())
 ```
 
 ## Learning More

--- a/rainier-docs/src/main/tut/tour.md
+++ b/rainier-docs/src/main/tut/tour.md
@@ -110,7 +110,7 @@ val poisson9: RandomVariable[_] = Poisson(9).fit(sales)
 val poisson10: RandomVariable[_] = Poisson(10).fit(sales)
 ```
 
-Although it's almost never necessary, we can reach into any `RandomVariable` and get its current probability `density`:
+Although it's almost never necessary, we can reach into any `RandomVariable` and get its current probability `densityValue`:
 
 ```tut
 poisson9.densityValue

--- a/rainier-docs/src/main/tut/tour.md
+++ b/rainier-docs/src/main/tut/tour.md
@@ -20,6 +20,8 @@ val model = for {
     intercept <- LogNormal(0,1).param
     regression <- Predictor.fromInt{x => Poisson(x*slope + intercept)}.fit(data)
 } yield regression.predict(21)
+
+model.sample(10)
 ```
 
 ## Distribution

--- a/rainier-docs/src/main/tut/tour.md
+++ b/rainier-docs/src/main/tut/tour.md
@@ -129,7 +129,7 @@ We can see here that our data is about 3x as likely to have come from a `Poisson
 val poisson: RandomVariable[_] = e_x.flatMap{r => Poisson(r).fit(sales)}
 ```
 
-By the way: before, when we looked at `poisson9.densityValue`, the model had no parameters and so we got a constant value back. Now, since the model's density is a function of the parameter value, we get something more opaque back. This is why inspecting `density` is not normally useful.
+By the way: before, when we looked at `poisson9.densityValue`, the model had no parameters and so we got a constant value back. Now, since the model's density is a function of the parameter value, we get something more opaque back. This is why inspecting the density is not normally useful.
 
 ```tut
 poisson.densityValue

--- a/rainier-docs/src/main/tut/tour.md
+++ b/rainier-docs/src/main/tut/tour.md
@@ -110,9 +110,9 @@ val poisson9: RandomVariable[_] = Poisson(9).fit(sales)
 val poisson10: RandomVariable[_] = Poisson(10).fit(sales)
 ```
 
-Since it is almost never necessary to reach into a `RandomVariable` and get its current probability `density`, Rainier makes this hard to do. Taking on faith momentarily that
+A `RandomVariable`'s density is a rather opaque objects and, since it is almost never necessary to reach into a `RandomVariable` and get its current probability `density`, Rainier makes this hard to do. Taking on faith momentarily that
 
-```tut
+```tut:silent
 val poisson9density = -18.03523006575617
 val poisson10density = -19.135041188917896
 ```
@@ -129,13 +129,14 @@ We can see here that our data is about 3x as likely to have come from a `Poisson
 val poisson: RandomVariable[_] = e_x.flatMap{r => Poisson(r).fit(sales)}
 ```
 
-By the way: before, when we looked at `poisson9.density`, the model had no parameters and so we got a constant value back. Now, since the model's density is a function of the parameter value, we get something more opaque back. This is why inspecting `density` is not normally useful.
+Reaching under the hood for a second: our `poisson9`'s `density` had no parameters whereas now, our model's density is a function of the parameter value
 
-```
-poisson.density
+```tut
+poisson9.density().nVars
+poisson.density().nVars
 ```
 
-Instead, we can sample the quantity we're actually interested in. To start with, let's try to sample the rate parameter of the Poisson, conditioned by our observed data. Here's almost the same thing we had above, recreated with the slightly friendlier `for` syntax, and yielding the `r` parameter at the end:
+As mentioned, the `density` itself is rather opaque so instead of manipulating it directly, we can sample the quantity we're actually interested in. To start with, let's try to sample the rate parameter of the Poisson, conditioned by our observed data. Here's almost the same thing we had above, recreated with the slightly friendlier `for` syntax, and yielding the `r` parameter at the end:
 
 ```tut
 val rate = for {

--- a/rainier-docs/src/main/tut/tour.md
+++ b/rainier-docs/src/main/tut/tour.md
@@ -271,14 +271,12 @@ val regLookup = for {
 } yield (slopes(0), intercept)
 ```
 
-Plotting slope vs. intercept now, we first see that they do agree.
+Plotting slope vs. intercept now, we see that, even though these are two separate regressions, we get tighter bounds than before by letting the new data influence the shared parameter. It makes sense that we'd get more confidence on the intercept, since we have two different time series to learn from now; but because of the anti-correlation, that also leads to somewhat more confidence than before on the `slopes(0)` parameter as well.
 
 ```tut
-plot2D(regr3.sample())
 plot2D(regLookup.sample())
 ```
 
-Mathematically, we see that, even though these are two separate regressions, we get tighter bounds than before by letting the new data influence the shared parameter. It makes sense that we'd get more confidence on the intercept, since we have two different time series to learn from now; but because of the anti-correlation, that also leads to somewhat more confidence than before on the `slope1` parameter as well.
 ## Learning More
 
 This tour has focused on the high-level API. If you want to understand more about what's going on under the hood, you might enjoy reading about [Real](real.md) or checking out some [implementation notes](impl.md). If you want to learn more about Bayesian modeling in general, [Cam Davidson Pilon's book][CDP] is an excellent resource - the examples are in Python, but porting them to Rainier is a good learning exercise. Over time, we hope to add more Rainier-specific documentation and community resources; for now, feel free to file a [GitHub issue][GISSUES] with any questions or problems.

--- a/rainier-docs/src/main/tut/tour.md
+++ b/rainier-docs/src/main/tut/tour.md
@@ -110,7 +110,7 @@ val poisson9: RandomVariable[_] = Poisson(9).fit(sales)
 val poisson10: RandomVariable[_] = Poisson(10).fit(sales)
 ```
 
-A `RandomVariable`'s density is a rather opaque objects and, since it is almost never necessary to reach into a `RandomVariable` and get its current probability `density`, Rainier makes this hard to do. Taking on faith momentarily that
+A `RandomVariable`'s density is a rather opaque object and, since it is almost never necessary to reach into a `RandomVariable` and get its current probability `density`, Rainier makes this hard to do. Taking on faith momentarily that
 
 ```tut:silent
 val poisson9density = -18.03523006575617
@@ -136,7 +136,7 @@ poisson9.density().nVars
 poisson.density().nVars
 ```
 
-As mentioned, the `density` itself is rather opaque so instead of manipulating it directly, we can sample the quantity we're actually interested in. To start with, let's try to sample the rate parameter of the Poisson, conditioned by our observed data. Here's almost the same thing we had above, recreated with the slightly friendlier `for` syntax, and yielding the `r` parameter at the end:
+Rather than manipulating the `density` directly, we can sample the quantity we're actually interested in. To start with, let's try to sample the rate parameter of the Poisson, conditioned on our observed data. Here's almost the same thing we had above, recreated with the slightly friendlier `for` syntax, and yielding the `r` parameter at the end:
 
 ```tut
 val rate = for {

--- a/rainier-docs/src/main/tut/tour.md
+++ b/rainier-docs/src/main/tut/tour.md
@@ -105,12 +105,12 @@ val sales = List(4, 4, 7, 11, 8, 12, 10)
 
 We can model the number of sales we get on each day as a poisson distribution parameterized by the underlying rate. For example, looking at that data, we might guess that it came from a `Poisson(9)` or `Poisson(10)`. We can test those hypotheses by using the `fit` method available on all `Distribution` objects. Since `Poisson` is a `Distribution[Int]`, its `fit` will accept either `Int` or `Seq[Int]`, and return a `RandomVariable` which encodes the likelihood of the provided data being produced by that distribution. (We're not going to worry right now about what *kind* of `RandomVariable` it is, since we're only really interested in the likelihood).
 
-```tut
+```tut:silent
 val poisson9: RandomVariable[_] = Poisson(9).fit(sales)
 val poisson10: RandomVariable[_] = Poisson(10).fit(sales)
 ```
 
-Since it is almost never necessary to can reach into a `RandomVariable` and get its current probability `density`, Rainier makes this hard to do. Taking on faith momentarily that
+Since it is almost never necessary to reach into a `RandomVariable` and get its current probability `density`, Rainier makes this hard to do. Taking on faith momentarily that
 
 ```tut
 val poisson9density = -18.03523006575617
@@ -119,8 +119,8 @@ val poisson10density = -19.135041188917896
 
 we can find the likelihood ratio of these two hypotheses. Since the density is stored in log space, the best way to do this numerically is to subtract the logs first before exponentiating:
 
-```
-val lr = (poisson9density - poisson10density).exp
+```tut
+val lr = math.exp(poisson9density - poisson10density)
 ```
 
 We can see here that our data is about 3x as likely to have come from a `Poisson(9)` as it is to have come from a `Poisson(10)`. We could keep doing this with a large number of values to build up a sense of the rate distribution, but it would be tedious, and we'd be ignoring any prior we had on the rate. Instead, the right way to do this in Rainier is to make the rate a parameter, and let the library do the hard work of exploring the space. Specifically, we can use `flatMap` to chain the creation of the parameter with the creation and fit of the `Poisson` distribution. Since we want our rate to be a positive number, and expect it to be more likely to be on the small side than the large side, the log-normal parameter we created earlier as `e_x` seems like a reasonable choice.

--- a/rainier-docs/src/main/tut/tour.md
+++ b/rainier-docs/src/main/tut/tour.md
@@ -110,17 +110,17 @@ val poisson9: RandomVariable[_] = Poisson(9).fit(sales)
 val poisson10: RandomVariable[_] = Poisson(10).fit(sales)
 ```
 
-A `RandomVariable`'s density is a rather opaque object and, since it is almost never necessary to reach into a `RandomVariable` and get its current probability `density`, Rainier makes this hard to do. Taking on faith momentarily that
-
-```tut:silent
-val poisson9density = -18.03523006575617
-val poisson10density = -19.135041188917896
-```
-
-we can find the likelihood ratio of these two hypotheses. Since the density is stored in log space, the best way to do this numerically is to subtract the logs first before exponentiating:
+Although it's almost never necessary, we can reach into any `RandomVariable` and get its current probability `density`:
 
 ```tut
-val lr = math.exp(poisson9density - poisson10density)
+poisson9.densityValue()
+poisson10.densityValue()
+```
+
+We can use this to find the likelihood ratio of these two hypotheses. Since the density is stored in log space, the best way to do this numerically is to subtract the logs first before exponentiating:
+
+```tut
+val lr = (poisson9.densityValue() - poisson10.densityValue()).exp
 ```
 
 We can see here that our data is about 3x as likely to have come from a `Poisson(9)` as it is to have come from a `Poisson(10)`. We could keep doing this with a large number of values to build up a sense of the rate distribution, but it would be tedious, and we'd be ignoring any prior we had on the rate. Instead, the right way to do this in Rainier is to make the rate a parameter, and let the library do the hard work of exploring the space. Specifically, we can use `flatMap` to chain the creation of the parameter with the creation and fit of the `Poisson` distribution. Since we want our rate to be a positive number, and expect it to be more likely to be on the small side than the large side, the log-normal parameter we created earlier as `e_x` seems like a reasonable choice.

--- a/rainier-docs/src/main/tut/tour.md
+++ b/rainier-docs/src/main/tut/tour.md
@@ -113,14 +113,14 @@ val poisson10: RandomVariable[_] = Poisson(10).fit(sales)
 Although it's almost never necessary, we can reach into any `RandomVariable` and get its current probability `density`:
 
 ```tut
-poisson9.densityValue()
-poisson10.densityValue()
+poisson9.densityValue
+poisson10.densityValue
 ```
 
 We can use this to find the likelihood ratio of these two hypotheses. Since the density is stored in log space, the best way to do this numerically is to subtract the logs first before exponentiating:
 
 ```tut
-val lr = (poisson9.densityValue() - poisson10.densityValue()).exp
+val lr = (poisson9.densityValue - poisson10.densityValue).exp
 ```
 
 We can see here that our data is about 3x as likely to have come from a `Poisson(9)` as it is to have come from a `Poisson(10)`. We could keep doing this with a large number of values to build up a sense of the rate distribution, but it would be tedious, and we'd be ignoring any prior we had on the rate. Instead, the right way to do this in Rainier is to make the rate a parameter, and let the library do the hard work of exploring the space. Specifically, we can use `flatMap` to chain the creation of the parameter with the creation and fit of the `Poisson` distribution. Since we want our rate to be a positive number, and expect it to be more likely to be on the small side than the large side, the log-normal parameter we created earlier as `e_x` seems like a reasonable choice.
@@ -129,14 +129,14 @@ We can see here that our data is about 3x as likely to have come from a `Poisson
 val poisson: RandomVariable[_] = e_x.flatMap{r => Poisson(r).fit(sales)}
 ```
 
-Reaching under the hood for a second: our `poisson9`'s `density` had no parameters whereas now, our model's density is a function of the parameter value
+By the way: before, when we looked at `poisson9.densityValue`, the model had no parameters and so we got a constant value back. Now, since the model's density is a function of the parameter value, we get something more opaque back. This is why inspecting `density` is not normally useful.
 
 ```tut
-poisson9.density().nVars
-poisson.density().nVars
+poisson.densityValue
 ```
 
-Rather than manipulating the `density` directly, we can sample the quantity we're actually interested in. To start with, let's try to sample the rate parameter of the Poisson, conditioned on our observed data. Here's almost the same thing we had above, recreated with the slightly friendlier `for` syntax, and yielding the `r` parameter at the end:
+Instead, we can sample the quantity we're actually interested in. To start with, let's try to sample the rate parameter of the Poisson, conditioned by our observed data. Here's almost the same thing we had above, recreated with the slightly friendlier `for` syntax, and yielding the `r` parameter at the end:
+
 
 ```tut
 val rate = for {

--- a/rainier-docs/src/main/tut/tour.md
+++ b/rainier-docs/src/main/tut/tour.md
@@ -1,8 +1,10 @@
 # A Tour of Rainier's Core
 
-Hello! This document will provide a quick tour through the most important parts of Rainier's core. If you'd like to follow along with this tour, `sbt "project rainierCore" console` will get you to a Scala REPL.
+Hello! This document will provide a quick tour through the most important parts of Rainier's core.
+If you'd like to follow along with this tour, `sbt "project rainierCore" console` will get you to a Scala REPL.
 
-The `rainier.core` package defines some key traits like `Distribution`, `RandomVariable`, `Likelihood`, and `Predictor`. Let's import it, along with a `repl` package that gives us some useful utilities.
+The `rainier.core` package defines some key traits like `Distribution`, `RandomVariable`, `Likelihood`, and `Predictor`.
+Let's import it, along with a `repl` package that gives us some useful utilities.
 
 ```tut:silent
 import com.stripe.rainier.core._
@@ -10,15 +12,18 @@ import com.stripe.rainier.repl._
 import com.stripe.rainier.compute._
 ```
 
-Together, those traits let you define Bayesian models in Rainier. To throw you a little bit into the deep end, here's a simple linear regression that we'll return to later. This probably won't entirely make sense yet. That's ok. Hopefully it will serve as a bit of a roadmap that put the rest of the tour in context as we build up to it. 
+Together, those traits let you define Bayesian models in Rainier.
+To throw you a little bit into the deep end, here's a simple linear regression that we'll return to later.
+This probably won't entirely make sense yet. That's ok.
+Hopefully it will serve as a bit of a roadmap that put the rest of the tour in context as we build up to it.
 
-```scala
+```tut
 val data =  List((0,8), (1,12), (2,16), (3,20), (4,21), (5,31), (6,23), (7,33), (8,31), (9,33), (10,36), (11,42), (12,39), (13,56), (14,55), (15,63), (16,52), (17,66), (18,52), (19,80), (20,71))
 
 val model = for {
-    slope <- LogNormal(0,1).param
-    intercept <- LogNormal(0,1).param
-    regression <- Predictor.fromInt{x => Poisson(x*slope + intercept)}.fit(data)
+  slope <- LogNormal(0,1).param
+  intercept <- LogNormal(0,1).param
+  regression <- Predictor.fromInt{x => Poisson(x*slope + intercept)}.fit(data)
 } yield regression.predict(21)
 
 model.sample(10)
@@ -29,22 +34,44 @@ model.sample(10)
 The starting point for almost any work in Rainier will be some object that implements
 `rainier.core.Distribution[T]`.
 
-Rainier implements various familiar families of probability distributions like the [Normal](https://en.wikipedia.org/wiki/Normal_distribution) distribution,
-the [Uniform](https://en.wikipedia.org/wiki/Uniform_distribution_(continuous)) distribution, and the [Poisson](https://en.wikipedia.org/wiki/Poisson_distribution) distribution. You will find these three in [Continuous.scala](/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala) and [Discrete.scala](/rainier-core/src/main/scala/com/stripe/rainier/core/Discrete.scala) - along with a few more, and we'll keep adding them as the need arises.
+Rainier implements various familiar families of probability distributions like
+the [Normal](https://en.wikipedia.org/wiki/Normal_distribution) distribution,
+the [Uniform][UC] distribution,
+and the [Poisson](https://en.wikipedia.org/wiki/Poisson_distribution) distribution.
+You will find these three in [Continuous.scala](/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala)
+and [Discrete.scala](/rainier-core/src/main/scala/com/stripe/rainier/core/Discrete.scala) -
+along with a few more, and we'll keep adding them as the need arises.
 
-You construct a distribution from its parameters, usually with the `apply` method on the object representing its family. So for example, this is a normal distribution with a mean of 0 and a standard deviation of 1:
+You construct a distribution from its parameters, usually with the `apply` method on the object representing its family.
+So for example, this is a normal distribution with a mean of 0 and a standard deviation of 1:
 
 ```tut
 val normal: Distribution[Double] = Normal(0,1)
 ```
 
-In Rainier, `Distribution` objects play three different roles. `Continuous` distributions (like `Normal`), implement `param`, and all distributions implement `fit` and `generator`. Each of these methods is central to one of the three stages of building a model in Rainier: defining your parameters and their priors; fitting the parameters to some observed data; and using the fit parameters to generate samples of some posterior distribution of interest. We'll start by exploring each of these in turn.
+In Rainier, `Distribution` objects play three different roles.
+`Continuous` distributions (like `Normal`), implement `param`, and all distributions implement `fit` and `generator`.
+Each of these methods is central to one of the three stages of building a model in Rainier:
+
+* defining your parameters and their priors
+* fitting the parameters to some observed data and
+* using the fit parameters to generate samples of some posterior distribution of interest.
+
+We'll start by exploring each of these in turn.
 
 ## `param` and `RandomVariable`
 
-Every model in Rainier has some parameters whose values are unknown (if that's not true for your model, you don't need an inference library!).  The first step in constructing a model is to set up these parameters. 
+Every model in Rainier has some parameters whose values are unknown
+(if that's not true for your model, you don't need an inference library!).
+The first step in constructing a model is to set up these parameters.
 
-You create a parameter by calling `param` on the distribution that represents the prior for that parameter. `param` is only implemented for continuous distributions (which extend `Continuous`, which extends `Distribution[Double]`). As you might be able to tell from those types: in Rainier, all parameters are continuous real scalar values. There's no support for discrete model parameters, and there's no support (or need) for explicit vectorization.
+You create a parameter by calling `param` on the distribution that represents
+the prior for that parameter. `param` is only implemented for continuous distributions
+(which extend `Continuous`, which extends `Distribution[Double]`).
+As you might be able to tell from those types:
+in Rainier, all parameters are continuous real scalar values.
+There's no support for discrete model parameters, and there's no support (or need)
+for explicit vectorization.
 
 Let's use that same `Normal(0,1)` distribution as a prior for a new parameter:
 
@@ -52,28 +79,38 @@ Let's use that same `Normal(0,1)` distribution as a prior for a new parameter:
 val x = Normal(0,1).param
 ```
 
-You can see that the type of `x` is `RandomVariable[Real]`. `RandomVariable` pairs a type of value (in this case, a real number) with some knowledge of the relative probability density of different values of that type. We can use this knowledge to produce a sample of these possible values:
+You can see that the type of `x` is `RandomVariable[Real]`.
+`RandomVariable` pairs a type of value (in this case, a real number)
+with some knowledge of the relative probability density of different values of that type.
+We can use this knowledge to produce a sample of these possible values:
 
 ```tut
 x.sample()
 ```
 
-Each element of the list above represents a single sample from the distribution over `x`. It's easier to understand these if we plot them as a histogram:
+Each element of the list above represents a single sample from the distribution over `x`.
+It's easier to understand these if we plot them as a histogram:
 
 ```tut
 plot1D(x.sample())
 ```
 
-Since the only information we have about `x` so far is its `Normal` prior, this distribution unsurprisingly looks  normal. Later we'll see how to update our beliefs about `x` based on observational data.
+Since the only information we have about `x` so far is its `Normal` prior, this distribution unsurprisingly looks  normal.
+Later we'll see how to update our beliefs about `x` based on observational data.
 
-For now, though, let's explore what we can do just with priors. `RandomVariable` has more than just `sample`: you can use the familiar collection methods like `map`, `flatMap`, and `zip` to transform and combine the parameters you create. For example, we can create a log-normal distribution just by mapping over `e^x`:
+For now, though, let's explore what we can do just with priors.
+`RandomVariable` has more than just `sample`:
+you can use the familiar collection methods like `map`, `flatMap`, and `zip`
+to transform and combine the parameters you create.
+For example, we can create a log-normal distribution just by mapping over `e^x`:
 
 ```tut
 val e_x = x.map(_.exp)
 plot1D(e_x.sample())
 ```
 
-Or we can create another `Normal` parameter and zip the two together to produce a 2D gaussian. Since there's nothing relating these two parameters to each other, you can see in the plot that they're completely independent.
+Or we can create another `Normal` parameter and zip the two together to produce a 2D gaussian.
+Since there's nothing relating these two parameters to each other, you can see in the plot that they're completely independent.
 
 ```tut
 val y = Normal(0,1).param
@@ -81,7 +118,10 @@ val xy = x.zip(y)
 plot2D(xy.sample())
 ```
 
-Finally, we can use `flatMap` to create two parameters that *are* related to each other. In particular, we'll create a new parameter `z` that we believe to be very close to `x`: its prior is a `Normal` centered on `x` with a very small standard deviation. We'll then make a 2D plot of `(x,z)` to see the relationship.
+Finally, we can use `flatMap` to create two parameters that *are* related to each other.
+In particular, we'll create a new parameter `z` that we believe to be very close to `x`:
+its prior is a `Normal` centered on `x` with a very small standard deviation.
+We'll then make a 2D plot of `(x,z)` to see the relationship.
 
 ```tut
 val z = x.flatMap{a => Normal(a, 0.1).param}
@@ -89,52 +129,47 @@ val xz = x.zip(z)
 plot2D(xz.sample())
 ```
 
-You can see that although we still sample from the full range of `x` values, for any given sample, `x` and `z` are quite close to each other.
+You can see that although we still sample from the full range of `x` values,
+for any given sample, `x` and `z` are quite close to each other.
 
-A note about the `Real` type: you may have noticed that, for example, `x` is a `RandomVariable[Real]` or that `normal.mean` was a `Real`. What's that? `Real` is a special numeric type used by Rainier to represent your model's parameter values, and any values derived from those parameters (if you do arithmetic on a `Real`, you get back another `Real`). It's also the type that all the distribution objects like `Normal` expect to be parameterized with, so that you can chain things together like we did for `z` - though you can also use regular `Int` or `Double` values here and they'll get wrapped automatically. `Real` is, by design, an extremely restricted type: it only supports the 4 basic arithmetic operations, `log`, and `exp`. Restricting it in this way helps keep Rainier models as efficient to perform inference on as possible. At sampling time, however, any `Real` outputs are converted to `Double` so that you can work with them from there.
+A note about the `Real` type: you may have noticed that, for example,
+`x` is a `RandomVariable[Real]` or that `normal.mean` was a `Real`. What's that?
+`Real` is a special numeric type used by Rainier to represent your model's parameter values,
+and any values derived from those parameters (if you do arithmetic on a `Real`, you get back another `Real`).
+It's also the type that all the distribution objects like `Normal` expect to be parameterized with,
+so that you can chain things together like we did for `z` -
+though you can also use regular `Int` or `Double` values here and they'll get wrapped automatically.
+`Real` is, by design, an extremely restricted type:
+it only supports the 4 basic arithmetic operations, `log`, and `exp`.
+Restricting it in this way helps keep Rainier models as efficient to perform inference on as possible.
+At sampling time, however, any `Real` outputs are converted to `Double` so that you can work with them from there.
 
 ## `fit`
 
-Just like every Rainier model has one more more parameters with priors, every Rainier model uses some observational data to update our belief about the values of those parameters (again, if your model doesn't have this, you're probably using the wrong library).
+Just like every Rainier model has one more more parameters with priors,
+every Rainier model uses some observational data to update our belief about
+the values of those parameters (again, if your model doesn't have this, you're probably using the wrong library).
 
-Let's say that we have some data that represents the last week's worth of sales on a website, at (we believe) a constant daily rate, and we'd like to know how many sales we might get tomorrow. Here's our data:
+Let's say that we have some data that represents the last week's worth of sales
+on a website, at (we believe) a constant daily rate, and we'd like to know
+how many sales we might get tomorrow.
+Here's our data:
 
-```tut
+```tut:silent
 val sales = List(4, 4, 7, 11, 8, 12, 10)
 ```
 
-We can model the number of sales we get on each day as a poisson distribution parameterized by the underlying rate. For example, looking at that data, we might guess that it came from a `Poisson(9)` or `Poisson(10)`. We can test those hypotheses by using the `fit` method available on all `Distribution` objects. Since `Poisson` is a `Distribution[Int]`, its `fit` will accept either `Int` or `Seq[Int]`, and return a `RandomVariable` which encodes the likelihood of the provided data being produced by that distribution. (We're not going to worry right now about what *kind* of `RandomVariable` it is, since we're only really interested in the likelihood).
-
-```tut
-val poisson9: RandomVariable[_] = Poisson(9).fit(sales)
-val poisson10: RandomVariable[_] = Poisson(10).fit(sales)
-```
-
-Although it's almost never necessary, we can reach into any `RandomVariable` and get its current probability `density`:
-
-```
-poisson9.density
-```
-
-We can use this to find the likelihood ratio of these two hypotheses. Since the density is stored in log space, the best way to do this numerically is to subtract the logs first before exponentiating:
-
-```
-val lr = (poisson9.density - poisson10.density).exp
-```
-
-We can see here that our data is about 3x as likely to have come from a `Poisson(9)` as it is to have come from a `Poisson(10)`. We could keep doing this with a large number of values to build up a sense of the rate distribution, but it would be tedious, and we'd be ignoring any prior we had on the rate. Instead, the right way to do this in Rainier is to make the rate a parameter, and let the library do the hard work of exploring the space. Specifically, we can use `flatMap` to chain the creation of the parameter with the creation and fit of the `Poisson` distribution. Since we want our rate to be a positive number, and expect it to be more likely to be on the small side than the large side, the log-normal parameter we created earlier as `e_x` seems like a reasonable choice.
-
-```tut
-val poisson: RandomVariable[_] = e_x.flatMap{r => Poisson(r).fit(sales)}
-```
-
-By the way: before, when we looked at `poisson9.density`, the model had no parameters and so we got a constant value back. Now, since the model's density is a function of the parameter value, we get something more opaque back. This is why inspecting `density` is not normally useful.
-
-```
-poisson.density
-```
-
-Instead, we can sample the quantity we're actually interested in. To start with, let's try to sample the rate parameter of the Poisson, conditioned by our observed data. Here's almost the same thing we had above, recreated with the slightly friendlier `for` syntax, and yielding the `r` parameter at the end:
+We can model the number of sales we get on each day as a Poisson distribution
+parameterized by the underlying rate.
+Looking at the data, we might guess that it came from a `Poisson(9)` or `Poisson(10)`.
+In Rainier, we define our model and it fit to the observed data.
+Since we want our rate to be a positive number,
+and expect it to be more likely to be on the small side than the large side,
+the log-normal parameter we created earlier as `e_x` seems like a reasonable choice.
+We use `flatMap` to chain the creation of the parameter with the creation and
+fit of the `Poisson` distribution.
+Although we _can_ do this with explicit `flatMaps` and `maps`,
+it's much neater with `for{...}` syntax.
 
 ```tut
 val rate = for {
@@ -143,7 +178,9 @@ val rate = for {
 } yield r
 ```
 
-This is our first "full" model: we have a parameter with a log-normal prior, bundled into the `RandomVariable` named `e_x`; we use that parameter to initialize a `Poisson` noise distribution which we fit to our observations; and at the end, we output the same parameter (referenced by `r`) as the quantity we're interested in sampling from the posterior.
+This is our first "full" model: we have a parameter with a log-normal prior bundled into the `RandomVariable` named `e_x`;
+we use that parameter to initialize a `Poisson` noise distribution which we fit to our observations;
+and at the end, we output the same parameter (referenced by `r`) as the quantity we're interested in sampling from the posterior.
 
 Let's plot the results!
 
@@ -151,17 +188,29 @@ Let's plot the results!
 plot1D(rate.sample())
 ```
 
-Looks like our daily rate is probably somewhere between 6 and 9, which corresponds well to the steep 3x dropoff we saw before between 9 and 10.
+Looks like our daily rate is probably somewhere between 6 and 9,
+and is in fact much more likely to be around 9 than 10.
 
 ## A mathematical digression
 
 Please feel free to skip this section if it's not helping you.
 
-One thing that sometimes confuses people at this stage is, what is the line with `fit` actually doing? It seems to return a `poisson` object that we just ignore. (That object, by the way, is just the `Poisson(r)` distribution object that we used to do the `fit`.) And yet the line is clearly doing something, because sampling from `rate` gives quite different results from just sampling directly from `e_x`.
+One thing that sometimes confuses people at this stage is,
+what is the line with `fit` actually doing?
+It seems to return some value `poisson` that we just ignore.
+(That object, by the way, is just the `Poisson(r)` distribution object that we used
+to do the `fit`.)
+And yet the line is clearly doing something, because sampling from `rate` gives quite different results from just sampling directly from `e_x`.
 
-The key is to remember that a `RandomVariable` has two parts: a `value` and a `density`. Mathematically, you should think of these as two different *functions* of the same latent parameter space `Q`. That is, you should think of `value` as being some deterministic function `f = F(q)`, and `density` as being the (unnormalized) probability function `P(Q=q)`.
+The key is to remember that a `RandomVariable` has two parts: a `value` and a `density`.
+Mathematically, you should think of these as two different *functions* of the same latent parameter space `Q`.
+That is, you should think of `value` as being some deterministic function `f = F(q)`,
+and `density` as being the (unnormalized) probability function `P(Q=q)`.
 
- When we `map` or `flatMap` a `RandomVariable` (whether explicitly or inside a `for` construct), the object we see and work with (like, the `r` above) is the `value` object. And we can see in the definition of `rate` that it's just passing that value object through to the end; it should end up with the same `value` function as the prior, `e_x`. And indeed, it does:
+When we `map` or `flatMap` a `RandomVariable` (whether explicitly or inside a `for` construct),
+the object we see and work with (like, the `r` above) is the `value` object.
+And we can see in the definition of `rate` that it's just passing that value object through to the end;
+it should end up with the same `value` function as the prior, `e_x`. And indeed, it does:
 
 ```tut
 e_x.value == rate.value
@@ -169,17 +218,32 @@ e_x.value == rate.value
 
 So, for the same input in the latent parameter space, `e_x` and `rate` will produce the same output.
 
-However, when we `flatMap`, behind the scenes we're also working with the `density` object. Specifically, when we start with one `RandomVariable` (like `e_x`), and use `flatMap` to flatten another `RandomVariable` into it (like the result of `fit`), the resulting `RandomVariable` (like `rate`) will have a `density` that *combines* the densities of the other two `RandomVariable`s. Put another way, `flatMap` is the Bayesian update operation: you're putting in a prior, coming up with a likelihood, and getting back the posterior. That's what the `fit` line is doing: constructing a likelihood function that we can incorporate into our posterior density. And if we look at the densities, we'll see that they are indeed different:
+However, when we `flatMap`, behind the scenes we're also working with the `density` object.
+Specifically, when we start with one `RandomVariable` (like `e_x`),
+and use `flatMap` to flatten another `RandomVariable` into it (like the result of `fit`),
+the resulting `RandomVariable` (like `rate`) will have a `density` that *combines*
+the densities of the other two `RandomVariable`s.
+Put another way, `flatMap` is the Bayesian update operation:
+you're putting in a prior, coming up with a likelihood, and getting back the posterior.
+That's what the `fit` line is doing: constructing a likelihood function that we can incorporate into our posterior density.
+And if we look at the densities, we'll see that they are indeed different:
 
 ```tut
 e_x.density == rate.density
 ```
 
-So although `F(q)` has not changed, `P(Q=q)` *has* changed; which means that `P(F(q)=f)` has also changed, and it's that change which we're observing when we see that sampling values of `F` produces different results in the two cases.
+So although `F(q)` has not changed, `P(Q=q)` *has* changed;
+which means that `P(F(q)=f)` has also changed, and it's that change which we're observing
+when we see that sampling values of `F` produces different results in the two cases.
 
 ## `generator` and `Generator`
 
-Sampling from the rate parameter is nice, but what we originally said is that we wanted to predict how many sales to expect tomorrow. As we just discussed in the digression, we got a `poisson` value back from `fit` but didn't do anything with it. This value is just the distribution we used for the `fit`, that is, `Poisson(r)`. Now, instead of fitting data *to* that distribution, we want to generate data *from* that distribution. One idea might be to do that with `param`, that is, with something like this:
+Sampling from the rate parameter is nice, but what we originally said is that
+we wanted to predict how many sales to expect tomorrow.
+As we just discussed in the digression, we got a `poisson` value back from `fit` but didn't do anything with it.
+This value is just the distribution we used for the `fit`, that is, `Poisson(r)`.
+Now, instead of fitting data *to* that distribution, we want to generate data *from* that distribution.
+One idea might be to do that with `param`, that is, with something like this:
 
 ```scala
 //This code won't compile
@@ -190,9 +254,19 @@ for {
 } yield prediction
 ```
 
-This has a couple of problems. First, it seems conceptually wrong to think of a prediction as a parameter: there is no true value of "how many sales will we have tomorrow" for us to infer, and we have no observational data that can influence our belief about its value; once we've derived the rate parameter, the prediction is purely generative. Second, as a practical matter, Rainier only supports continuous parameters, and here we need to generate discrete values, so `poisson.param` won't, in fact, compile.
+This has a couple of problems.
+First, it seems conceptually wrong to think of a prediction as a parameter:
+there is no true value of "how many sales will we have tomorrow" for us to infer,
+and we have no observational data that can influence our belief about its value;
+once we've derived the rate parameter, the prediction is purely generative.
+Second, as a practical matter, Rainier only supports continuous parameters,and
+here we need to generate discrete values, so `poisson.param` won't, in fact, compile.
 
-Luckily, all distributions, continious or discrete, implement `generator`, which gives us what we need: a way to randomly generate new values from a distribution as part of the sampling process. Every `Distribution[T]` can give us a `Generator[T]`, and if we sample from a `RandomVariable[Generator[T]]`, we will get values of type `T`. (You can think of `Real` as being a special case that acts in this sense like a `Generator[Double]`).
+Luckily, all distributions, continious or discrete, implement `generator`,
+which gives us what we need: a way to randomly generate new values from a distribution as part of the sampling process.
+Every `Distribution[T]` can give us a `Generator[T]`, and if we sample from a `RandomVariable[Generator[T]]`,
+we will get values of type `T`.
+(You can think of `Real` as being a special case that acts in this sense like a `Generator[Double]`).
 
 Here's one way we could implement what we're looking for:
 
@@ -203,7 +277,10 @@ val prediction = for {
 } yield poisson.generator
 ```
 
-This is almost the same model as `rate` above, but instead of taking the real-valued `r` rate parameter as the output, we're producing poisson-distributed integers. The samples look like this:
+This is almost the same model as `rate` above,
+but instead of taking the real-valued `r` rate parameter as the output,
+we're producing poisson-distributed integers.
+The samples look like this:
 
 ```tut
 prediction.sample()
@@ -216,7 +293,10 @@ plot1D(prediction.sample())
 
 ## `Likelihood` and `Predictor`
 
-What if, instead of assuming that our website's sales are constant over time, we assume that they're growing at a constant rate? We might have data like the following, organized in (day, sales) pairs. (You may recognize this data from the start of the tour.)
+What if, instead of assuming that our website's sales are constant over time,
+we assume that they're growing at a constant rate?
+We might have data like the following, organized in (day, sales) pairs.
+(You may recognize this data from the start of the tour.)
 
 ```tut
 val data =  List((0,8), (1,12), (2,16), (3,20), (4,21), (5,31), (6,23), (7,33), (8,31), (9,33), (10,36), (11,42), (12,39), (13,56), (14,55), (15,63), (16,52), (17,66), (18,52), (19,80), (20,71))
@@ -228,7 +308,10 @@ Plotting the data gives a clear sense of the trend:
 plot2D(data)
 ```
 
-How should we model this? We'll need to know what the rate was on day 0 (the intercept), as well as how fast the rate increases each day (the slope). We know they're both positive and not too large, so let's keep using log-normal priors. (This time we can just use the builtin `LogNormal` instead of deriving it ourselves).
+How should we model this? We'll need to know what the rate was on day 0 (the intercept),
+as well as how fast the rate increases each day (the slope).
+We know they're both positive and not too large, so let's keep using log-normal priors.
+(This time we can just use the builtin `LogNormal` instead of deriving it ourselves).
 
 ```tut
 val prior = for {
@@ -237,7 +320,12 @@ val prior = for {
     } yield (slope, intercept)
 ```
 
-Now, for any given day `i`, we want to check the number of sales against `Poisson(intercept + slope*i)`. We could write some kind of recursive flatMap to build and fit each of these different distribution objects in turn, but this is a common enough pattern that Rainier already has something built in for it: `Predictor`. `Predictor` is not a `Distribution`, but instead wraps a function from `X => Distribution[Y]` for some `(X,Y)`; you can use this any time you have a dependent variable of type `Y` that you're modeling with some independent variables jointly represented as `X`. 
+Now, for any given day `i`, we want to check the number of sales against `Poisson(intercept + slope*i)`.
+We could write some kind of recursive flatMap to build and fit each of these different distribution objects in turn,
+but this is a common enough pattern that Rainier already has something built in for it: `Predictor`.
+`Predictor` is not a `Distribution`, but instead wraps a function from `X => Distribution[Y]` for some `(X,Y)`;
+you can use this any time you have a dependent variable of type `Y` that you're modeling
+with some independent variables jointly represented as `X`.
 
 Like `Distribution`, `Predictor` implements `fit` (in fact, they both extend the `Likelihood` trait which provides that method). So we can extend the previous model to create and use a `Predictor` like this:
 
@@ -246,52 +334,76 @@ val regr = for {
     (slope, intercept) <- prior
     predictor <- Predictor.fromInt{i =>
                     Poisson(intercept + slope*i)
-                }.fit(data) 
+                }.fit(data)
 } yield (slope, intercept)
 ```
-As before, we're starting out by just sampling the parameters. By plotting them, we can see that the model's confidence in the intercept, in particular, is pretty low: although it's most likely to be somewhere around 8, it could be anywhere from 3 to 13 or even higher. Second, as you'd hope, the two parameters are anti-correlated: a smaller intercept would imply a higher slope, and vice versa.
+
+As before, we're starting out by just sampling the parameters.
+By plotting them, we can see that the model's confidence in the intercept, in particular, is pretty low:
+although it's most likely to be somewhere around 8, it could be anywhere from 3 to 13 or even higher.
+Second, as you'd hope, the two parameters are anti-correlated:
+a smaller intercept would imply a higher slope, and vice versa.
 
 ```tut
 plot2D(regr.sample())
 ```
 
-Alternatively, as in the earlier example, we could try to predict what will happen tomorrow. This is similar to calling `poisson.generator` before, but this time, we use the `predict` method on `Predictor`, which takes the covariate (the day, in this case), and returns a `Generator` for the dependent variable (the number of sales). Putting it all together, it looks like this:
+Alternatively, as in the earlier example, we could try to predict what will happen tomorrow.
+This is similar to calling `poisson.generator` before, but this time, we use the `predict` method on `Predictor`,
+which takes the covariate (the day, in this case), and returns a `Generator` for the dependent variable (the number of sales).
+Putting it all together, it looks like this:
 
 ```tut
 val regr2 = for {
     slope <- LogNormal(0,1).param
     intercept <- LogNormal(0,1).param
-    predictor <- Predictor.fromInt{i => 
+    predictor <- Predictor.fromInt{i =>
                     Poisson(intercept + slope*i)
                 }.fit(data)
 } yield predictor.predict(21)
 ```
 
-Plotting this gives us a prediction which incorporates both the natural noise of a poisson distribution and our uncertainty about its underlying parameterization.
+Plotting this gives us a prediction which incorporates both the natural noise of a Poisson distribution
+and our uncertainty about its underlying parameterization.
 
 ```tut
 plot1D(regr2.sample())
 ```
 
-Finally, let's close with a small and somewhat contrived example of a hierarchical model, where we have two separate regressions that share a parameter. For the sake of the example, let's assume that we have a second sales dataset, much like the first, where we know they had the same rate at the start of the observations, but may have grown at different rates - so their intercepts will be equal but their slopes will not. Here's the data:
+Finally, let's close with a small and somewhat contrived example of a hierarchical model,
+where we have two separate regressions that share a parameter.
+For the sake of the example, let's assume that we have a second sales dataset,
+much like the first, where we know they had the same rate at the start of the observations,
+but may have grown at different rates - so their intercepts will be equal but their slopes will not.
+Here's the data:
 
 ```tut
 val data2 = List((0,9), (1,2), (2,3), (3,17), (4,21), (5,12), (6,21), (7,19), (8,21), (9,18), (10,25), (11,27), (12,33), (13,23), (14,28), (15,45), (16,35), (17,45), (18,47), (19,54), (20,40))
 ```
 
-It's straightforward to set up two separate slopes, two separate predictor, but the same interecept. We'll still just sample the first slope so we can compare to the previous model.
+It's straightforward to set up two separate slopes, two separate predictors,
+but the same interecept.
+We'll still just sample the first slope so we can compare to the previous model.
+We _could_ write out the parameters of the models separately and fit each one
+to its respective data, but this is a bit tedious,
+so we can use Rainier's `Lookup` to do it more succinctly.
 
 ```tut
+val allData = data.map{ case (x,y) => ((0, x), y) } ++ data2.map{ case (x, y) => ((1, x), y) }
 val regr3 = for {
-    slope1 <- LogNormal(0,1).param
-    slope2 <- LogNormal(0,1).param
-    intercept <- LogNormal(0,1).param
-    pred1 <- Predictor.fromInt{i => Poisson(intercept + slope1*i)}.fit(data)
-    pred2 <- Predictor.fromInt{i => Poisson(intercept + slope2*i)}.fit(data2)
-} yield (slope1, intercept)
+  slopes <- RandomVariable.fill(2)(LogNormal(0,1).param).map(Lookup(_))
+  intercept <- LogNormal(0,1).param
+  _ <- Predictor.from[(Int, Int), Int, (Real, Real), Real]{ case (i,x) => Poisson(intercept + slopes(i) * x) }.fit(allData)
+} yield (slopes(0), intercept)
 ```
-
-Plotting slope vs intercept now, we can see that, even though these are two separate regressions, we get tighter bounds than before by letting the new data influence the shared parameter. It makes sense that we'd get more confidence on the intercept, since we have two different time series to learn from now; but because of the anti-correlation, that also leads to somewhat more confidence than before on the `slope1` parameter as well.
+Here, `i` indexes the model and `x` is the x-value of the observation.
+Plotting slope vs intercept now, we can see that,
+even though these are two separate regressions,
+we get tighter bounds than before by letting the new data influence the shared parameter.
+It makes sense that we'd get more confidence on the intercept,
+since we have two different time series to learn from now;
+but because of the anti-correlation, that also leads to somewhat more confidence
+than before on the `slope1` parameter as well.
 
 ```tut
 plot2D(regr3.sample())
@@ -299,4 +411,16 @@ plot2D(regr3.sample())
 
 ## Learning More
 
-This tour has focused on the high-level API. If you want to understand more about what's going on under the hood, you might enjoy reading about [Real](real.md) or checking out some [implementation notes](impl.md). If you want to learn more about Bayesian modeling in general, [Cam Davidson Pilon's book](http://camdavidsonpilon.github.io/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers/) is an excellent resource - the examples are in Python, but porting them to Rainier is a good learning exercise. Over time, we hope to add more Rainier-specific documentation and community resources; for now, feel free to file a [GitHub issue](https://github.com/stripe/rainier/issues) with any questions or problems.
+This tour has focused on the high-level API.
+If you want to understand more about what's going on under the hood,
+you might enjoy reading about [Real](real.md) or checking out some
+[implementation notes](impl.md).
+If you want to learn more about Bayesian modeling in general,
+[Cam Davidson Pilon's book][CDP] is an excellent resource - the examples are in Python,
+but porting them to Rainier is a good learning exercise.
+Over time, we hope to add more Rainier-specific documentation and community resources;
+for now, feel free to file a [GitHub issue][GISSUES] with any questions or problems.
+
+[CDP]: http://camdavidsonpilon.github.io/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers/
+[GISSUES]: https://github.com/stripe/rainier/issues
+[UC]: https://en.wikipedia.org/wiki/Uniform_distribution_(continuous)


### PR DESCRIPTION
The main differences are that I removed the comparison of the log densities of Poisson(9) and Poisson(10) fit to data because showing how to compute the density seemed too involved. Happy to put it back. I also updated the hierarchical model at the end which feels a little involved because it uses a `Predictor.from` (not one of the existing helpers), so I'm open to suggestions there.