### PR TITLE
Do not cast to Double in loadCSV to support non-numeric data

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/repl/package.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/repl/package.scala
@@ -32,13 +32,13 @@ package object repl {
   }
 
   def loadCSV(path: String,
-              delimiter: String = ","): List[Map[String, Double]] = {
+              delimiter: String = ","): List[Map[String, String]] = {
     val (head :: tail) = scala.io.Source.fromFile(path).getLines.toList
     val headings = head.split(delimiter).map { s =>
       s.stripPrefix("\"").stripSuffix("\"")
     }
     tail.map { line =>
-      headings.zip(line.split(delimiter).map(_.toDouble)).toMap
+      headings.zip(line.split(delimiter)).toMap
     }
   }
 


### PR DESCRIPTION
As previously written, `loadCSV` only works if all columns in the CSV are numeric. This removes the type conversion from `loadCSV` so it can work on different types of input.