### PR TITLE
Add Dagon for Real optimization

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -69,6 +69,7 @@ lazy val unpublished = Seq(publish := {}, publishLocal := {}, publishArtifact :=
 lazy val V = new {
   val asm = "6.0"
   val cats = "1.1.0"
+  val dagon = "0.3.1"
   val evilplot = "0.6.0"
   val scalacheck = "1.14.0"
   val scalatest = "3.0.5"
@@ -89,7 +90,9 @@ lazy val rainierCore = project.
       BazelDep("//.rainier-shaded-asm", "shadedAsm"),
     libraryDependencies ++= Seq(
       "com.google.flogger" % "flogger" % V.flogger,
-      "com.google.flogger" % "flogger-system-backend" % V.flogger)
+      "com.google.flogger" % "flogger-system-backend" % V.flogger,
+      "com.stripe" %% "dagon-core" % V.dagon
+      )
   )
 
 lazy val rainierPlot = project.

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Coefficients.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Coefficients.scala
@@ -28,7 +28,10 @@ object Coefficients {
       Many(filtered.toMap, filtered.map(_._1).toList)
   }
 
-  val Empty: Coefficients = new Coefficients {
+  val Empty: Coefficients = EmptyCoeff
+
+  // this makes match completeness easier if we only have named classes
+  case object EmptyCoeff extends Coefficients {
     val isEmpty = true
     val size = 0
     val coefficients = Nil

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/RealOptimizer.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/RealOptimizer.scala
@@ -1,0 +1,135 @@
+package com.stripe.rainier.compute
+
+import com.stripe.rainier.ir
+import com.stripe.dagon._
+
+object RealOptimizer {
+  // Reals are untyped as far as Dagon goes
+  type RealN[A] = Real
+  type RealLit[A] = Literal[RealN, A]
+
+  /**
+    * Dagon requires mapping your DAG nodes onto a unified
+    * AST to allow it to see the structure of your DAG
+    */
+  val toLiteral: FunctionK[RealN, RealLit] =
+    Memoize.functionK(new Memoize.RecursiveK[RealN, RealLit] {
+
+      def lens(c: Coefficients): (List[Real], List[Real] => Coefficients) =
+        c match {
+          case Coefficients.EmptyCoeff =>
+            (Nil, _ => Coefficients.EmptyCoeff)
+          case Coefficients.One(term, co) =>
+            (term :: Nil, {
+              case (h: NonConstant) :: Nil => Coefficients.One(h, co)
+              case other =>
+                sys.error(
+                  s"invalid transformation: $c must only be converted to One, found: $other")
+            })
+          case m @ Coefficients.Many(_, _) =>
+            val mList = m.toList
+            val decList = mList.map(_._2)
+            (mList.map(_._1), {
+              (rs: List[Real]) =>
+                val rsize = rs.size
+                require(rsize == m.size,
+                        s"expected size: ${m.size} but found: $rsize: $rs")
+                val terms = rs.map {
+                  case nc: NonConstant => nc
+                  case other =>
+                    sys.error(
+                      s"found non-constant in parameters: $other from $m")
+                }
+
+                Coefficients.Many(terms.zip(decList).toMap, terms)
+            })
+
+        }
+
+      def toFunction[A] = {
+        case (c @ (Constant(_) | Infinity | NegInfinity), _) =>
+          Literal.Const[RealN, A](c)
+        case (v: Variable, _) =>
+          Literal.Const[RealN, A](v)
+        case (Compare(a, b), rec) =>
+          Literal.Binary[RealN, A, A, A](rec(a), rec(b), Compare(_, _))
+        case (l: Line, rec) =>
+          val (e, d) = lens(l.ax)
+          Literal.Variadic[RealN, A, A](e.map(rec[A](_)), { rs: List[Real] =>
+            Line(d(rs), l.b)
+          })
+        case (LogLine(c), rec) =>
+          val (e, d) = lens(c)
+          Literal.Variadic[RealN, A, A](e.map(rec[A](_)), { rs: List[Real] =>
+            LogLine(d(rs))
+          })
+        case (l: Lookup, rec) =>
+          val argsAsList: List[Real] = l.index :: l.table.toList
+          Literal.Variadic[RealN, A, A](argsAsList.map(rec[A](_)), {
+            rs: List[Real] =>
+              val h :: t = rs
+              Lookup(h, t, l.low)
+          })
+        case (Pow(b, e), rec) =>
+          Literal.Binary[RealN, A, A, A](
+            rec(b),
+            rec(e),
+            // This cast is safe since the rewrite rules
+            // operate on Real, which will require this
+            { (b: Real, exp: Real) =>
+              Pow(b, exp.asInstanceOf[NonConstant])
+            }
+          )
+        case (Unary(v, op), rec) =>
+          // This cast is safe since the rewrite rules
+          // operate on Real, which will require this
+          Literal.Unary[RealN, A, A](rec(v), { e: Real =>
+            Unary(e.asInstanceOf[NonConstant], op)
+          })
+      }
+    })
+
+  /**
+    * Apply the given rule to a Real
+    */
+  def apply(r: Real, rule: Rule[RealN]): Real = {
+    val (dag, id) = Dag[Any, RealN](r, toLiteral)
+
+    val optDag = dag(rule)
+    optDag.evaluate(id)
+  }
+
+  /**
+    * Run all the optimizations on this formula
+    */
+  def apply(r: Real): Real =
+    apply(r, allRules)
+
+  case object ExpLogInverse extends Rule[RealN] {
+    def apply[A](dag: Dag[RealN]) = {
+      case Unary(inner @ Unary(v, ir.LogOp), ir.ExpOp)
+          if dag.hasSingleDependent(inner) =>
+        // exp(log(x)) = x, and we should remove it if no one else needs inner
+        Some(v)
+      case Unary(inner @ Unary(v, ir.ExpOp), ir.LogOp)
+          if dag.hasSingleDependent(inner) =>
+        // exp(log(x)) = x, and we should remove it if no one else needs v
+        Some(v)
+      case _ => None
+    }
+  }
+
+  case object RedundantAbs extends Rule[RealN] {
+    def apply[A](dag: Dag[RealN]) = {
+      case Unary(inner @ Unary(_, ir.ExpOp), ir.AbsOp) =>
+        // exp(n) is already positive
+        Some(inner)
+      case Unary(inner @ Unary(_, ir.AbsOp), ir.AbsOp) =>
+        // inner is already positive
+        Some(inner)
+      case _ => None
+    }
+  }
+
+  val allRules: Rule[RealN] = RedundantAbs.orElse(ExpLogInverse)
+}


### PR DESCRIPTION
This adds dagon to show how we can write nice optimization rules (once we write the harnesses, which has been done in this PR).

Just to show how to write rules, I write two of them which are pretty obvious, but I think many more interesting ones can be written.

I didn't look to see where to wire it up yet, nor did I yet write tests. I don't want to spend much time on this if it is not interesting. If it is interesting, hopefully I have removed all the risk in your minds in how this is to work.

The only issue you may hit with this is that if the Real graphs get VERY deep, you can hit stack overflows in Dagon currently. There is a PR to address this in dagon: https://github.com/stripe/dagon/pull/27 and I doubt your dags will be so deep to trigger this (we have only seen it once or twice in about a year of production use at Stripe with dagon on scalding/semblance/summingbird graphs).

Looking forward to your comments.