### PR TITLE
scatterShaded

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "metals.serverVersion": "0.7.0"
+}

--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,7 @@ scalafmtOnCompile in ThisBuild := true
 lazy val commonSettings = Seq(
   organization:= "com.stripe",
   scalaVersion := "2.12.8",
-  crossScalaVersions := List("2.11.12", scalaVersion.value),
+  crossScalaVersions := List(scalaVersion.value),
   releaseCrossBuild := true,
   releasePublishArtifactsAction := PgpKeys.publishSigned.value,
   homepage := Some(url("https://github.com/stripe/rainier")),
@@ -97,7 +97,6 @@ lazy val rainierPlot = project.
   dependsOn(rainierCore).
   settings(commonSettings).
   settings(
-    crossScalaVersions := List(scalaVersion.value),
     resolvers ++=
       Seq(
         Resolver.bintrayRepo("cibotech", "public"),
@@ -156,7 +155,6 @@ lazy val rainierExample = project.
   settings(commonSettings).
   settings(unpublished).
   settings(
-    crossScalaVersions := List(scalaVersion.value),    
     bazelCustomBuild := BuildPrelude +: BuildTargets +: BazelString(
     """
       |scala_binary(

--- a/build.sbt
+++ b/build.sbt
@@ -97,6 +97,7 @@ lazy val rainierPlot = project.
   dependsOn(rainierCore).
   settings(commonSettings).
   settings(
+    crossScalaVersions := List(scalaVersion.value),
     resolvers ++=
       Seq(
         Resolver.bintrayRepo("cibotech", "public"),
@@ -154,7 +155,9 @@ lazy val rainierExample = project.
   ).
   settings(commonSettings).
   settings(unpublished).
-  settings(bazelCustomBuild := BuildPrelude +: BuildTargets +: BazelString(
+  settings(
+    crossScalaVersions := List(scalaVersion.value),    
+    bazelCustomBuild := BuildPrelude +: BuildTargets +: BazelString(
     """
       |scala_binary(
       |    name = 'logNormal',

--- a/build.sbt
+++ b/build.sbt
@@ -69,7 +69,7 @@ lazy val unpublished = Seq(publish := {}, publishLocal := {}, publishArtifact :=
 lazy val V = new {
   val asm = "6.0"
   val cats = "1.1.0"
-  val evilplot = "0.6.0"
+  val evilplot = "0.7.0"
   val scalacheck = "1.14.0"
   val scalatest = "3.0.5"
   val flogger = "0.3.1"

--- a/rainier-core/src/main/scala/com/stripe/rainier/repl/package.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/repl/package.scala
@@ -60,7 +60,9 @@ package object repl {
   }
 
   def mean[N](seq: Seq[N])(implicit num: Numeric[N]): Double =
-    seq.map{ n => num.toDouble(n) }.sum / seq.size
+    seq.map { n =>
+      num.toDouble(n)
+    }.sum / seq.size
 
   def stddev[N](seq: Seq[N])(implicit num: Numeric[N]): Double = {
     val doubles = seq.map { n =>

--- a/rainier-core/src/main/scala/com/stripe/rainier/repl/package.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/repl/package.scala
@@ -59,8 +59,13 @@ package object repl {
     }
   }
 
+  def mean[N](seq: Seq[N])(implicit num: Numeric[N]): Double =
+    seq.map{ n => num.toDouble(n) }.sum / seq.size
+
   def stddev[N](seq: Seq[N])(implicit num: Numeric[N]): Double = {
-    val doubles = seq.map{n => num.toDouble(n)}
+    val doubles = seq.map { n =>
+      num.toDouble(n)
+    }
     val mean = doubles.sum / doubles.size
     math.sqrt(doubles.map { x =>
       math.pow(x - mean, 2)

--- a/rainier-plot/src/main/scala/com/stripe/rainier/plot/Jupyter.scala
+++ b/rainier-plot/src/main/scala/com/stripe/rainier/plot/Jupyter.scala
@@ -61,6 +61,19 @@ object Jupyter {
       Point(mNum.toDouble(p._1), nNum.toDouble(p._2))
     }, surfaceRenderer = Some(SurfaceRenderer.contours()))
 
+  def line[M, N](seq: Seq[(M, N)])(implicit mNum: Numeric[M],
+                                   nNum: Numeric[N],
+                                   theme: Theme): Plot =
+    LinePlot(seq.map {
+      case (m, n) =>
+        Point(mNum.toDouble(m), nNum.toDouble(n))
+    })
+
+  def line(xbounds: Bounds)(fn: Double => Double)(implicit theme: Theme): Plot =
+    lines(xbounds) { x =>
+      List(fn(x))
+    }
+
   def lines(xbounds: Bounds)(fn: Double => Seq[Double])(
       implicit theme: Theme): Plot =
     Overlay.fromSeq(fn(0.0).zipWithIndex.toList.map {
@@ -71,17 +84,15 @@ object Jupyter {
                             Some(xbounds))
     })
 
-  def line(xbounds: Bounds)(fn: Double => Double)(implicit theme: Theme): Plot =
-    lines(xbounds) { x =>
-      List(fn(x))
-    }
-
   def shade[M, N](intervals: Seq[(M, (N, N))])(implicit mNum: Numeric[M],
                                                nNum: Numeric[N]): Plot = {
-    val doubleTriples = intervals.map {
-      case (m, (n1, n2)) =>
-        (mNum.toDouble(m), nNum.toDouble(n1), nNum.toDouble(n2))
-    }
+    val doubleTriples = intervals
+      .map {
+        case (m, (n1, n2)) =>
+          (mNum.toDouble(m), nNum.toDouble(n1), nNum.toDouble(n2))
+      }
+      .sortBy(_._1)
+
     val minX = doubleTriples.map(_._1).min
     val maxX = doubleTriples.map(_._1).max
     val minY = doubleTriples.map(_._2).min

--- a/rainier-plot/src/main/scala/com/stripe/rainier/plot/Jupyter.scala
+++ b/rainier-plot/src/main/scala/com/stripe/rainier/plot/Jupyter.scala
@@ -6,220 +6,116 @@ import com.cibo.evilplot.plot._
 import com.cibo.evilplot.numeric._
 import com.cibo.evilplot.colors._
 import com.cibo.evilplot.plot.renderers._
-import com.cibo.evilplot.plot.renderers.SurfaceRenderer.SurfaceRenderContext
-import com.cibo.evilplot.plot.aesthetics.DefaultTheme._
-import com.cibo.evilplot.plot.aesthetics.Theme
-import com.stripe.rainier.repl.hdpi
+import com.cibo.evilplot.plot.aesthetics._
 
 object Jupyter {
-  implicit val extent = Extent(400, 400)
-
-  def traces(out: Seq[Map[String, Double]],
-             truth: Map[String, Double] = Map(),
-             lagMax: Int = 40,
-             numBars: Int = 50)(implicit outputHandler: OutputHandler): Unit = {
-    implicit val extent = Extent(1200, out.head.keys.size * 300.0)
-    show(EvilTracePlot.traces(out, truth, lagMax, numBars))
-  }
-
-  def pairs(out: Seq[Map[String, Double]],
-            truth: Map[String, Double] = Map(),
-            numBars: Int = 30)(implicit outputHandler: OutputHandler): Unit = {
-    implicit val extent =
-      Extent(out.head.keys.size * 300.0, out.head.keys.size * 300.0)
-    show(EvilTracePlot.pairs(out, truth, numBars))
-  }
-
-  def histogram[N](seq: Seq[N], bounds: Option[(Double,Double)] = None)(implicit num: Numeric[N],
-                                                   oh: OutputHandler,
-                                                   extent: Extent): Unit =
-    show(
-      Histogram(seq.map { n =>
-        num.toDouble(n)
-      }, binningFunction = Histogram.density,
-      xbounds = bounds.map{case (a,b) => Bounds(a,b)})
-        .xAxis()
-        .frame())
-
-  private def scatterPlot[N](seq: Seq[(N, N)])(implicit num: Numeric[N]): Plot =
-    ScatterPlot(
-      seq.map { p =>
-        Point(num.toDouble(p._1), num.toDouble(p._2))
-      },
-      pointRenderer = Some(
-        PointRenderer.default[Point](Some(HSLA(210, 100, 56, 0.5)), Some(2))))
-
-  def scatter[N](seq: Seq[(N, N)], xLabel: String = "x", yLabel: String = "y")(
-      implicit num: Numeric[N],
-      oh: OutputHandler,
-      extent: Extent): Unit =
-    show(
-      scatterPlot(seq)
-        .xAxis()
-        .yAxis()
-        .frame()
-        .xLabel(xLabel)
-        .yLabel(yLabel))
-
-  def scatter(seq: Seq[Map[String, Double]], xKey: String, yKey: String)(
-      implicit oh: OutputHandler,
-      extent: Extent): Unit =
-    scatter(seq.map { s =>
-      (s(xKey), s(yKey))
-    }, xKey, yKey)
-
-  def scatterLines(seq: Seq[Map[String, Double]], xKey: String, yKey: String)(
-      fn: Double => Seq[Double])(implicit oh: OutputHandler,
-                                 extent: Extent): Unit = {
-    val scatter = scatterPlot(seq.map { s =>
-      (s(xKey), s(yKey))
-    })
-    val functionPlots = fn(0.0).zipWithIndex.toList.map {
-      case (_, i) =>
-        FunctionPlot.series(x => fn(x)(i), "", HSLA(0, 100, 56, 0.5), Some(scatter.xbounds))
-    }
-    show(
-      Overlay
-        .fromSeq(scatter :: functionPlots)
-        .xAxis()
-        .yAxis()
-        .frame()
-        .xLabel(xKey)
-        .yLabel(yKey))
-  }
-
-  private def shadedRenderer(intervals: Seq[(Double, (Double,Double))]) = new PlotRenderer {
-    def render(plot: Plot, plotExtent: Extent)(implicit theme: Theme): Drawable = {
-
-      val xtransformer = plot.xtransform(plot, plotExtent)
-      val ytransformer = plot.ytransform(plot, plotExtent)
-
-      val points = intervals.map{case (x, (y1, _)) => 
-        Point(xtransformer(x), ytransformer(y1))
-      } ++ intervals.reverse.map{case (x, (_, y2)) =>
-        Point(xtransformer(x), ytransformer(y2))
-      }
-      Polygon(points).filled(HSLA(210, 100, 0, 0.2))
-    }
-  }
-
-  def scatterShaded(seq: Seq[Map[String, Double]], xKey: String, yKey: String)(
-    fn: Double => Seq[Double])(implicit oh: OutputHandler,
-                               extent: Extent): Unit = {
-    val xy = seq.map { s => (s(xKey), s(yKey)) }
-    val scatter = scatterPlot(xy)  
+  val font = java.awt.GraphicsEnvironment
+              .getLocalGraphicsEnvironment
+              .getAvailableFontFamilyNames
+              .find(_.startsWith("Century Schoolbook"))
+              .getOrElse("Arial")
   
-    val minX = BigDecimal(scatter.xbounds.min)
-    val maxX = BigDecimal(scatter.xbounds.max)
-    val grid = (maxX - minX) / 20.0
-    val xVals = (minX - grid).to(maxX+grid).by(grid).map(_.toDouble).toList
-    val intervals = xVals.map{x => (x, hdpi(fn(x)))}
+  implicit val extent = Extent(400, 400)
+  implicit val theme = Theme(
+      fonts = DefaultTheme.DefaultFonts.copy(
+          tickLabelSize = 11,
+          labelSize = 12,
+          fontFace = font
+      ),
+      colors = DefaultTheme.DefaultColors.copy(
+          point = HSLA(211, 38, 48, 0.5),
+          fill = HSLA(210, 100, 0, 0.2)
+      ),
+      elements = DefaultTheme.DefaultElements.copy(
+      
+      )
+  )
+def density[N](seq: Seq[N], xLabel: String = "", bounds: Option[Bounds] = None)(implicit num: Numeric[N], theme: Theme): Plot = 
+  Histogram(
+          seq.map{n => num.toDouble(n)},
+          binningFunction = Histogram.density,
+          xbounds = bounds)
+    .xLabel(xLabel)
+    .yLabel("Density")
+    .xAxis()
+    .yAxis()
+    .frame()
 
-    val shaded = Plot(
-      scatter.xbounds,
-      scatter.ybounds,
-      shadedRenderer(intervals))
+def scatter[M,N](seq: Seq[(M,N)])(implicit mNum: Numeric[M], nNum: Numeric[N], theme: Theme): Plot = 
+  ScatterPlot(seq.map{p => Point(mNum.toDouble(p._1), nNum.toDouble(p._2))})
 
-    val line = LinePlot.series(intervals.map{case (x, (y1, y2)) => 
-        Point(x, y1 + ((y2 - y1)/2))
-    }, "", HSLA(210, 100, 0, 0.8))
-    
-    show(Overlay(shaded, scatter, line)
-        .xAxis()
-        .yAxis()
-        .frame()
-        .xLabel(xKey)
-        .yLabel(yKey))
-  }
+def contour[M,N](seq: Seq[(M,N)])(implicit mNum: Numeric[M], nNum: Numeric[N], theme: Theme): Plot = 
+  ContourPlot(
+      seq.map{p => Point(mNum.toDouble(p._1), nNum.toDouble(p._2))},
+      surfaceRenderer = Some(SurfaceRenderer.contours()))
 
-  def contour[N](seq: Seq[(N, N)], xLabel: String = "x", yLabel: String = "y")(
-      implicit num: Numeric[N],
-      oh: OutputHandler,
-      extent: Extent): Unit =
-    show(
-      ContourPlot(
-        seq.map { p =>
-          Point(num.toDouble(p._1), num.toDouble(p._2))
-        },
-        surfaceRenderer = Some(
-          SurfaceRenderer.contours(color = Some(HTMLNamedColors.dodgerBlue))))
-        .xAxis()
-        .yAxis()
-        .frame()
-        .xLabel(xLabel)
-        .yLabel(yLabel))
+def lines(xbounds: Bounds)(fn: Double => Seq[Double])(implicit theme: Theme): Plot = 
+  Overlay.fromSeq(fn(0.0).zipWithIndex.toList.map{
+      case(_, i) =>
+          FunctionPlot.series(x => fn(x)(i), "", theme.colors.trendLine, Some(xbounds))
+  })
+  
+def line(xbounds: Bounds)(fn: Double => Double)(implicit theme: Theme): Plot = 
+  lines(xbounds){x => List(fn(x))}
 
-  def contour(seq: Seq[Map[String, Double]], xKey: String, yKey: String)(
-      implicit oh: OutputHandler,
-      extent: Extent): Unit =
-    contour(seq.map { s =>
-      (s(xKey), s(yKey))
-    }, xKey, yKey)
+def shade[M,N](intervals: Seq[(M,(N,N))])(implicit mNum: Numeric[M], nNum: Numeric[N]): Plot = {
+  val doubleTriples = intervals.map{case (m,(n1,n2)) => (mNum.toDouble(m), nNum.toDouble(n1), nNum.toDouble(n2))}
+  val minX = doubleTriples.map(_._1).min
+  val maxX = doubleTriples.map(_._1).max
+  val minY = doubleTriples.map(_._2).min
+  val maxY = doubleTriples.map(_._3).max
+  
+  Plot(Bounds(minX, maxX), Bounds(minY, maxY),
+      new PlotRenderer {
+          def render(plot: Plot, plotExtent: Extent)(implicit theme: Theme) = {
+            val xtransformer = plot.xtransform(plot, plotExtent)
+            val ytransformer = plot.ytransform(plot, plotExtent)
 
-  private def show(p: Plot)(implicit oh: OutputHandler, extent: Extent): Unit =
-    show(List(List(p)))
-
-  private def show(plots: List[List[Plot]])(implicit oh: OutputHandler,
-                                            extent: Extent): Unit =
-    DisplayData
-      .png(renderBytes(plots))
-      .show()
-
-  private def renderBytes(plots: List[List[Plot]])(
-      implicit extent: Extent): Array[Byte] = {
-    val baos = new java.io.ByteArrayOutputStream
-    val bi = com.cibo.evilplot.plot.Facets(plots).render(extent).asBufferedImage
-    val width = extent.width.toInt
-    val height = extent.height.toInt
-    //enforce that we actually get the dimensions we asked for
-    val bo = new java.awt.image.BufferedImage(width, height, bi.getType)
-    val g2d = bo.createGraphics()
-    g2d.drawImage(
-      bi.getScaledInstance(width, height, java.awt.Image.SCALE_SMOOTH),
-      0,
-      0,
-      width,
-      height,
-      null)
-    g2d.dispose()
-    javax.imageio.ImageIO.write(bo, "png", baos)
-    val array = baos.toByteArray
-    baos.close
-    array
-  }
-
-  //copied from private evilplot class
-  private case class SurfacePlotRenderer(
-    data: Seq[Seq[Seq[Point3]]],
-    surfaceRenderer: SurfaceRenderer
-  ) extends PlotRenderer {
-    // Throw away empty levels.
-    private val allLevels = data.flatMap(_.headOption.map(_.headOption.map(_.z).getOrElse(0d)))
-
-    override def legendContext: LegendContext = {
-      surfaceRenderer.legendContext(allLevels)
-    }
-
-    def render(plot: Plot, plotExtent: Extent)(implicit theme: Theme): Drawable = {
-      val xtransformer = plot.xtransform(plot, plotExtent)
-      val ytransformer = plot.ytransform(plot, plotExtent)
-
-      data.zipWithIndex
-        .withFilter(_._1.nonEmpty)
-        .map {
-          case (level, index) =>
-            val transformedAndCulled = level.map { path =>
-              path
-                .withFilter { p =>
-                  plot.xbounds.isInBounds(p.x) && plot.ybounds.isInBounds(p.y)
-                }
-                .map(p => Point(xtransformer(p.x), ytransformer(p.y)))
+            val points = doubleTriples.map{case (x, y1, _) => 
+              Point(xtransformer(x), ytransformer(y1))
+            } ++ doubleTriples.reverse.map{case (x, _, y2) =>
+              Point(xtransformer(x), ytransformer(y2))
             }
-            val levelContext =
-              SurfaceRenderContext(allLevels, transformedAndCulled, allLevels(index))
-            surfaceRenderer.render(plot, plotExtent, levelContext)
-        }
-        .group
-    }
-  }
+              
+            Polygon(points).filled(theme.colors.fill)
+          }
+      })
+}
+  
+def show(xLabel: String, yLabel: String, plots: Plot*)(
+  implicit extent: Extent, theme: Theme, oh: OutputHandler): Unit = 
+  show(Overlay
+       .fromSeq(plots)
+       .xAxis()
+       .yAxis()
+       .frame()
+       .xLabel(xLabel)
+       .yLabel(yLabel))
+  
+def show(plot: Plot)(implicit extent: Extent, theme: Theme, oh: OutputHandler): Unit =
+  DisplayData
+        .png(renderBytes(plot))
+        .show()
+  
+def renderBytes(plot: Plot)(implicit extent: Extent, theme: Theme): Array[Byte] = {
+  val baos = new java.io.ByteArrayOutputStream
+  val bi = plot.render(extent).asBufferedImage
+  val width = extent.width.toInt
+  val height = extent.height.toInt
+  //enforce that we actually get the dimensions we asked for
+  val bo = new java.awt.image.BufferedImage(width, height, bi.getType)
+  val g2d = bo.createGraphics()
+  g2d.drawImage(
+    bi.getScaledInstance(width, height, java.awt.Image.SCALE_SMOOTH),
+    0,
+    0,
+    width,
+    height,
+    null)
+  g2d.dispose()
+  javax.imageio.ImageIO.write(bo, "png", baos)
+  val array = baos.toByteArray
+  baos.close
+  array
+}
 }

--- a/rainier-plot/src/main/scala/com/stripe/rainier/plot/Jupyter.scala
+++ b/rainier-plot/src/main/scala/com/stripe/rainier/plot/Jupyter.scala
@@ -106,11 +106,6 @@ object Jupyter {
     }
   }
 
-  private def median(seq: Seq[Double]): Double = {
-    val sorted = seq.toList.sorted
-    sorted(seq.size / 2)
-  }
-
   def scatterShaded(seq: Seq[Map[String, Double]], xKey: String, yKey: String)(
     fn: Double => Seq[Double])(implicit oh: OutputHandler,
                                extent: Extent): Unit = {

--- a/rainier-plot/src/main/scala/com/stripe/rainier/plot/Jupyter.scala
+++ b/rainier-plot/src/main/scala/com/stripe/rainier/plot/Jupyter.scala
@@ -137,7 +137,7 @@ object Jupyter {
         .fromSeq(plots)
         .xAxis()
         .frame()
-        .xLabel(xLabel)
+        .xLabel(xLabel))
 
   def show(plot: Plot)(implicit extent: Extent,
                        theme: Theme,

--- a/rainier-plot/src/main/scala/com/stripe/rainier/plot/Jupyter.scala
+++ b/rainier-plot/src/main/scala/com/stripe/rainier/plot/Jupyter.scala
@@ -30,19 +30,16 @@ object Jupyter {
     show(EvilTracePlot.pairs(out, truth, numBars))
   }
 
-  def histogram[N](seq: Seq[N], numBars: Int = 40)(implicit num: Numeric[N],
+  def histogram[N](seq: Seq[N], bounds: Option[(Double,Double)] = None)(implicit num: Numeric[N],
                                                    oh: OutputHandler,
-                                                   extent: Extent): Unit = {
+                                                   extent: Extent): Unit =
     show(
       Histogram(seq.map { n =>
         num.toDouble(n)
-      }, numBars)
+      }, binningFunction = Histogram.density,
+      xbounds = bounds.map{case (a,b) => Bounds(a,b)})
         .xAxis()
-        .yAxis()
-        .frame()
-        .xLabel("x")
-        .yLabel("Frequency"))
-  }
+        .frame())
 
   private def scatterPlot[N](seq: Seq[(N, N)])(implicit num: Numeric[N]): Plot =
     ScatterPlot(

--- a/rainier-plot/src/main/scala/com/stripe/rainier/plot/Jupyter.scala
+++ b/rainier-plot/src/main/scala/com/stripe/rainier/plot/Jupyter.scala
@@ -9,113 +9,140 @@ import com.cibo.evilplot.plot.renderers._
 import com.cibo.evilplot.plot.aesthetics._
 
 object Jupyter {
-  val font = java.awt.GraphicsEnvironment
-              .getLocalGraphicsEnvironment
-              .getAvailableFontFamilyNames
-              .find(_.startsWith("Century Schoolbook"))
-              .getOrElse("Arial")
-  
+  val font =
+    java.awt.GraphicsEnvironment.getLocalGraphicsEnvironment.getAvailableFontFamilyNames
+      .find(_.startsWith("Century Schoolbook"))
+      .getOrElse("Arial")
+
   implicit val extent = Extent(400, 400)
   implicit val theme = Theme(
-      fonts = DefaultTheme.DefaultFonts.copy(
-          tickLabelSize = 11,
-          labelSize = 12,
-          fontFace = font
-      ),
-      colors = DefaultTheme.DefaultColors.copy(
-          point = HSLA(211, 38, 48, 0.5),
-          fill = HSLA(210, 100, 0, 0.2)
-      ),
-      elements = DefaultTheme.DefaultElements.copy(
-      
+    fonts = DefaultTheme.DefaultFonts.copy(
+      tickLabelSize = 11,
+      labelSize = 12,
+      fontFace = font
+    ),
+    colors = DefaultTheme.DefaultColors.copy(
+      point = HSLA(211, 38, 48, 0.5),
+      fill = HSLA(210, 100, 0, 0.2)
+    ),
+    elements = DefaultTheme.DefaultElements.copy(
       )
   )
-def density[N](seq: Seq[N], xLabel: String = "", bounds: Option[Bounds] = None)(implicit num: Numeric[N], theme: Theme): Plot = 
-  Histogram(
-          seq.map{n => num.toDouble(n)},
-          binningFunction = Histogram.density,
-          xbounds = bounds)
-    .xLabel(xLabel)
-    .yLabel("Density")
-    .xAxis()
-    .yAxis()
-    .frame()
+  def density[N](seq: Seq[N],
+                 xLabel: String = "",
+                 bounds: Option[Bounds] = None)(implicit num: Numeric[N],
+                                                theme: Theme): Plot =
+    Histogram(seq.map { n =>
+      num.toDouble(n)
+    }, binningFunction = Histogram.density, xbounds = bounds)
+      .xLabel(xLabel)
+      .yLabel("Density")
+      .xAxis()
+      .yAxis()
+      .frame()
 
-def scatter[M,N](seq: Seq[(M,N)])(implicit mNum: Numeric[M], nNum: Numeric[N], theme: Theme): Plot = 
-  ScatterPlot(seq.map{p => Point(mNum.toDouble(p._1), nNum.toDouble(p._2))})
+  def scatter[M, N](seq: Seq[(M, N)])(implicit mNum: Numeric[M],
+                                      nNum: Numeric[N],
+                                      theme: Theme): Plot =
+    ScatterPlot(seq.map { p =>
+      Point(mNum.toDouble(p._1), nNum.toDouble(p._2))
+    })
 
-def contour[M,N](seq: Seq[(M,N)])(implicit mNum: Numeric[M], nNum: Numeric[N], theme: Theme): Plot = 
-  ContourPlot(
-      seq.map{p => Point(mNum.toDouble(p._1), nNum.toDouble(p._2))},
-      surfaceRenderer = Some(SurfaceRenderer.contours()))
+  def contour[M, N](seq: Seq[(M, N)])(implicit mNum: Numeric[M],
+                                      nNum: Numeric[N],
+                                      theme: Theme): Plot =
+    ContourPlot(seq.map { p =>
+      Point(mNum.toDouble(p._1), nNum.toDouble(p._2))
+    }, surfaceRenderer = Some(SurfaceRenderer.contours()))
 
-def lines(xbounds: Bounds)(fn: Double => Seq[Double])(implicit theme: Theme): Plot = 
-  Overlay.fromSeq(fn(0.0).zipWithIndex.toList.map{
-      case(_, i) =>
-          FunctionPlot.series(x => fn(x)(i), "", theme.colors.trendLine, Some(xbounds))
-  })
-  
-def line(xbounds: Bounds)(fn: Double => Double)(implicit theme: Theme): Plot = 
-  lines(xbounds){x => List(fn(x))}
+  def lines(xbounds: Bounds)(fn: Double => Seq[Double])(
+      implicit theme: Theme): Plot =
+    Overlay.fromSeq(fn(0.0).zipWithIndex.toList.map {
+      case (_, i) =>
+        FunctionPlot.series(x => fn(x)(i),
+                            "",
+                            theme.colors.trendLine,
+                            Some(xbounds))
+    })
 
-def shade[M,N](intervals: Seq[(M,(N,N))])(implicit mNum: Numeric[M], nNum: Numeric[N]): Plot = {
-  val doubleTriples = intervals.map{case (m,(n1,n2)) => (mNum.toDouble(m), nNum.toDouble(n1), nNum.toDouble(n2))}
-  val minX = doubleTriples.map(_._1).min
-  val maxX = doubleTriples.map(_._1).max
-  val minY = doubleTriples.map(_._2).min
-  val maxY = doubleTriples.map(_._3).max
-  
-  Plot(Bounds(minX, maxX), Bounds(minY, maxY),
+  def line(xbounds: Bounds)(fn: Double => Double)(implicit theme: Theme): Plot =
+    lines(xbounds) { x =>
+      List(fn(x))
+    }
+
+  def shade[M, N](intervals: Seq[(M, (N, N))])(implicit mNum: Numeric[M],
+                                               nNum: Numeric[N]): Plot = {
+    val doubleTriples = intervals.map {
+      case (m, (n1, n2)) =>
+        (mNum.toDouble(m), nNum.toDouble(n1), nNum.toDouble(n2))
+    }
+    val minX = doubleTriples.map(_._1).min
+    val maxX = doubleTriples.map(_._1).max
+    val minY = doubleTriples.map(_._2).min
+    val maxY = doubleTriples.map(_._3).max
+
+    Plot(
+      Bounds(minX, maxX),
+      Bounds(minY, maxY),
       new PlotRenderer {
-          def render(plot: Plot, plotExtent: Extent)(implicit theme: Theme) = {
-            val xtransformer = plot.xtransform(plot, plotExtent)
-            val ytransformer = plot.ytransform(plot, plotExtent)
+        def render(plot: Plot, plotExtent: Extent)(implicit theme: Theme) = {
+          val xtransformer = plot.xtransform(plot, plotExtent)
+          val ytransformer = plot.ytransform(plot, plotExtent)
 
-            val points = doubleTriples.map{case (x, y1, _) => 
+          val points = doubleTriples.map {
+            case (x, y1, _) =>
               Point(xtransformer(x), ytransformer(y1))
-            } ++ doubleTriples.reverse.map{case (x, _, y2) =>
+          } ++ doubleTriples.reverse.map {
+            case (x, _, y2) =>
               Point(xtransformer(x), ytransformer(y2))
-            }
-              
-            Polygon(points).filled(theme.colors.fill)
           }
-      })
-}
-  
-def show(xLabel: String, yLabel: String, plots: Plot*)(
-  implicit extent: Extent, theme: Theme, oh: OutputHandler): Unit = 
-  show(Overlay
-       .fromSeq(plots)
-       .xAxis()
-       .yAxis()
-       .frame()
-       .xLabel(xLabel)
-       .yLabel(yLabel))
-  
-def show(plot: Plot)(implicit extent: Extent, theme: Theme, oh: OutputHandler): Unit =
-  DisplayData
-        .png(renderBytes(plot))
-        .show()
-  
-def renderBytes(plot: Plot)(implicit extent: Extent, theme: Theme): Array[Byte] = {
-  val baos = new java.io.ByteArrayOutputStream
-  val bi = plot.render(extent).asBufferedImage
-  val width = extent.width.toInt
-  val height = extent.height.toInt
-  //enforce that we actually get the dimensions we asked for
-  val bo = new java.awt.image.BufferedImage(width, height, bi.getType)
-  val g2d = bo.createGraphics()
-  g2d.drawImage(
-    bi.getScaledInstance(width, height, java.awt.Image.SCALE_SMOOTH),
-    0,
-    0,
-    width,
-    height,
-    null)
-  g2d.dispose()
-  javax.imageio.ImageIO.write(bo, "png", baos)
-  val array = baos.toByteArray
-  baos.close
-  array
-}
+
+          Polygon(points).filled(theme.colors.fill)
+        }
+      }
+    )
+  }
+
+  def show(xLabel: String, yLabel: String, plots: Plot*)(
+      implicit extent: Extent,
+      theme: Theme,
+      oh: OutputHandler): Unit =
+    show(
+      Overlay
+        .fromSeq(plots)
+        .xAxis()
+        .yAxis()
+        .frame()
+        .xLabel(xLabel)
+        .yLabel(yLabel))
+
+  def show(plot: Plot)(implicit extent: Extent,
+                       theme: Theme,
+                       oh: OutputHandler): Unit =
+    DisplayData
+      .png(renderBytes(plot))
+      .show()
+
+  def renderBytes(plot: Plot)(implicit extent: Extent,
+                              theme: Theme): Array[Byte] = {
+    val baos = new java.io.ByteArrayOutputStream
+    val bi = plot.render(extent).asBufferedImage
+    val width = extent.width.toInt
+    val height = extent.height.toInt
+    //enforce that we actually get the dimensions we asked for
+    val bo = new java.awt.image.BufferedImage(width, height, bi.getType)
+    val g2d = bo.createGraphics()
+    g2d.drawImage(
+      bi.getScaledInstance(width, height, java.awt.Image.SCALE_SMOOTH),
+      0,
+      0,
+      width,
+      height,
+      null)
+    g2d.dispose()
+    javax.imageio.ImageIO.write(bo, "png", baos)
+    val array = baos.toByteArray
+    baos.close
+    array
+  }
 }

--- a/rainier-plot/src/main/scala/com/stripe/rainier/plot/Jupyter.scala
+++ b/rainier-plot/src/main/scala/com/stripe/rainier/plot/Jupyter.scala
@@ -34,20 +34,13 @@ object Jupyter {
   def density[N](seq: Seq[N], minX: Double, maxX: Double)(
       implicit num: Numeric[N],
       theme: Theme): Plot =
-    density(seq, "", Some(Bounds(minX, maxX)))
+    density(seq, Some(Bounds(minX, maxX)))
 
-  def density[N](seq: Seq[N],
-                 xLabel: String = "",
-                 bounds: Option[Bounds] = None)(implicit num: Numeric[N],
+  def density[N](seq: Seq[N], bounds: Option[Bounds] = None)(implicit num: Numeric[N],
                                                 theme: Theme): Plot =
     Histogram(seq.map { n =>
       num.toDouble(n)
     }, binningFunction = Histogram.density, xbounds = bounds)
-      .xLabel(xLabel)
-      .yLabel("Density")
-      .xAxis()
-      .yAxis()
-      .frame()
 
   def scatter[M, N](seq: Seq[(M, N)])(implicit mNum: Numeric[M],
                                       nNum: Numeric[N],
@@ -134,6 +127,17 @@ object Jupyter {
         .frame()
         .xLabel(xLabel)
         .yLabel(yLabel))
+
+  def show(xLabel: String, plots: Plot*)(
+    implicit extent: Extent,
+    theme: Theme,
+    oh: OutputHandler): Unit =
+    show(
+      Overlay
+        .fromSeq(plots)
+        .xAxis()
+        .frame()
+        .xLabel(xLabel)
 
   def show(plot: Plot)(implicit extent: Extent,
                        theme: Theme,

--- a/rainier-plot/src/main/scala/com/stripe/rainier/plot/Jupyter.scala
+++ b/rainier-plot/src/main/scala/com/stripe/rainier/plot/Jupyter.scala
@@ -28,6 +28,12 @@ object Jupyter {
     elements = DefaultTheme.DefaultElements.copy(
       )
   )
+
+  def density[N](seq: Seq[N], minX: Double, maxX: Double)(
+      implicit num: Numeric[N],
+      theme: Theme): Plot =
+    density(seq, "", Some(Bounds(minX, maxX)))
+
   def density[N](seq: Seq[N],
                  xLabel: String = "",
                  bounds: Option[Bounds] = None)(implicit num: Numeric[N],

--- a/rainier-plot/src/main/scala/com/stripe/rainier/plot/Jupyter.scala
+++ b/rainier-plot/src/main/scala/com/stripe/rainier/plot/Jupyter.scala
@@ -26,7 +26,9 @@ object Jupyter {
       fill = HSLA(210, 100, 0, 0.2)
     ),
     elements = DefaultTheme.DefaultElements.copy(
-      )
+      strokeWidth = 0.5,
+      pointSize = 3
+    )
   )
 
   def density[N](seq: Seq[N], minX: Double, maxX: Double)(


### PR DESCRIPTION
This adds a `scatterShaded` method to the `Jupyter` tools in the style of Statistical Rethinking. It takes the same interface as `scatterLines`, where you provide both raw 2D data and a function to do posterior predictions from x => y, but rather then drawing a line for each sample, it shades the HDPI region of those samples, and then draws a single line through the center of that region.

I originally attempted to do a full density heatmap but that was taking too much time to do correctly, so I settled for this.

![Screenshot from 2019-07-04 13-54-12](https://user-images.githubusercontent.com/9892/60687398-3e8eaf00-9e63-11e9-8da4-fb69a545a591.png)
