### PR TITLE
writeCSV

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/repl/package.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/repl/package.scala
@@ -1,6 +1,7 @@
 package com.stripe.rainier
 
 import com.stripe.rainier.sampler._
+import java.io._
 
 package object repl {
   def plot1D[N](seq: Seq[N])(implicit num: Numeric[N]): Unit = {
@@ -13,6 +14,21 @@ package object repl {
       DensityPlot()
         .plot2D(seq.map { case (a, b) => (m.toDouble(a), n.toDouble(b)) })
         .mkString("\n"))
+  }
+
+  def writeCSV(path: String, seq: Seq[Map[String, Double]]): Unit = {
+    val fieldNames = seq.map(_.keys.toSet).reduce(_ ++ _).toList
+    val pw = new PrintWriter(new File(path))
+    pw.write(fieldNames.mkString(","))
+    seq.foreach { row =>
+      pw.write("\n")
+      fieldNames.tail.foreach { f =>
+        pw.write(row.get(f).map(_.toString).getOrElse(""))
+        pw.write(",")
+      }
+      pw.write(row.get(fieldNames.head).map(_.toString).getOrElse(""))
+    }
+    pw.close
   }
 
   implicit val rng: RNG = RNG.default


### PR DESCRIPTION
This is a tiny little utility for writing out CSV files from `Seq[Map[String,Double]]`. The intended use is as a barebones arviz integration; if you write out your samples in this format, you can then do something like this:

<img width="974" alt="screen shot 2019-02-10 at 8 22 07 pm" src="https://user-images.githubusercontent.com/23175169/52546141-be5f9400-2d71-11e9-9426-caf74b9b233c.png">
