### PR TITLE
Fix automated differentiation of Lookup and Abs

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Gradient.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Gradient.scala
@@ -103,10 +103,10 @@ private object Gradient {
       case LogOp => gradient.toReal * (Real.one / child.original)
       case ExpOp => gradient.toReal * child
       case AbsOp =>
-        Real.lt(child.original,
+        Real.eq(child.original,
                 Real.zero,
-                gradient.toReal * child.original / child,
-                Real.zero)
+                Real.zero,
+                gradient.toReal * child.original / child)
       case NoOp => gradient.toReal
     }
   }

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Gradient.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Gradient.scala
@@ -54,7 +54,7 @@ private object Gradient {
           case l: Lookup =>
             l.table.zipWithIndex.foreach {
               case (x, i) =>
-                diff(x).register(LookupDiff(l, diff(l), i))
+                diff(x).register(LookupDiff(l, diff(l), i + l.low))
                 visit(x)
             }
             visit(l.index)

--- a/rainier-tests/src/test/scala/com/stripe/rainier/compute/RealTest.scala
+++ b/rainier-tests/src/test/scala/com/stripe/rainier/compute/RealTest.scala
@@ -4,30 +4,54 @@ import org.scalatest._
 import com.stripe.rainier.core._
 import scala.util.{Try, Success, Failure}
 class RealTest extends FunSuite {
-  def run(description: String)(fn: Real => Real): Unit = {
+  def run(description: String, testDeriv: Double => Boolean = _ => true)(
+      fn: Real => Real): Unit = {
     test(description) {
       val x = new Variable
       val result = fn(x)
+      val deriv = result.gradient.head
+
+      def evalAt(d: Double): Double = Try { fn(Constant(d)) } match {
+        case Success(Infinity)                 => 1.0 / 0.0
+        case Success(NegInfinity)              => -1.0 / 0.0
+        case Success(Constant(bd))             => bd.toDouble
+        case Failure(_: ArithmeticException)   => 0.0 / 0.0
+        case Failure(_: NumberFormatException) => 0.0 / 0.0
+        case x                                 => sys.error("Non-constant value " + x)
+      }
+
       val c = Compiler(200, 100).compile(List(x), result)
+      val dc = Compiler(200, 100).compile(List(x), deriv)
       List(1.0, 0.0, -1.0, 2.0, -2.0, 0.5, -0.5).foreach { n =>
-        val constant = Try { fn(Constant(n)) } match {
-          case Success(Infinity)                 => 1.0 / 0.0
-          case Success(NegInfinity)              => -1.0 / 0.0
-          case Success(Constant(bd))             => bd.toDouble
-          case Failure(_: ArithmeticException)   => 0.0 / 0.0
-          case Failure(_: NumberFormatException) => 0.0 / 0.0
-          case x                                 => sys.error("Non-constant value " + x)
-        }
+        val constant = evalAt(n)
         val eval = new Evaluator(Map(x -> n))
         val withVar = eval.toDouble(result)
         assertWithinEpsilon(constant, withVar, s"[c/ev, n=$n]")
         val compiled = c(Array(n))
         assertWithinEpsilon(withVar, compiled, s"[ev/ir, n=$n]")
+
+        // derivatives of automated differentiation vs numeric differentiation
+        if (testDeriv(n)) {
+          val dx = 10E-6
+          val numDiff = (evalAt(n + dx) - evalAt(n - dx)) / (dx * 2)
+          val diffWithVar = eval.toDouble(deriv)
+          assertWithinEpsilon(numDiff,
+                              diffWithVar,
+                              s"[numDiff/diffWithVar, n=$n]")
+          val diffCompiled = dc(Array(n))
+          assertWithinEpsilon(diffWithVar,
+                              diffCompiled,
+                              s"[diffWithVar/diffCompiled, n=$n]")
+        }
       }
     }
   }
 
   def assertWithinEpsilon(x: Double, y: Double, clue: String): Unit = {
+    if (x.abs < 10E-8 && y.abs < 10E-8)
+      // both values really close to 0, consider equal to
+      // account for inaccuracies in numeric differentiation
+      return ()
     val relativeError = ((x - y) / x).abs
     if (!(x.isNaN && y.isNaN || relativeError < 0.001))
       assert(x == y, clue)
@@ -50,6 +74,25 @@ class RealTest extends FunSuite {
     val t = x * 3
     t + t
   }
+  run("abs") { x =>
+    x.abs
+  }
+  run("max(x, 0)", testDeriv = _ != 0) { x =>
+    x.max(0)
+  }
+  run("max(x, x)") { x =>
+    x.max(x)
+  }
+  run("x > 0 ? x^2 : 1", testDeriv = _ != 0) { x =>
+    Real.gt(x, 0, x * x, 1)
+  }
+  run("x > 0 ? 1 : x + 1", testDeriv = _ != 0) { x =>
+    Real.gt(x, 0, 1, x + 1)
+  }
+  run("x > 0 ? x^2 : x + 1", _ != 0) { x =>
+    Real.gt(x, 0, x * x, x + 1)
+  }
+
   run("normal") { x =>
     Real.sum(Range.BigDecimal(0d, 2d, 1d).toList.map { y =>
       Normal(x, 1).logDensity(Real(y))
@@ -65,7 +108,7 @@ class RealTest extends FunSuite {
     Real.one / (x.exp + 1)
   }
 
-  run("log x^2") { x =>
+  run("log x^2", testDeriv = _ != 0) { x =>
     x.pow(2).log
   }
 
@@ -81,20 +124,20 @@ class RealTest extends FunSuite {
       (x * x * x))
   }
 
-  run("lookup") { x =>
+  run("lookup", testDeriv = _ => false) { x => // not derivable
     val i = x.abs * 2 //should be a non-negative whole number
     Lookup(i, Real.seq(List(0, 1, 2, 3, 4)))
   }
 
   val exponents = scala.util.Random.shuffle(-40.to(40))
-  run("exponent sums") { x =>
+  run("exponent sums", testDeriv = _ != 0) { x =>
     exponents.foldLeft(x) {
       case (a, e) =>
         (a + x.pow(e)) * x
     }
   }
 
-  run("pow") { x =>
+  run("pow", testDeriv = _ >= 0) { x =>
     x.pow(x)
   }
 


### PR DESCRIPTION
This PR introduces automated tests for AD by comparing its results to numeric differentiation.
This unveils bugs in the implementation of AD for `abs` and `lookup` which are fixed by this PR (see #329 for the bug report on lookup).

Below are the results of the tests on my machine.
Of the two tests that still fail and for which I would appreciate additional input : 
 -  `pow` seems unrelated to this PR
 - `gamm fit` might fail due to the inaccuracy of numeric differentiation

```
[info] RealTest:
[info] - plus
[info] - exp
[info] - square
[info] - log
[info] - temp
[info] - abs
[info] - max(x, 0)
[info] - max(x, x)
[info] - x > 0 ? x^2 : 1
[info] - x > 0 ? 1 : x + 1
[info] - x > 0 ? x^2 : x + 1
[info] - normal
[info] - logistic
[info] - minimal logistic
[info] - log x^2
[info] - poisson
[info] - 4x^3
[info] - lookup
[info] - exponent sums
[info] - pow *** FAILED ***
[info]   java.lang.ArithmeticException: Cannot take the log of -1.0
[info]   at com.stripe.rainier.compute.RealOps$.unary(RealOps.scala:32)
[info]   at com.stripe.rainier.compute.Evaluator.eval(Evaluator.scala:29)
[info]   at com.stripe.rainier.compute.Evaluator.toDouble(Evaluator.scala:11)
[info]   at com.stripe.rainier.compute.Evaluator.$anonfun$eval$2(Evaluator.scala:26)
[info]   at com.stripe.rainier.compute.Evaluator.$anonfun$eval$2$adapted(Evaluator.scala:26)
[info]   at scala.collection.immutable.List.map(List.scala:290)
[info]   at com.stripe.rainier.compute.Evaluator.eval(Evaluator.scala:26)
[info]   at com.stripe.rainier.compute.Evaluator.toDouble(Evaluator.scala:11)
[info]   at com.stripe.rainier.compute.Evaluator.$anonfun$eval$1(Evaluator.scala:23)
[info]   at com.stripe.rainier.compute.Evaluator.$anonfun$eval$1$adapted(Evaluator.scala:23)
[info]   ...
[info] - gamma fit *** FAILED ***
[info]   8.59681137184154 did not equal 3.523287795242514 [numDiff/diffWithVar, n=1.0] (RealTest.scala:56)
```