### PR TITLE
Events.observe

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Events.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Events.scala
@@ -1,0 +1,32 @@
+package com.stripe.rainier.core
+
+object Events {
+    def observe[T](seq: Seq[T], dist: Distribution[T]): RandomVariable[Generator[T]] =
+        dist.fit(seq).map(_.generator)
+
+    def observe[X,Y](seq: Seq[(X,Y)])(fn: X => Distribution[Y]): RandomVariable[Seq[X] => Generator[Seq[(X,Y)]]] = {
+        val rvs = seq.map { case (x, z) => fn(x).fit(z)}
+        RandomVariable.traverse(rvs).map { _ =>
+            (seq: Seq[X]) => 
+                Generator.traverse(seq.map{x =>
+                    fn(x).generator.map{y => x -> y}
+                })
+      }
+    }
+
+    def observe[X,Y](seq: Seq[(X,Y)], fn: Fn[X,Distribution[Y]]): RandomVariable[Seq[X] => Generator[Seq[(X,Y)]]] = {
+        val lh = Fn.toLikelihood[X,Distribution[Y],Y](implicitly[ToLikelihood[Distribution[Y],Y]])(fn)
+        lh.fit(seq).map{_ =>
+            (seq: Seq[X]) => 
+                Generator.traverse(seq.zip(fn(seq)).map{case (x,dist) =>
+                    dist.generator.map{y => x -> y}
+                })       
+        }
+    }
+
+    def observe[X,Y](xs: Seq[X], ys: Seq[Y])(fn: X => Distribution[Y]): RandomVariable[Seq[X] => Generator[Seq[(X,Y)]]] =
+        observe(xs.zip(ys))(fn)
+
+    def observe[X,Y](xs: Seq[X], ys: Seq[Y], fn: Fn[X,Distribution[Y]]): RandomVariable[Seq[X] => Generator[Seq[(X,Y)]]] =
+        observe(xs.zip(ys), fn)
+}

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Fn.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Fn.scala
@@ -7,10 +7,7 @@ trait Fn[A, Y] { self =>
   protected def encoder: Encoder[A] { type U = X }
   protected def xy(x: X): Y
 
-  def apply(seq: Seq[A]): Seq[Y] =
-    seq.map { a =>
-      xy(encoder.wrap(a))
-    }
+  def apply(a: A): Y = xy(encoder.wrap(a))
 
   def zip[B, Z](fn: Fn[B, Z]): Fn[(A, B), (Y, Z)] =
     new Fn[(A, B), (Y, Z)] {


### PR DESCRIPTION
This standardizes the ways to observe event data in a single `Events` object with a set of `observe` methods. The implementations here are not new (just moved from other places); the thing to focus on is the naming and choice of signatures. Once choice this makes is for the return value to be to what I believe is the most useful posterior-predictive generator object (eg, for the function variants, it's from `Seq[X] => Generator[Seq[(X,Y)]]`, which (given new feature vectors) produces generated predictive output in the same form as the observed data.)