### PR TITLE
logging for HMC

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/log/Logger.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/log/Logger.scala
@@ -31,8 +31,8 @@ trait Logger {
 
   def showInfo(): Unit = setConsoleLevel(Level.INFO)
   def showFine(): Unit = setConsoleLevel(Level.FINE)
-  def showFiner(): Unit = setConsoleLevel(Level.FINE)
-  def showFinest(): Unit = setConsoleLevel(Level.FINE)
+  def showFiner(): Unit = setConsoleLevel(Level.FINER)
+  def showFinest(): Unit = setConsoleLevel(Level.FINEST)
 
   protected def init: FluentLogger = {
     val cons = classOf[FluentLogger].getDeclaredConstructors.head

--- a/rainier-core/src/main/scala/com/stripe/rainier/sampler/HMC.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/sampler/HMC.scala
@@ -1,6 +1,8 @@
 package com.stripe.rainier.sampler
 
 import scala.collection.mutable.ListBuffer
+import Log._
+import java.util.concurrent.TimeUnit._
 
 final case class HMC(nSteps: Int) extends Sampler {
   def sample(density: DensityFunction,
@@ -9,19 +11,31 @@ final case class HMC(nSteps: Int) extends Sampler {
              keepEvery: Int)(implicit rng: RNG): List[Array[Double]] = {
     val lf = LeapFrog(density)
     val params = lf.initialize
+
+    FINE.log("Finding step size using %d warmup iterations", warmupIterations)
     val stepSize =
       DualAvg.findStepSize(lf, params, 0.65, nSteps, warmupIterations)
-    if (stepSize == 0.0) //something's wrong, bail early
+    FINE.log("Found step size of %f", stepSize)
+
+    if (stepSize == 0.0) {
+      WARNING.log("Found step size of 0.0, aborting!")
       List(lf.variables(params))
-    else {
+    } else {
       val buf = new ListBuffer[Array[Double]]
       var i = 0
+      FINE.log("Sampling for %d iterations", iterations)
+
       while (i < iterations) {
+        FINER
+          .atMostEvery(1, SECONDS)
+          .log("Sampling iteration %d of %d", i, iterations)
         lf.step(params, nSteps, stepSize)
         if (i % keepEvery == 0)
           buf += lf.variables(params)
         i += 1
       }
+      FINE.log("Finished sampling")
+
       buf.toList
     }
   }

--- a/rainier-core/src/main/scala/com/stripe/rainier/sampler/LeapFrog.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/sampler/LeapFrog.scala
@@ -1,5 +1,7 @@
 package com.stripe.rainier.sampler
 
+import Log._
+
 private[sampler] case class LeapFrog(density: DensityFunction) {
   /*
   Params layout:
@@ -92,8 +94,12 @@ private[sampler] case class LeapFrog(density: DensityFunction) {
     }
     finalHalfStep(stepSize)
     val p = logAcceptanceProb(params, pqBuf)
-    if (p > Math.log(rng.standardUniform))
+    if (p > Math.log(rng.standardUniform)) {
+      FINEST.log("Accepting proposal")
       copy(pqBuf, params)
+    } else {
+      FINEST.log("REJECTING proposal")
+    }
     p
   }
 
@@ -148,7 +154,14 @@ private[sampler] case class LeapFrog(density: DensityFunction) {
                                 to: Array[Double]): Double = {
     val deltaH = kinetic(to) + to(potentialIndex) - kinetic(from) - from(
       potentialIndex)
-    if (deltaH.isNaN) { Math.log(0.0) } else { (-deltaH).min(0.0) }
+    if (deltaH.isNaN) {
+      FINEST.log("deltaH = NaN, setting acceptance prob to 0.0")
+      Math.log(0.0)
+    } else {
+      val lap = (-deltaH).min(0.0)
+      FINEST.log("logAcceptanceProb %f", lap)
+      lap
+    }
   }
 
   private def initializePs(array: Array[Double])(implicit rng: RNG): Unit = {

--- a/rainier-core/src/main/scala/com/stripe/rainier/sampler/LeapFrog.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/sampler/LeapFrog.scala
@@ -69,6 +69,15 @@ private[sampler] case class LeapFrog(density: DensityFunction) {
   private def copyQsAndUpdateDensity(): Unit = {
     System.arraycopy(pqBuf, nVars, qBuf, 0, nVars)
     density.update(qBuf)
+    if (FINEST.isEnabled) {
+      FINEST.log("Log density: %f", density.density)
+      var i = 0
+      val j = nVars
+      while (i < j) {
+        FINEST.log("Gradient for parameter %d: %f", i, density.gradient(i))
+        i += 1
+      }
+    }
   }
   //Compute the acceptance probability for a single step at this stepSize without
   //re-initializing the ps, or modifying params


### PR DESCRIPTION
Adding some logging to the HMC sampler:

* at `FINE`, logs the stages of warmup/sampling
* at `FINER`, logs individual iterations (no more than once per second)
* at `FINEST`, logs each iteration with accept/reject info