### PR TITLE
refactor to allow Predictor.fit

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Likelihood.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Likelihood.scala
@@ -10,7 +10,8 @@ trait Likelihood[T] {
 
   def fit(value: T): RandomVariable[Unit] = {
     val doubles = extract(value)
-    val map = placeholders.zip(doubles).map{case (p,d) => p -> Array(d)}.toMap
+    val map =
+      placeholders.zip(doubles).map { case (p, d) => p -> Array(d) }.toMap
     val density = new Target(real, map).inlined
     RandomVariable.fromDensity(density)
   }

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Likelihood.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Likelihood.scala
@@ -8,6 +8,13 @@ trait Likelihood[T] {
   def placeholders: List[Variable]
   def extract(t: T): List[Double]
 
+  def fit(value: T): RandomVariable[Unit] = {
+    val doubles = extract(value)
+    val map = placeholders.zip(doubles).map{case (p,d) => p -> Array(d)}.toMap
+    val density = new Target(real, map).inlined
+    RandomVariable.fromDensity(density)
+  }
+
   def fit(seq: Seq[T]): RandomVariable[Unit] = {
     val arrayBufs =
       placeholders.map { _ =>

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Predictor.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Predictor.scala
@@ -2,25 +2,8 @@ package com.stripe.rainier.core
 
 import com.stripe.rainier.compute._
 
-/**
-  * Predictor class, for fitting data with covariates
-  */
-sealed trait Predictor[X, L] { self =>
-  type P
-  protected def encoder: Encoder[X] { type U = P }
-  protected def create(p: P): L
-
-  def fit[Y](values: Seq[(X, Y)])(
-      implicit lh: ToLikelihood[L, Y]): RandomVariable[Predictor[X, L]] =
-    Predictor
-      .likelihood[L, X, Y](this)
-      .fit(values)
-      .map { _ =>
-        this
-      }
-
-  def predict[Y](x: X)(implicit gen: ToGenerator[L, Y]): Generator[Y] =
-    gen(create(encoder.wrap(x)))
+sealed trait Predictor[X, L] {
+  def predict[Y](x: X)(implicit gen: ToGenerator[L, Y]): Generator[Y]
 
   def predict[Y](seq: Seq[X])(
       implicit gen: ToGenerator[L, Y]): Generator[Seq[(X, Y)]] =
@@ -31,22 +14,51 @@ sealed trait Predictor[X, L] { self =>
     })
 }
 
-object Predictor {
-  def likelihood[L, X, Y](pred: Predictor[X, L])(
-      implicit lh: ToLikelihood[L, Y]): Likelihood[(X, Y)] = {
-    val (p, vs) = pred.encoder.create(Nil)
-    val l = pred.create(p)
+/**
+  * Predictor class, for fitting data with covariates
+  */
+private[core] trait EncoderPredictor[X, L] extends Predictor[X,L] {
+  type P
+  protected def encoder: Encoder[X] { type U = P }
+  protected def create(p: P): L
+
+  def predict[Y](x: X)(implicit gen: ToGenerator[L, Y]): Generator[Y] =
+    gen(create(encoder.wrap(x)))
+
+  def fit[Y](values: Seq[(X, Y)])(
+      implicit lh: ToLikelihood[L, Y]): RandomVariable[Predictor[X, L]] =
+    likelihood(lh)
+      .fit(values)
+      .map { _ =>
+        this
+      }
+
+  private def likelihood[Y](lh: ToLikelihood[L, Y]): Likelihood[(X, Y)] = {
+    val (p, vs) = encoder.create(Nil)
+    val l = create(p)
     val inner = lh(l)
     new Likelihood[(X, Y)] {
       val real = inner.real
       val placeholders = vs ++ inner.placeholders
       def extract(t: (X, Y)) =
-        pred.encoder.extract(t._1, Nil) ++ inner.extract(t._2)
+        encoder.extract(t._1, Nil) ++ inner.extract(t._2)
+    }
+  }
+}
+
+object Predictor {
+  def fit[L,X,Z](values: Seq[(X, Z)])(fn: X => L)(implicit lh: ToLikelihood[L, Z]): RandomVariable[Predictor[X,L]] = {
+    val rvs = values.map{case (x, z) => lh(fn(x)).fit(z)}
+    RandomVariable.traverse(rvs).map{_ => 
+      new Predictor[X,L] {
+        def predict[Y](x: X)(implicit gen: ToGenerator[L, Y]) =
+          gen(fn(x))
+      }
     }
   }
 
   def lookup[K, L](map: Map[K, Real])(fn: Real => L): Predictor[K, L] =
-    new Predictor[K, L] {
+    new EncoderPredictor[K, L] {
       type P = Real
       val keys = map.keys.toList
       val encoder = new Encoder[K] {
@@ -73,14 +85,14 @@ object Predictor {
   def apply[X](implicit enc: Encoder[X]) =
     new From[X, enc.U] {
       def from[L](fn: enc.U => L) =
-        new Predictor[X, L] {
+        new EncoderPredictor[X, L] {
           type P = enc.U
           val encoder: Encoder.Aux[X, enc.U] = enc
           def create(p: P) = fn(p)
         }
       def fromVector[L](k: Int)(fn: IndexedSeq[enc.U] => L) = {
         val vecEnc = Encoder.vector[X](k)
-        new Predictor[Seq[X], L] {
+        new EncoderPredictor[Seq[X], L] {
           type P = IndexedSeq[enc.U]
           val encoder = vecEnc
           def create(p: P) = fn(p)

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Predictor.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Predictor.scala
@@ -17,7 +17,7 @@ sealed trait Predictor[X, L] {
 /**
   * Predictor class, for fitting data with covariates
   */
-private[core] trait EncoderPredictor[X, L] extends Predictor[X,L] {
+private[core] trait EncoderPredictor[X, L] extends Predictor[X, L] {
   type P
   protected def encoder: Encoder[X] { type U = P }
   protected def create(p: P): L
@@ -47,10 +47,11 @@ private[core] trait EncoderPredictor[X, L] extends Predictor[X,L] {
 }
 
 object Predictor {
-  def fit[L,X,Z](values: Seq[(X, Z)])(fn: X => L)(implicit lh: ToLikelihood[L, Z]): RandomVariable[Predictor[X,L]] = {
-    val rvs = values.map{case (x, z) => lh(fn(x)).fit(z)}
-    RandomVariable.traverse(rvs).map{_ => 
-      new Predictor[X,L] {
+  def fit[L, X, Z](values: Seq[(X, Z)])(fn: X => L)(
+      implicit lh: ToLikelihood[L, Z]): RandomVariable[Predictor[X, L]] = {
+    val rvs = values.map { case (x, z) => lh(fn(x)).fit(z) }
+    RandomVariable.traverse(rvs).map { _ =>
+      new Predictor[X, L] {
         def predict[Y](x: X)(implicit gen: ToGenerator[L, Y]) =
           gen(fn(x))
       }


### PR DESCRIPTION
* narrow the interface of `Predictor` to allow non-`Encoder` implementations
* provide a scalar version of `Likelihood.fit`
* use these to provide an immediate `Predictor.fit` that does not use any vector/placeholder logic, for small datasets