### PR TITLE
Fix ToMap encoder

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Encoder.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Encoder.scala
@@ -78,9 +78,9 @@ object Encoder {
 
       def create(acc: List[Variable]): (Map[String, Real], List[Variable]) =
         toMap.fields.foldRight((Map[String, Real](), acc)) {
-          case (field, (map, _)) =>
+          case (field, (map, a)) =>
             val v = new Variable
-            (map + (field -> v), v :: acc)
+            (map + (field -> v), v :: a)
         }
 
       def extract(t: T, acc: List[Double]): List[Double] = {

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/RandomVariable.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/RandomVariable.scala
@@ -127,6 +127,14 @@ class RandomVariable[+T](val value: T, val targets: Set[Target]) {
       def gradient(index: Int) = outputs(index + 1)
     }
 
+  def densityAtOrigin: Double = {
+    val inputs = new Array[Double](dataFn.numInputs)
+    val globals = new Array[Double](dataFn.numGlobals)
+    val outputs = new Array[Double](dataFn.numOutputs)
+    dataFn(inputs, globals, outputs)
+    outputs(0)
+  }
+
   lazy val densityValue: Real = targetGroup.base
 
   //this is really just here to allow destructuring in for{}

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/RandomVariable.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/RandomVariable.scala
@@ -204,4 +204,8 @@ object RandomVariable {
 
   def fill[A](k: Int)(fn: => RandomVariable[A]): RandomVariable[Seq[A]] =
     traverse(List.fill(k)(fn))
+
+  def fit[L, T](l: L, seq: Seq[T])(
+      implicit toLH: ToLikelihood[L, T]): RandomVariable[Unit] =
+    toLH(l).fit(seq)
 }

--- a/rainier-core/src/main/scala/com/stripe/rainier/ir/DataFunction.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/ir/DataFunction.scala
@@ -23,7 +23,6 @@ case class DataFunction(cf: CompiledFunction,
                         numParamInputs: Int,
                         numOutputs: Int,
                         data: Array[Array[Array[Double]]]) {
-  println("Data.size " + data.size)
   val numInputs = cf.numInputs
   val numGlobals = cf.numGlobals
 

--- a/rainier-core/src/main/scala/com/stripe/rainier/ir/DataFunction.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/ir/DataFunction.scala
@@ -23,6 +23,7 @@ case class DataFunction(cf: CompiledFunction,
                         numParamInputs: Int,
                         numOutputs: Int,
                         data: Array[Array[Array[Double]]]) {
+  println("Data.size " + data.size)
   val numInputs = cf.numInputs
   val numGlobals = cf.numGlobals
 

--- a/rainier-core/src/main/scala/com/stripe/rainier/sampler/Ehmc.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/sampler/Ehmc.scala
@@ -56,7 +56,7 @@ final case class EHMC(l0: Int, k: Int) extends Sampler {
           .log("Sampling iteration %d of %d for %d steps, acceptance rate %f",
                i,
                iterations,
-               nSteps, 
+               nSteps,
                (acceptSum / i))
 
         val logAccept = lf.step(params, nSteps, stepSize)


### PR DESCRIPTION
This fixes a bug where we weren't properly accumulating variables in the `create` method of the ToMap encoder.

It also adds a couple of methods (`densityAtOrigin` and `RandomVariable.fit`) that were useful in debugging.

I'm going to self-merge this in advance of the release but cc @mikeheaton-stripe and @mio-stripe for awareness.