### PR TITLE
Fixes related to handling unusual double values (+/- infinity and NaN).

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/RealOps.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/RealOps.scala
@@ -190,6 +190,8 @@ private[compute] object RealOps {
   def pow(a: BigDecimal, b: BigDecimal): BigDecimal =
     if (b.isValidInt)
       a.pow(b.toInt)
+    else if (a < Real.BigZero)
+      throw new ArithmeticException(s"Undefined: $a ^ $b")
     else
       BigDecimal(Math.pow(a.toDouble, b.toDouble))
 

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/ToReal.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/ToReal.scala
@@ -18,6 +18,8 @@ trait LowPriToReal {
           Real.negInfinity
         else if (double.isInfinity)
           Real.infinity
+        else if (double.isNaN)
+          throw new ArithmeticException("Trying to convert NaN to Real")
         else
           Constant(BigDecimal(double))
       }


### PR DESCRIPTION
Just a few fixes related to edges cases involving infinities and NaN.
One common error was the use of `Constant(d)` to construct a `Real` from a `Double`, this would throw a `NumberFormatException` on NaN and infinities when converting to `BigDecimal`. Using `Real(d)` should handle infinities and throw an arithmetic error on NaN.