### PR TITLE
Add support for traversing maps in RandomVariable and Generator

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/core/RandomVariable.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/RandomVariable.scala
@@ -202,6 +202,21 @@ object RandomVariable {
       .map(_.reverse)
   }
 
+  def traverse[K, V](
+      rvs: Map[K, RandomVariable[V]]): RandomVariable[Map[K, V]] = {
+    def go(accum: RandomVariable[Map[K, V]], k: K, rv: RandomVariable[V]) = {
+      for {
+        v <- rv
+        vs <- accum
+      } yield vs + (k -> v)
+    }
+
+    rvs
+      .foldLeft[RandomVariable[Map[K, V]]](apply(Map[K, V]())) {
+        case (accum, (k, v)) => go(accum, k, v)
+      }
+  }
+
   def fill[A](k: Int)(fn: => RandomVariable[A]): RandomVariable[Seq[A]] =
     traverse(List.fill(k)(fn))
 

--- a/rainier-tests/src/test/scala/com/stripe/rainier/core/RandomVariableTest.scala
+++ b/rainier-tests/src/test/scala/com/stripe/rainier/core/RandomVariableTest.scala
@@ -72,4 +72,23 @@ class RandomVariableTest extends FunSuite {
                   (x: Real) => Uniform(0, x).param,
                   (x: Real) => Exponential(x).param)
   }
+
+  test("traverse a map") {
+    val input = Map(
+      "zero" -> RandomVariable(DiscreteConstant(0)),
+      "one" -> RandomVariable(DiscreteConstant(1))
+    )
+    val expect = Map(
+      "zero" -> 0,
+      "one" -> 1
+    )
+    implicit val rng: RNG = RNG.default
+
+    assert(
+      expect === RandomVariable
+        .traverse(input)
+        .map(Generator.traverse(_))
+        .sample(1)
+        .head)
+  }
 }


### PR DESCRIPTION
This adds support for Map types to `RandomVariable.traverse` and `Generator.traverse`. For both, we assume that the keys will be constants and the values will be RandomVariable/Generator. Additionally, I've changed the signature to `Generator.traverse` to take an implicit `ToGenerator` for elements of the sequence rather than requiring it to already be a sequence of generators.