### PR TITLE
whiskers plot

### DIFF
--- a/rainier-plot/src/main/scala/com/stripe/rainier/plot/Jupyter.scala
+++ b/rainier-plot/src/main/scala/com/stripe/rainier/plot/Jupyter.scala
@@ -124,7 +124,7 @@ object Jupyter {
     val xb = Bounds(0, seq.size.toDouble)
     val yb = Bounds(
       stats.map(_.min).min,
-      stats.map(_.max).max,
+      stats.map(_.max).max
     )
 
     Plot(

--- a/rainier-plot/src/main/scala/com/stripe/rainier/plot/Jupyter.scala
+++ b/rainier-plot/src/main/scala/com/stripe/rainier/plot/Jupyter.scala
@@ -91,6 +91,16 @@ object Jupyter {
                             Some(xbounds))
     })
 
+  def whiskers[K, N](samples: Seq[Map[String, Double]]): Plot = {
+    val labels = samples.head.keys.toList.sorted
+    val data = labels.map { k =>
+      samples.map { m =>
+        m(k)
+      }
+    }
+    BoxPlot(data).standard(xLabels = labels)
+  }
+
   def shade[M, N](intervals: Seq[(M, (N, N))])(implicit mNum: Numeric[M],
                                                nNum: Numeric[N]): Plot = {
     val doubleTriples = intervals


### PR DESCRIPTION
This adds an option to use evilplot's default BoxPlot to draw box-and-whiskers diagrams from the same sample format as we use in `precis`. Here's an example from the book.

<img width="526" alt="Screen Shot 2019-08-21 at 1 12 49 PM" src="https://user-images.githubusercontent.com/23175169/63465158-7d79c380-c415-11e9-8bfb-1ce040767856.png">
