### PR TITLE
0.2.2 prep

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ You can enable fatal warnings locally by either setting
 Rainier is published on sonatype. To use it in your SBT project, you can add the following to your build.sbt:
 
 ```scala
-libraryDependencies += "com.stripe" %% "rainier-core" % "0.2.1"
+libraryDependencies += "com.stripe" %% "rainier-core" % "0.2.2"
 ```
 
 ## Authors
@@ -104,6 +104,7 @@ libraryDependencies += "com.stripe" %% "rainier-core" % "0.2.1"
 Rainier's primary author is [Avi Bryant](http://twitter.com/avibryant) with major contributions from [Mio Alter](https://twitter.com/mioalter). Many thanks also for contributions and support from:
  * Christian Anderson
  * Alex Beal
+ * Arthur Bit-Monnot
  * Travis Brown
  * Peadar Coyle
  * Mike Heaton

--- a/build.sbt
+++ b/build.sbt
@@ -134,8 +134,7 @@ lazy val rainierDocs = project.
     scalacOptions in Tut ~= {
       _.filterNot(sc => sc.contains("-Ywarn-unused") || sc == "-Yno-predef" )
     },
-    // todo: uncomment once docs generation is deterministic
-    // tutTargetDirectory := (baseDirectory in LocalRootProject).value / "docs"
+    tutTargetDirectory := (baseDirectory in LocalRootProject).value / "docs"
   ).
   settings(unpublished)
 

--- a/build.sbt
+++ b/build.sbt
@@ -73,6 +73,7 @@ lazy val V = new {
   val scalacheck = "1.14.0"
   val scalatest = "3.0.5"
   val flogger = "0.3.1"
+  val shadedAsm = "0.2.1"
 }
 
 // primary modules
@@ -80,16 +81,12 @@ lazy val V = new {
 lazy val rainierCore = project.
   in(file("rainier-core")).
   settings(name := "rainier-core").
-  dependsOn(shadedAsm).
   settings(commonSettings).
   settings(
-    bazelRuleDeps := (Deps(Compile) - ScalaLib(Compile)) +
-      BazelDep("//.rainier-shaded-asm", "asmTreeShaded") +
-      BazelDep("//.rainier-shaded-asm", "asmShaded") -
-      BazelDep("//.rainier-shaded-asm", "shadedAsm"),
     libraryDependencies ++= Seq(
       "com.google.flogger" % "flogger" % V.flogger,
-      "com.google.flogger" % "flogger-system-backend" % V.flogger)
+      "com.google.flogger" % "flogger-system-backend" % V.flogger,
+      "com.stripe" % "rainier-shaded-asm_6.0" % V.shadedAsm)
   )
 
 lazy val rainierPlot = project.

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.2.1"
+version in ThisBuild := "0.2.2"


### PR DESCRIPTION
Some prep for a 0.2.2 release.

* update the list of contributors in the readme to include @arthur-bit-monnot 
* depend on a published shaded-asm artifact rather than on the sbt sub-module. It's a little wonky here the way we still publish a new asm artifact for every rainier release even though it never changes, and that we just depend on a random previously published version, but this was the quickest way to improve things and we can always make it better later.
* uncomment `tutTargetDirectory` because our doc gen should be deterministic now. @andyscott, is this actually checked by CI or is there something else I'd need to enable there?