### PR TITLE
bare bones Data

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Data.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Data.scala
@@ -1,0 +1,14 @@
+package com.stripe.rainier.core
+
+case class Data[T](seq: Seq[T]) {
+    def update[L](l: L)(implicit toLH: ToLikelihood[L, T]): RandomVariable[L] = 
+        toLH(l).fit(seq).map{_ => l}
+
+    def update[K,V,L](fn: K => L)(implicit ev: T <:< (K,V), toLH: ToLikelihood[L, V]): RandomVariable[K => L] = {
+        val rvs = seq.map {t => 
+            val (k,v) = ev(t)
+            toLH(fn(k)).fit(v)
+        }
+        RandomVariable.traverse(rvs).map{_ => fn}
+    }
+}


### PR DESCRIPTION
This is a bare bones `Data` class which allows for `Data(seq).update(dist)` instead of `dist.fit(seq)`. It also allows `Data(pairs).update{k => distFor(k)}` instead of `Predictor.fit(pairs){k => distFor(k)}`.

The intent here is to make introducing observations more consistent and flexible instead of the current `dist.fit`. `predictor.fit`, and `Predictor.fit` variations. To actually replace `Predictor` we'll need to introduce a `Fn` type (PR to follow separately).

As with the `RVG` PR, there's a lot of convenience methods we should add here, just trying to get the basics settled.