### PR TITLE
Fix compute bug with batched observations

### DIFF
--- a/rainier-benchmark/src/main/scala/com/stripe/rainier/bench/SBCBenchmark.scala
+++ b/rainier-benchmark/src/main/scala/com/stripe/rainier/bench/SBCBenchmark.scala
@@ -41,7 +41,7 @@ abstract class SBCBenchmark {
 
   @Benchmark
   def compile() =
-    Compiler.default.compileTargets(TargetGroup(model.targets), true, 4)
+    Compiler.default.compileTargets(TargetGroup(model.targets, 0), true, 4)
 
   @Benchmark
   def run() =

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Target.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Target.scala
@@ -47,7 +47,7 @@ class Target(val real: Real, val placeholders: Map[Variable, Array[Double]]) {
     }
 
   def batched(batchBits: Int): (List[Variable], List[Real]) = {
-    val (variables, outputs) =
+    val (batchVariables, outputs) =
       0.to(batchBits)
         .toList
         .map { i =>
@@ -55,7 +55,8 @@ class Target(val real: Real, val placeholders: Map[Variable, Array[Double]]) {
         }
         .unzip
 
-    (placeholderVariables ++ variables.flatMap(_.flatten), real :: outputs)
+    (placeholderVariables ++ batchVariables.flatMap(_.flatten),
+     real :: outputs.reverse)
   }
 
   private def batch(bit: Int): (List[List[Variable]], Real) = {

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Target.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Target.scala
@@ -28,8 +28,7 @@ class Target(val real: Real, val placeholders: Map[Variable, Array[Double]]) {
       Real.sum(inlinedRows.toList)
     }
 
-  val MAX_INLINE_TERMS = 500
-  def maybeInlined: Option[Real] =
+  def maybeInlined(maxInlineTerms: Int): Option[Real] =
     if (placeholders.isEmpty)
       Some(real)
     else {
@@ -39,7 +38,7 @@ class Target(val real: Real, val placeholders: Map[Variable, Array[Double]]) {
         result += inlineRow(i)
         i += 1
         result match {
-          case l: Line if (l.ax.size > MAX_INLINE_TERMS) =>
+          case l: Line if (l.ax.size > maxInlineTerms) =>
             return None
           case _ => ()
         }
@@ -95,10 +94,10 @@ case class TargetGroup(base: Real,
                        variables: List[Variable])
 
 object TargetGroup {
-  def apply(targets: Iterable[Target]): TargetGroup = {
+  def apply(targets: Iterable[Target], maxInlineTerms: Int): TargetGroup = {
     val (base, batched) = targets.foldLeft((Real.zero, List.empty[Target])) {
       case ((b, l), t) =>
-        t.maybeInlined match {
+        t.maybeInlined(maxInlineTerms) match {
           case Some(r) => ((b + r), l)
           case None    => (b, t :: l)
         }

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/RandomVariable.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/RandomVariable.scala
@@ -109,7 +109,7 @@ class RandomVariable[+T](val value: T, val targets: Set[Target]) {
     (allSamples, diagnostics)
   }
 
-  lazy val targetGroup = TargetGroup(targets)
+  lazy val targetGroup = TargetGroup(targets, 500)
   lazy val dataFn =
     Compiler.default.compileTargets(targetGroup, true, 4)
 

--- a/rainier-tests/src/test/scala/com/stripe/rainier/compute/RealTest.scala
+++ b/rainier-tests/src/test/scala/com/stripe/rainier/compute/RealTest.scala
@@ -28,7 +28,7 @@ class RealTest extends FunSuite {
   }
 
   def assertWithinEpsilon(x: Double, y: Double, clue: String): Unit = {
-    val relativeError = ((x - y).abs / x)
+    val relativeError = ((x - y) / x).abs
     if (!(x.isNaN && y.isNaN || relativeError < 0.001))
       assert(x == y, clue)
     ()
@@ -96,5 +96,11 @@ class RealTest extends FunSuite {
 
   run("pow") { x =>
     x.pow(x)
+  }
+
+  run("gamma fit") { x =>
+    Real.sum(List(1d, 2d, 3d).map { y =>
+      Gamma.standard(x.abs).logDensity(y)
+    })
   }
 }

--- a/rainier-tests/src/test/scala/com/stripe/rainier/compute/TargetTest.scala
+++ b/rainier-tests/src/test/scala/com/stripe/rainier/compute/TargetTest.scala
@@ -11,26 +11,59 @@ class TargetTest extends FunSuite {
       val inlinedGroup = TargetGroup(Real.sum(targets.map(_.inlined)),
                                      Nil,
                                      batchedGroup.variables)
-      val batchedFn = Compiler.default.compileTargets(batchedGroup, false, 1)
-      val inlinedFn = Compiler.default.compileTargets(inlinedGroup, false, 1)
-      val inputs = Array.fill[Double](batchedFn.numInputs)(0.0)
-      val globals = Array.fill[Double](batchedFn.numGlobals)(0.0)
-      val outputs = Array[Double](0.0)
-      batchedFn(inputs, globals, outputs)
-      val batchedOutput = outputs(0)
-      inlinedFn(inputs, globals, outputs)
-      val inlinedOutput = outputs(0)
-      assert(batchedOutput == inlinedOutput)
+      0.to(2).foreach { i =>
+        val batchedFn = Compiler.default.compileTargets(batchedGroup, false, i)
+        val inlinedFn = Compiler.default.compileTargets(inlinedGroup, false, i)
+        val inputs = Array.fill[Double](batchedFn.numInputs)(0.0)
+        val globals = Array.fill[Double](batchedFn.numGlobals)(0.0)
+        val outputs = Array[Double](0.0)
+        batchedFn(inputs, globals, outputs)
+        val batchedOutput = outputs(0)
+        inlinedFn(inputs, globals, outputs)
+        val inlinedOutput = outputs(0)
+        assertWithinEpsilon(batchedOutput, inlinedOutput, s"bits: $i")
+      }
     }
+  }
+
+  def assertWithinEpsilon(x: Double, y: Double, clue: String): Unit = {
+    val relativeError = ((x - y) / x).abs
+    if (!(x.isNaN && y.isNaN || relativeError < 0.001))
+      assert(x == y, clue)
+    ()
   }
 
   run("normal param") {
     Normal.standard.param.targets
   }
 
-  run("fit gamma") {
-    Normal(0.55, 0.1).param.flatMap { a =>
-      Gamma(a, 3).fit(List(3d, 4d, 6d))
+  run("normal fit") {
+    Normal.standard.param.flatMap { a =>
+      Normal(a, 1).fit(List(1d, 2d, 3d))
+    }.targets
+  }
+
+  run("uniform normal fit") {
+    Uniform.standard.param.flatMap { a =>
+      Normal(a, 1).fit(List(1d, 2d, 3d))
+    }.targets
+  }
+
+  run("poisson fit") {
+    Uniform.standard.param.flatMap { a =>
+      Poisson(a).fit(List(1, 2, 3))
+    }.targets
+  }
+
+  run("exponential fit") {
+    Uniform.standard.param.flatMap { a =>
+      Exponential(a).fit(List(1d, 2d, 3d))
+    }.targets
+  }
+
+  run("gamma fit") {
+    Normal(0.5, 1).param.flatMap { a =>
+      Gamma.standard(a).fit(List(1d, 2d, 3d))
     }.targets
   }
 }

--- a/rainier-tests/src/test/scala/com/stripe/rainier/compute/TargetTest.scala
+++ b/rainier-tests/src/test/scala/com/stripe/rainier/compute/TargetTest.scala
@@ -1,0 +1,36 @@
+package com.stripe.rainier.compute
+
+import org.scalatest._
+
+import com.stripe.rainier.core._
+
+class TargetTest extends FunSuite {
+  def run(description: String)(targets: Iterable[Target]): Unit = {
+    test(description) {
+      val batchedGroup = TargetGroup(targets, 0)
+      val inlinedGroup = TargetGroup(Real.sum(targets.map(_.inlined)),
+                                     Nil,
+                                     batchedGroup.variables)
+      val batchedFn = Compiler.default.compileTargets(batchedGroup, false, 1)
+      val inlinedFn = Compiler.default.compileTargets(inlinedGroup, false, 1)
+      val inputs = Array.fill[Double](batchedFn.numInputs)(0.0)
+      val globals = Array.fill[Double](batchedFn.numGlobals)(0.0)
+      val outputs = Array[Double](0.0)
+      batchedFn(inputs, globals, outputs)
+      val batchedOutput = outputs(0)
+      inlinedFn(inputs, globals, outputs)
+      val inlinedOutput = outputs(0)
+      assert(batchedOutput == inlinedOutput)
+    }
+  }
+
+  run("normal param") {
+    Normal.standard.param.targets
+  }
+
+  run("fit gamma") {
+    Normal(0.55, 0.1).param.flatMap { a =>
+      Gamma(a, 3).fit(List(3d, 4d, 6d))
+    }.targets
+  }
+}


### PR DESCRIPTION
This fixes a hard-to-trigger bug in the implementation of mini-batched likelihoods. The problem was:

* in `compileTargets`, we construct a single `CompiledFunction` that includes, as distinct outputs, `k+1` extra versions of the likelihood function; each one sums the likelihoods for `2^i` observations, for `i` in `0..k`.
* when compiling multiple outputs, they are treated by the compiler as being evaluated in order, and it is legal for output `n` to rely on intermediate computations stored in the `globals` array by any output `< n`.
* the `k+1` extra versions of the likelihood function were given to the compiler in ascending order from 0..k 
* however, in `DataFunction`, we were computing the outputs in reverse order, from k..0. This meant that in the case that one of these outputs depended on intermediate state from a previous output, that state will not have been initialized yet, and we'd get the wrong answer.
* this problem was rare because we deliberately include and use a separate, special version of the likelihood function for the very first observation, intending for that to compute any intermediate values that can be shared across outputs. The bug would only occur when, for some reason, there's some sharing that can occur between two of the other outputs but *not* with this one. (I'm still unclear on why that ever happens, but I accept that it's possible).

For now, we fix this simply by reversing the order of the outputs as we provide them to the compiler, so that it matches their evaluation order in `DataFunction`.

This PR also adds tests that would fail before this fix, and just might catch future regressions.

This PR does not fix the real underlying problem here, which is that `Target` and `DataFunction` are extremely brittle, tightly coupled, and confusing pieces of code. 

Thanks to @kailuowang for the initial bug report on this.