### PR TITLE
warn on methods getting too large

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/internal/asm/MethodSizer.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/internal/asm/MethodSizer.scala
@@ -1,0 +1,16 @@
+package com.stripe.rainier.internal.asm
+
+object MethodSizer {
+  val firstMethodField = classOf[ClassWriter].getDeclaredField("firstMethod")
+  firstMethodField.setAccessible(true)
+
+  def methodSizes(cw: ClassWriter): List[Int] = {
+    var list = List.empty[Int]
+    var methodWriter = firstMethodField.get(cw).asInstanceOf[MethodWriter]
+    while (methodWriter != null) {
+      list = methodWriter.getSize :: list
+      methodWriter = methodWriter.mv.asInstanceOf[MethodWriter]
+    }
+    list
+  }
+}

--- a/rainier-core/src/main/scala/com/stripe/rainier/ir/ClassGenerator.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/ir/ClassGenerator.scala
@@ -3,6 +3,8 @@ package com.stripe.rainier.ir
 import com.stripe.rainier.internal.asm.Opcodes._
 import com.stripe.rainier.internal.asm.tree.{ClassNode, MethodNode}
 import com.stripe.rainier.internal.asm.ClassWriter
+import com.stripe.rainier.internal.asm.MethodSizer
+import Log._
 
 private[ir] trait ClassGenerator {
 
@@ -49,6 +51,14 @@ private[ir] trait ClassGenerator {
     val cw = new ClassWriter(
       ClassWriter.COMPUTE_FRAMES + ClassWriter.COMPUTE_MAXS)
     classNode.accept(cw)
+
+    val maxMethodSize = MethodSizer.methodSizes(cw).max
+    FINE.log("%s maximum method size: %d", name, maxMethodSize)
+    if (maxMethodSize > 8000)
+      SEVERE.log("%s produced method of size %d which will likely not JIT",
+                 name,
+                 maxMethodSize)
+                 
     cw.toByteArray
   }
 }


### PR DESCRIPTION
This uses some janky reflection to reach into the internals of ASM6 and pull out the bytecode sizes of individual methods from `ClassWriter`. This lets us produce a warning if the sizes start to exceed the default max JIT size.

Obviously something using a public interface would be better, and this will need to be updated if we ever upgrade the ASM version, but it's a tiny and encapsulated piece of code that is very valuable as a debugging tool, so I think it's worth it.