### PR TITLE
bail out of HMC if we get to 0 step size

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/sampler/DualAvg.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/sampler/DualAvg.scala
@@ -81,16 +81,16 @@ private object DualAvg {
   private def computeExponent(logAcceptanceProb: Double): Double =
     if (logAcceptanceProb > Math.log(0.5)) { 1.0 } else { -1.0 }
 
-  private def continueTuningStepSize(logAcceptanceProb: Double,
+  private def continueTuningStepSize(stepSize: Double, logAcceptanceProb: Double,
                                      exponent: Double): Boolean =
-    exponent * logAcceptanceProb > -exponent * Math.log(2)
+    stepSize != 0.0 && (exponent * logAcceptanceProb > -exponent * Math.log(2))
 
   def findReasonableStepSize(lf: LeapFrog, params: Array[Double]): Double = {
     var stepSize = 1.0
     var logAcceptanceProb = lf.tryStepping(params, stepSize)
     val exponent = computeExponent(logAcceptanceProb)
     val doubleOrHalf = Math.pow(2, exponent)
-    while (continueTuningStepSize(logAcceptanceProb, exponent)) {
+    while (continueTuningStepSize(stepSize, logAcceptanceProb, exponent)) {
       stepSize *= doubleOrHalf
       logAcceptanceProb = lf.tryStepping(params, stepSize)
 

--- a/rainier-core/src/main/scala/com/stripe/rainier/sampler/DualAvg.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/sampler/DualAvg.scala
@@ -81,7 +81,8 @@ private object DualAvg {
   private def computeExponent(logAcceptanceProb: Double): Double =
     if (logAcceptanceProb > Math.log(0.5)) { 1.0 } else { -1.0 }
 
-  private def continueTuningStepSize(stepSize: Double, logAcceptanceProb: Double,
+  private def continueTuningStepSize(stepSize: Double,
+                                     logAcceptanceProb: Double,
                                      exponent: Double): Boolean =
     stepSize != 0.0 && (exponent * logAcceptanceProb > -exponent * Math.log(2))
 


### PR DESCRIPTION
This stops trying to find a reasonable step size if our stepSize gets down to 0, since we're obviously never going to get anywhere useful if we're not moving. This will cause a WARNING to be logged further down the call stack.