### PR TITLE
Implement generator traversal using implicits

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Categorical.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Categorical.scala
@@ -126,9 +126,9 @@ final case class Multinomial[T](pmf: Map[T, Real], k: Real)
 }
 
 object Multinomial {
-  def optional[T](pmf: Map[T,Real], k: Real): Multinomial[Option[T]] = {
+  def optional[T](pmf: Map[T, Real], k: Real): Multinomial[Option[T]] = {
     val total = Real.sum(pmf.values)
-    val newPMF = pmf.map{case (t,p) => Option(t) -> p} + (None -> (Real.one - total))
+    val newPMF = pmf.map { case (t, p) => Option(t) -> p } + (None -> (Real.one - total))
     Multinomial(newPMF, k)
   }
 

--- a/rainier-scalacheck/src/main/scala/com/stripe/rainier/scalacheck/package.scala
+++ b/rainier-scalacheck/src/main/scala/com/stripe/rainier/scalacheck/package.scala
@@ -12,12 +12,11 @@ import org.scalacheck.Cogen
 import org.scalacheck.Gen
 
 object `package` {
-
   implicit val arbitraryReal: Arbitrary[Real] =
     Arbitrary(arbitrary[Double].map(Real(_)))
 
   implicit def arbitraryGenerator[A: Arbitrary]: Arbitrary[Generator[A]] =
-    Arbitrary(genGenerator)
+    Arbitrary(genGenerator[A])
 
   def genGenerator[A: Arbitrary]: Gen[Generator[A]] = {
 

--- a/rainier-tests/src/test/scala/com/stripe/rainier/core/GeneratorTest.scala
+++ b/rainier-tests/src/test/scala/com/stripe/rainier/core/GeneratorTest.scala
@@ -1,0 +1,50 @@
+package com.stripe.rainier.core
+
+import com.stripe.rainier.compute._
+import com.stripe.rainier.sampler.RNG
+import org.scalatest.FunSuite
+
+class GeneratorTest extends FunSuite {
+  def assertSampleEquals[T](gen: Generator[T], expect: T) = {
+    implicit val rng: RNG = RNG.default
+    assert(expect === RandomVariable(gen).sample(1).head)
+  }
+
+  case class TraverseMe[T](v: T)
+  object TraverseMe {
+    implicit def generatorTraversal[T, U](
+        implicit toGen: ToGenerator[T, U]
+    ): GeneratorTraversal[TraverseMe[T], TraverseMe[U]] =
+      new GeneratorTraversal[TraverseMe[T], TraverseMe[U]] {
+        def apply(tm: TraverseMe[T]): Generator[TraverseMe[U]] = {
+          val asGen = toGen(tm.v)
+          new Generator[TraverseMe[U]] {
+            val requirements: Set[Real] = asGen.requirements
+            def get(implicit r: RNG, n: Numeric[Real]): TraverseMe[U] =
+              new TraverseMe(asGen.get)
+          }
+        }
+      }
+  }
+
+  test("traverse a seq") {
+    val input = List(
+      Generator.constant(0),
+      Generator.constant(1)
+    )
+    assertSampleEquals(Generator.traverse(input), List(0, 1))
+  }
+
+  test("traverse a map") {
+    val input = Map(
+      "zero" -> Generator.constant(0),
+      "one" -> Generator.constant(1)
+    )
+    assertSampleEquals(Generator.traverse(input), Map("zero" -> 0, "one" -> 1))
+  }
+
+  test("custom case class") {
+    val input = TraverseMe(Generator.constant(0))
+    assertSampleEquals(Generator.traverse(input), TraverseMe(0))
+  }
+}


### PR DESCRIPTION
This re-implements `Generator.traverse` based on a `GeneratorTraversal` implicit trait. This allows for defining traversals for custom classes as demonstrated in the test. I'm pretty sure you could use shapeless with this to implement traversal for any case class where each member has a `ToGenerator`.

Assuming this looks good, I'll implement the same thing for RandomVariable.

