### PR TITLE
fixes to mappings and placeholders

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Likelihood.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Likelihood.scala
@@ -14,7 +14,7 @@ trait Likelihood[T] {
   def sequence(seq: Seq[T]): Target = {
     val ph = wrapping.placeholder(seq)
     val real = logDensity(ph.value)
-    val variables = ph.variables
+    val variables = ph.variables(Nil)
     val arrayBufs =
       variables.map { _ =>
         new ArrayBuffer[Double]

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Mapping.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Mapping.scala
@@ -29,7 +29,8 @@ trait LowPriMappings {
         val x = new Variable
         new Placeholder[Int, Real] {
           val value = x
-          val variables = List(x)
+          def variables(acc: List[Variable]) =
+            x :: acc
           def extract(t: Int, acc: List[Double]) =
             t.toDouble :: acc
         }
@@ -48,7 +49,8 @@ object Mapping extends LowPriMappings {
         val x = new Variable
         new Placeholder[Double, Real] {
           val value = x
-          val variables = List(x)
+          def variables(acc: List[Variable]) =
+            x :: acc
           def extract(t: Double, acc: List[Double]) =
             t :: acc
         }
@@ -91,7 +93,11 @@ object Mapping extends LowPriMappings {
             })
           }
           val value = tuPlaceholders.map(_.value)
-          val variables = tuPlaceholders.flatMap(_.variables)
+          def variables(acc: List[Variable]) =
+            tuPlaceholders.foldLeft(acc) {
+              case (a, p) => p.variables(a)
+            }
+
           def extract(t: Seq[T], acc: List[Double]) =
             tuPlaceholders.zipWithIndex.foldLeft(acc) {
               case (a, (p, i)) =>
@@ -100,9 +106,11 @@ object Mapping extends LowPriMappings {
                     p.extract(v, a)
                   }
                   .getOrElse {
-                    p.variables.map { _ =>
-                      0.0
-                    }.toList ++ a
+                    p.variables(Nil)
+                      .map { _ =>
+                        0.0
+                      }
+                      .toList ++ a
                   }
             }
         }
@@ -134,7 +142,10 @@ object Mapping extends LowPriMappings {
             })
           }
           val value = tuPlaceholders.map { case (k, p) => k -> p.value }.toMap
-          val variables = tuPlaceholders.map(_._2.variables).reduce(_ ++ _)
+          def variables(acc: List[Variable]) =
+            tuPlaceholders.foldLeft(acc) {
+              case (a, (_, p)) => p.variables(a)
+            }
           def extract(t: Map[K, T], acc: List[Double]) =
             tuPlaceholders.foldLeft(acc) {
               case (a, (k, p)) =>
@@ -143,9 +154,11 @@ object Mapping extends LowPriMappings {
                     p.extract(v, a)
                   }
                   .getOrElse {
-                    p.variables.map { _ =>
-                      0.0
-                    }.toList ++ a
+                    p.variables(Nil)
+                      .map { _ =>
+                        0.0
+                      }
+                      .toList ++ a
                   }
             }
         }
@@ -166,7 +179,11 @@ object Mapping extends LowPriMappings {
             k -> new Variable
           }
           val value = tPlaceholders.toMap
-          val variables = tPlaceholders.map(_._2)
+          def variables(acc: List[Variable]) =
+            tPlaceholders.foldLeft(acc) {
+              case (a, (_, v)) =>
+                v :: a
+            }
           def extract(t: T, acc: List[Double]) =
             tPlaceholders.foldLeft(acc) {
               case (a, (k, _)) =>

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Mapping.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Mapping.scala
@@ -126,7 +126,7 @@ object Mapping extends LowPriMappings {
           case (a, m) => a ++ m.keys.toSet
         }
         new Placeholder[Map[K, T], Map[K, U]] {
-          val tuPlaceholders = keys.map { k =>
+          val tuPlaceholders = keys.toList.map { k =>
             k -> tu.placeholder(seq.collect { m =>
               m.get(k) match {
                 case Some(t) => t

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Placeholder.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Placeholder.scala
@@ -4,12 +4,13 @@ import com.stripe.rainier.compute._
 
 trait Placeholder[T, U] { self =>
   def value: U
-  def variables: Seq[Variable]
+  def variables(acc: List[Variable]): List[Variable]
   def extract(t: T, acc: List[Double]): List[Double]
   def zip[A, B](other: Placeholder[A, B]): Placeholder[(T, A), (U, B)] =
     new Placeholder[(T, A), (U, B)] {
       val value = (self.value, other.value)
-      val variables = self.variables ++ other.variables
+      def variables(acc: List[Variable]) =
+        self.variables(other.variables(acc))
       def extract(value: (T, A), acc: List[Double]) =
         self.extract(value._1, other.extract(value._2, acc))
     }


### PR DESCRIPTION
This changes Placeholder.variables to work like Placeholder.extract, with an explicit accumulator. This makes it easy to verify that the two implementations align properly (eg that ph.variables.zip(ph.extract) will match up variables with values correctly). Less importantly, it should also improve performance.

This PR also fixes a bug where the Map mapping had unstable key ordering which also contributed to misalignment of those two methods.