### PR TITLE
Predictor.lookup

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Predictor.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Predictor.scala
@@ -45,6 +45,24 @@ object Predictor {
     }
   }
 
+  def lookup[K,L](map: Map[K,Real])(fn: Real => L): Predictor[K,L] =
+    new Predictor[K,L] {
+      type P = Real
+      val keys = map.keys.toList
+      val encoder = new Encoder[K] {
+        type U = Real
+        def wrap(t: K) = map(t)
+        def create(acc: List[Variable]): (Real, List[Variable]) = {
+          val v = new Variable
+          val r = Lookup(v, keys.map{k => map(k)})
+          (r, v :: acc)
+        }
+        def extract(t: K, acc: List[Double]): List[Double] = 
+          keys.indexOf(t).toDouble :: acc
+      }
+      def create(p: Real) = fn(p)
+    }
+
   trait From[X, U] {
     def from[L](fn: U => L): Predictor[X, L]
     def fromVector[L](k: Int)(fn: IndexedSeq[U] => L): Predictor[Seq[X], L]


### PR DESCRIPTION
This makes it easier to use `Lookup` for hierarchical models and similar. If you have your data as a `Seq[(K,V)]`, where `K` indicates some kind of segmentation, you can now create a `Map[K,Real]` of parameters, and then build a predictor like this:

```scala
val params: Map[K,Real] = ???
val data: Seq[(K,V)] = ???

Predictor.lookup(params){param => ...}.fit(data)
```

where the `...` creates some kind of `L` with `ToLikelihood[L,V]`, ie, most likely a `Likelihood` object or a nested `Predictor`.