### PR TITLE
Fix a typo s/continious/continuous/ in tour.md

### DIFF
--- a/docs/tour.md
+++ b/docs/tour.md
@@ -327,7 +327,7 @@ for {
 This has a couple of problems. First, it seems conceptually wrong to think of a prediction as a parameter: there is no true value of "how many sales will we have tomorrow" for us to infer, and we have no observational data that can influence our belief about its value; once we've derived the rate parameter, the prediction is purely generative.
 Second, as a practical matter, Rainier only supports continuous parameters,and here we need to generate discrete values, so `poisson.param` won't, in fact, compile.
 
-Luckily, all distributions, continious or discrete, implement `generator`, which gives us what we need: a way to randomly generate new values from a distribution as part of the sampling process. Every `Distribution[T]` can give us a `Generator[T]`, and if we sample from a `RandomVariable[Generator[T]]`, we will get values of type `T`.
+Luckily, all distributions, continuous or discrete, implement `generator`, which gives us what we need: a way to randomly generate new values from a distribution as part of the sampling process. Every `Distribution[T]` can give us a `Generator[T]`, and if we sample from a `RandomVariable[Generator[T]]`, we will get values of type `T`.
 (You can think of `Real` as being a special case that acts in this sense like a `Generator[Double]`).
 
 Here's one way we could implement what we're looking for:

--- a/rainier-docs/src/main/tut/tour.md
+++ b/rainier-docs/src/main/tut/tour.md
@@ -190,7 +190,7 @@ for {
 This has a couple of problems. First, it seems conceptually wrong to think of a prediction as a parameter: there is no true value of "how many sales will we have tomorrow" for us to infer, and we have no observational data that can influence our belief about its value; once we've derived the rate parameter, the prediction is purely generative.
 Second, as a practical matter, Rainier only supports continuous parameters,and here we need to generate discrete values, so `poisson.param` won't, in fact, compile.
 
-Luckily, all distributions, continious or discrete, implement `generator`, which gives us what we need: a way to randomly generate new values from a distribution as part of the sampling process. Every `Distribution[T]` can give us a `Generator[T]`, and if we sample from a `RandomVariable[Generator[T]]`, we will get values of type `T`.
+Luckily, all distributions, continuous or discrete, implement `generator`, which gives us what we need: a way to randomly generate new values from a distribution as part of the sampling process. Every `Distribution[T]` can give us a `Generator[T]`, and if we sample from a `RandomVariable[Generator[T]]`, we will get values of type `T`.
 (You can think of `Real` as being a special case that acts in this sense like a `Generator[Double]`).
 
 Here's one way we could implement what we're looking for:


### PR DESCRIPTION
This pull request fixes a minor typo found in tour.md.