### PR TITLE
bare bones RVG

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/core/RVG.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/RVG.scala
@@ -1,0 +1,21 @@
+package com.stripe.rainier.core
+
+case class RVG[T](value: RandomVariable[Generator[T]]) {
+  def map[U](fn: T => U): RVG[U] = RVG(value.map(_.map(fn)))
+
+  def zip[U](other: RVG[U]): RVG[(T, U)] =
+    RVG(value.zip(other.value).map { case (tg, ug) => tg.zip(ug) })
+
+  def flatMapGen[U](fn: T => Generator[U]): RVG[U] =
+    RVG(value.map(_.flatMap(fn)))
+}
+
+object RVG {
+  def traverse[T](seq: Seq[RVG[T]]): RVG[Seq[T]] =
+    RVG(
+      RandomVariable
+        .traverse(seq.map(_.value))
+        .map { gs =>
+          Generator.traverse(gs)
+        })
+}


### PR DESCRIPTION
This is the simplest possible implementation of an `RVG[T]` type, which is a monad-transformer-style stacking of `RandomVariable[Generator[T]]`. There are lots of convenience methods missing, eg, for converting from `RandomVariable[T:ToGenerator]`, or for sampling `RVG[T]`.

This implementation is technically a functor rather than a monad, because it does not provide `flatMap`. The reasoning is that it doesn't make any sense to create a new `RandomVariable` sequentially after a `Generator` (because `RandomVariable` is about creating/updating the posterior, and `Generator` is about predicting *from* the posterior). However, it does provide a `flatMapGen` for conveniently flatmapping the internal Generator from the stacked object.

