### PR TITLE
add asMap encoder

### DIFF
--- a/rainier-core/BUILD
+++ b/rainier-core/BUILD
@@ -59,6 +59,7 @@ scala_library(
     'src/main/scala/com/stripe/rainier/compute/Compiler.scala',
     'src/main/scala/com/stripe/rainier/compute/Gradient.scala',
     'src/main/scala/com/stripe/rainier/compute/LineOps.scala',
+    'src/main/scala/com/stripe/rainier/compute/ToMap.scala',
     'src/main/scala/com/stripe/rainier/compute/ToReal.scala',
     'src/main/scala/com/stripe/rainier/sampler/DualAvg.scala',
     'src/main/scala/com/stripe/rainier/sampler/Walkers.scala',

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/ToMap.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/ToMap.scala
@@ -1,0 +1,14 @@
+package com.stripe.rainier.compute
+
+/**
+  * Describes a mapping from an arbitrary class with known key/value pairs, such as a case class,
+  * to a Map[String, Double].
+  *
+  * This allows for T to be encoded in real-space via lifting the map to a Map[String, Real].
+  * @tparam T
+  */
+trait ToMap[T] {
+  def fields: Seq[String]
+
+  def apply(t: T): Map[String, Double]
+}

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Predictor.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Predictor.scala
@@ -45,8 +45,8 @@ object Predictor {
     }
   }
 
-  def lookup[K,L](map: Map[K,Real])(fn: Real => L): Predictor[K,L] =
-    new Predictor[K,L] {
+  def lookup[K, L](map: Map[K, Real])(fn: Real => L): Predictor[K, L] =
+    new Predictor[K, L] {
       type P = Real
       val keys = map.keys.toList
       val encoder = new Encoder[K] {
@@ -54,10 +54,12 @@ object Predictor {
         def wrap(t: K) = map(t)
         def create(acc: List[Variable]): (Real, List[Variable]) = {
           val v = new Variable
-          val r = Lookup(v, keys.map{k => map(k)})
+          val r = Lookup(v, keys.map { k =>
+            map(k)
+          })
           (r, v :: acc)
         }
-        def extract(t: K, acc: List[Double]): List[Double] = 
+        def extract(t: K, acc: List[Double]): List[Double] =
           keys.indexOf(t).toDouble :: acc
       }
       def create(p: Real) = fn(p)


### PR DESCRIPTION
Adds an `asMap` encoder, worked on with @avi-stripe and @mio-stripe. The encoder provides a way to encode a numeric case class, or other similar objects such as a `Map[String, Double]`-like with known keys, into Real-space by supplying a `ToMap` definition on the companion object.

Testing: Passes existing tests. Used in Stripe-internal repo. 

r? @avi-stripe @mio-stripe 