### PR TITLE
Update resolvers again, third time is the charm

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -97,11 +97,11 @@ lazy val rainierPlot = project.
   dependsOn(rainierCore).
   settings(commonSettings).
   settings(
-    resolvers ++= 
+    resolvers ++=
       Seq(
         Resolver.bintrayRepo("cibotech", "public"),
         "jitpack" at "https://jitpack.io"),
-    libraryDependencies ++= 
+    libraryDependencies ++=
       Seq(
         "com.cibo" %% "evilplot" % V.evilplot,
         "sh.almond" %% "interpreter-api" % V.almond)
@@ -137,6 +137,7 @@ lazy val rainierDocs = project.
   ).
   settings(commonSettings).
   settings(
+    resolvers := Seq(Resolver.bintrayRepo("tpolecat", "maven")),
     scalacOptions in Tut ~= {
       _.filterNot(sc => sc.contains("-Ywarn-unused") || sc == "-Yno-predef" )
     },


### PR DESCRIPTION
Somehow didn't get the updates to `build.sbt` into https://github.com/stripe/rainier/pull/339
Rerunning `sbt bazelGenerate` with these settings does update the WORKSPACE file correctly and produces to same generated BUILD files that we had to manually edit in the previous PR so the only addition here are the updates to `build.sbt`: https://github.com/stripe/rainier/compare/mio/again?expand=1

Last time @areese-stripe @avi-stripe 