### PR TITLE
logistic and logit methods

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Real.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Real.scala
@@ -46,6 +46,9 @@ sealed trait Real {
   //because abs does not have a smooth derivative, try to avoid using it
   def abs: Real = RealOps.unary(this, ir.AbsOp)
 
+  def logit: Real = -((Real.one / this - 1).log)
+  def logistic: Real = Real.one / (Real.one + (-this).exp)
+
   lazy val variables: List[Variable] = RealOps.variables(this).toList
   lazy val gradient: List[Real] = Gradient.derive(variables, this)
 

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Support.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Support.scala
@@ -63,14 +63,11 @@ object UnboundedSupport extends Support {
   * A support representing a bounded (min, max) interval.
   */
 case class BoundedSupport(min: Real, max: Real) extends Support {
-  private def logistic(v: Variable): Real =
-    (Real.one / (Real.one + (v * -1).exp))
-
   def transform(v: Variable): Real =
-    logistic(v) * (max - min) + min
+    v.logistic * (max - min) + min
 
   def logJacobian(v: Variable): Real =
-    logistic(v).log + (1 - logistic(v)).log + (max - min).log
+    v.logistic.log + (1 - v.logistic).log + (max - min).log
 }
 
 /**


### PR DESCRIPTION
The `logit` transformation, and its inverse the `logistic` function, are so incredibly commonly used in modeling that they should just be methods on `Real`.