### PR TITLE
basic Fn trait

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Fn.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Fn.scala
@@ -1,0 +1,35 @@
+package com.stripe.rainier.core
+
+import com.stripe.rainier.compute._
+
+trait Fn[A, Y] {self =>
+  type X
+  protected def encoder: Encoder[A] { type U = X }
+  protected def xy(x: X): Y
+
+  def apply(seq: Seq[A]): Seq[Y] =
+    seq.map{a => xy(encoder.wrap(a))}
+  
+  def zip[B, Z](fn: Fn[B, Z]): Fn[(A, B), (Y, Z)] =
+    new Fn[(A, B), (Y, Z)] {
+        type X = (self.X, fn.X)
+        val encoder = Encoder.zip(self.encoder, fn.encoder)
+        def xy(x: (self.X, fn.X)) = (self.xy(x._1), fn.xy(x._2))
+    }
+
+  def map[Z](g: Y => Z): Fn[A, Z] =
+    new Fn[A,Z] {
+        type X = self.X
+        val encoder = self.encoder
+        def xy(x: X) = g(self.xy(x))
+    }
+}
+
+object Fn {
+  def encode[A](implicit enc: Encoder[A]) =
+    new Fn[A, enc.U] {
+      type X = enc.U
+      val encoder = enc
+      def xy(x: X) = x
+    }
+}

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Fn.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Fn.scala
@@ -31,7 +31,7 @@ object Fn {
   def encode[A](implicit enc: Encoder[A]) =
     new Fn[A, enc.U] {
       type X = enc.U
-      val encoder = enc
+      val encoder: Encoder[A] { type U = X } = enc
       def xy(x: X) = x
     }
 

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Fn.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Fn.scala
@@ -2,26 +2,28 @@ package com.stripe.rainier.core
 
 import com.stripe.rainier.compute._
 
-trait Fn[A, Y] {self =>
+trait Fn[A, Y] { self =>
   type X
   protected def encoder: Encoder[A] { type U = X }
   protected def xy(x: X): Y
 
   def apply(seq: Seq[A]): Seq[Y] =
-    seq.map{a => xy(encoder.wrap(a))}
-  
+    seq.map { a =>
+      xy(encoder.wrap(a))
+    }
+
   def zip[B, Z](fn: Fn[B, Z]): Fn[(A, B), (Y, Z)] =
     new Fn[(A, B), (Y, Z)] {
-        type X = (self.X, fn.X)
-        val encoder = Encoder.zip(self.encoder, fn.encoder)
-        def xy(x: (self.X, fn.X)) = (self.xy(x._1), fn.xy(x._2))
+      type X = (self.X, fn.X)
+      val encoder = Encoder.zip(self.encoder, fn.encoder)
+      def xy(x: (self.X, fn.X)) = (self.xy(x._1), fn.xy(x._2))
     }
 
   def map[Z](g: Y => Z): Fn[A, Z] =
-    new Fn[A,Z] {
-        type X = self.X
-        val encoder = self.encoder
-        def xy(x: X) = g(self.xy(x))
+    new Fn[A, Z] {
+      type X = self.X
+      val encoder = self.encoder
+      def xy(x: X) = g(self.xy(x))
     }
 }
 
@@ -31,5 +33,24 @@ object Fn {
       type X = enc.U
       val encoder = enc
       def xy(x: X) = x
+    }
+
+  def likelihood[A, Y, L](fn: Fn[A, Y],
+                          lh: ToLikelihood[Y, L]): Likelihood[(A, L)] = {
+    val (x, vs) = fn.encoder.create(Nil)
+    val y = fn.xy(x)
+    val inner = lh(y)
+    new Likelihood[(A, L)] {
+      val real = inner.real
+      val placeholders = vs ++ inner.placeholders
+      def extract(t: (A, L)) =
+        fn.encoder.extract(t._1, Nil) ++ inner.extract(t._2)
+    }
+  }
+
+  implicit def toLikelihood[A, Y, L](
+      implicit lh: ToLikelihood[Y, L]): ToLikelihood[Fn[A, Y], (A, L)] =
+    new ToLikelihood[Fn[A, Y], (A, L)] {
+      def apply(fn: Fn[A, Y]) = likelihood(fn, lh)
     }
 }


### PR DESCRIPTION
This is the start of `Fn`, which I'm envisioning as the replacement for `Predictor`. It will be:

* more explicit: you'll create Fns with things like `Fn.encode[Int]` or `Fn.toMap[Foo]` which makes it clearer what's going on
* more composable: it's a functor with zip & map
* more general: it can be used in the posterior prediction phase as well as for fitting models

This now includes the ToLikelihood trait. Using Fn looks like this (example modified from 4.4 of the stats rethinking notebook):

```scala
val pairs = d2.map{m => m.weight -> m.height}

val m4_3 = 
  for{
      sigma <- Uniform(0,50).param
      a <- Normal(178, 100).param
      b <- Normal(0, 10).param
      f = Fn.encode[Double].map{weight => 
          val mu = a + b*weight
          Normal(mu, sigma)      
      }
      _ <- RandomVariable.fit(f, pairs)
  } yield Map("a" -> a, "b" -> b, "sigma" -> sigma)
```

or, in combination with https://github.com/stripe/rainier/pull/355, it looks like this:

```scala
val pairs = Data(d2.map{m => m.weight -> m.height})

val m4_3 = 
  for{
      sigma <- Uniform(0,50).param
      a <- Normal(178, 100).param
      b <- Normal(0, 10).param
      f = Fn.encode[Double].map{weight => 
          val mu = a + b*weight
          Normal(mu, sigma)      
      }
      _ <- pairs.update(f)
  } yield Map("a" -> a, "b" -> b, "sigma" -> sigma)
```