### PR TITLE
Events class with simulate method

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Events.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Events.scala
@@ -1,16 +1,36 @@
 package com.stripe.rainier.core
 
+case class Events[X, Y, D <: Distribution[Y]](fn: X => D) {
+  def apply(x: X): D = fn(x)
+  def simulate(seq: Seq[X]): Generator[Seq[(X, Y)]] =
+    Generator.traverse(seq.map { x =>
+      fn(x).generator.map { y =>
+        (x, y)
+      }
+    })
+}
+
 object Events {
-    def observe[T,D <: Distribution[T]](seq: Seq[T], dist: D): RandomVariable[D] =
-        dist.fit(seq).map{_ => dist}
-
-    def observe[X,Y,D <: Distribution[Y]](seq: Seq[(X,Y)])(fn: X => D): RandomVariable[X => D] = {
-        val rvs = seq.map { case (x, z) => fn(x).fit(z)}
-        RandomVariable.traverse(rvs).map { _ => fn}
+  def observe[T, D <: Distribution[T]](seq: Seq[T],
+                                       dist: D): RandomVariable[D] =
+    dist.fit(seq).map { _ =>
+      dist
     }
 
-    def observe[X,Y,D <: Distribution[Y]](seq: Seq[(X,Y)], fn: Fn[X,D]): RandomVariable[Fn[X,D]] = {
-        val lh = Fn.toLikelihood[X,D,Y](implicitly[ToLikelihood[D,Y]])(fn)
-        lh.fit(seq).map{_ => fn}
+  def observe[X, Y, D <: Distribution[Y]](seq: Seq[(X, Y)])(
+      fn: X => D): RandomVariable[Events[X, Y, D]] = {
+    val rvs = seq.map { case (x, z) => fn(x).fit(z) }
+    RandomVariable.traverse(rvs).map { _ =>
+      Events(fn)
     }
+  }
+
+  def observe[X, Y, D <: Distribution[Y]](
+      seq: Seq[(X, Y)],
+      fn: Fn[X, D]): RandomVariable[Events[X, Y, D]] = {
+    val lh = Fn.toLikelihood[X, D, Y](implicitly[ToLikelihood[D, Y]])(fn)
+    lh.fit(seq).map { _ =>
+      Events(fn(_))
+    }
+  }
 }


### PR DESCRIPTION
This follow-up to https://github.com/stripe/rainier/pull/365 changes the two `observe` methods that take functions so that instead of returning the bare function, they return a wrapper that provides a `simulate` method, which does the more complex thing the original version of that PR wanted to do (ie, take a Seq[X] and produce a Generator[Seq[(X,Y)]]). This seems like a nice compromise between the simplicity we ended up with and the convenience I was originally aiming for.

Here's an example use (taken from the Ch 4 notebook).

![Screenshot 2019-08-31 at 9 19 22 AM](https://user-images.githubusercontent.com/9892/64066638-3fc52980-cbd1-11e9-8fa9-639447f5c4cc.png)
