### PR TITLE
stack safe Packer

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/ir/Packer.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/ir/Packer.scala
@@ -1,52 +1,64 @@
 package com.stripe.rainier.ir
 
+import scala.util.control.TailCalls
+import TailCalls.TailRec
+
 private class Packer(methodSizeLimit: Int) {
   private var methodDefs: List[MethodDef] = Nil
   def methods = methodDefs
 
   def pack(p: Expr): MethodRef = {
-    val (pExpr, _) = traverse(p, 0)
+    val (pExpr, _) = traverse(p, 0).result
     createMethod(UnaryIR(pExpr, NoOp))
   }
 
-  private def traverse(p: Expr, parentSize: Int): (Expr, Int) =
+  private def traverse(p: Expr, parentSize: Int): TailRec[(Expr, Int)] =
     p match {
       case v: VarDef => traverseVarDef(v, parentSize)
-      case _: Ref    => (p, 1)
+      case _: Ref    => TailCalls.done((p, 1))
     }
 
-  private def traverseVarDef(v: VarDef, parentSize: Int): (VarDef, Int) = {
-    val (ir, irSize) = traverseIR(v.rhs)
-    val (newIR, newSize) =
-      if ((irSize + parentSize) > methodSizeLimit)
-        (createMethod(ir), 1)
-      else
-        (ir, irSize)
-    (new VarDef(v.sym, newIR), newSize + 1)
-  }
+  private def traverseVarDef(v: VarDef,
+                             parentSize: Int): TailRec[(VarDef, Int)] =
+    TailCalls.tailcall(traverseIR(v.rhs).map {
+      case (ir, irSize) =>
+        val (newIR, newSize) =
+          if ((irSize + parentSize) > methodSizeLimit)
+            (createMethod(ir), 1)
+          else
+            (ir, irSize)
+        (new VarDef(v.sym, newIR), newSize + 1)
+    })
 
-  private def traverseIR(p: IR): (IR, Int) =
+  private def traverseIR(p: IR): TailRec[(IR, Int)] =
     p match {
       case b: BinaryIR =>
-        val (leftExpr, leftSize) =
-          traverse(b.left, 2)
-        val (rightExpr, rightSize) =
-          traverse(b.right, leftSize + 1)
-        (new BinaryIR(leftExpr, rightExpr, b.op), leftSize + rightSize + 1)
+        traverse(b.left, 2).flatMap {
+          case (leftExpr, leftSize) =>
+            traverse(b.right, leftSize + 1).map {
+              case (rightExpr, rightSize) =>
+                (new BinaryIR(leftExpr, rightExpr, b.op),
+                 leftSize + rightSize + 1)
+            }
+        }
       case u: UnaryIR =>
-        val (expr, exprSize) =
-          traverse(u.original, 1)
-        (new UnaryIR(expr, u.op), exprSize + 1)
+        traverse(u.original, 1).map {
+          case (expr, exprSize) =>
+            (new UnaryIR(expr, u.op), exprSize + 1)
+        }
       case l: LookupIR =>
-        val (indexExpr, indexSize) =
-          traverse(l.index, l.table.size)
-        (new LookupIR(indexExpr, l.table, l.low), indexSize + l.table.size)
+        traverse(l.index, l.table.size).map {
+          case (indexExpr, indexSize) =>
+            (new LookupIR(indexExpr, l.table, l.low), indexSize + l.table.size)
+        }
       case s: SeqIR =>
-        val (firstDef, firstSize) =
-          traverseVarDef(s.first, 1)
-        val (secondDef, secondSize) =
-          traverseVarDef(s.second, firstSize + 1)
-        (SeqIR(firstDef, secondDef), firstSize + secondSize + 1)
+        traverseVarDef(s.first, 1).flatMap {
+          case (firstDef, firstSize) =>
+            traverseVarDef(s.second, firstSize + 1).map {
+              case (secondDef, secondSize) =>
+                (SeqIR(firstDef, secondDef), firstSize + secondSize + 1)
+            }
+        }
       case _: MethodRef =>
         sys.error("there shouldn't be any method refs yet")
     }


### PR DESCRIPTION
This uses the scala stdlib's trampolining to make Packer stack safe. This seems to have been the main stack-space bottleneck for deeply recursive models like DLM - without this change, it blows up above 15 observations. After this change, we can get into large enough numbers of iterations that it falls over for other reasons :)

cc @jonnylaw