### PR TITLE
Bump version to rc3 and fix some types

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Categorical.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Categorical.scala
@@ -126,9 +126,9 @@ final case class Multinomial[T](pmf: Map[T, Real], k: Real)
 }
 
 object Multinomial {
-  def optional[T](pmf: Map[T,Real], k: Real): Multinomial[Option[T]] = {
+  def optional[T](pmf: Map[T, Real], k: Real): Multinomial[Option[T]] = {
     val total = Real.sum(pmf.values)
-    val newPMF = pmf.map{case (t,p) => Option(t) -> p} + (None -> (Real.one - total))
+    val newPMF = pmf.map { case (t, p) => Option(t) -> p } + (None -> (Real.one - total))
     Multinomial(newPMF, k)
   }
 

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Generator.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Generator.scala
@@ -2,6 +2,7 @@ package com.stripe.rainier.core
 
 import com.stripe.rainier.compute._
 import com.stripe.rainier.sampler.RNG
+import scala.collection.Map
 
 /**
   * Generator trait, for posterior predictive distributions to be forwards sampled during sampling

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/RVG.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/RVG.scala
@@ -1,5 +1,7 @@
 package com.stripe.rainier.core
 
+import scala.collection.Map
+
 case class RVG[T](value: RandomVariable[Generator[T]]) {
   def map[U](fn: T => U): RVG[U] = RVG(value.map(_.map(fn)))
 
@@ -18,4 +20,13 @@ object RVG {
         .map { gs =>
           Generator.traverse(gs)
         })
+
+  def traverse[K, V](map: Map[K, RVG[V]]): RVG[Map[K, V]] =
+    RVG(
+      RandomVariable
+        .traverse(map.map { case (k, v) => k -> v.value })
+        .map { gs =>
+          Generator.traverse(gs)
+        }
+    )
 }

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/RandomVariable.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/RandomVariable.scala
@@ -3,6 +3,7 @@ package com.stripe.rainier.core
 import com.stripe.rainier.compute._
 import com.stripe.rainier.sampler._
 import com.stripe.rainier.optimizer._
+import scala.collection.Map
 
 /**
   * The main probability monad used in Rainier for constructing probabilistic programs which can be sampled

--- a/rainier-plot/src/main/scala/com/stripe/rainier/plot/EvilTracePlot.scala
+++ b/rainier-plot/src/main/scala/com/stripe/rainier/plot/EvilTracePlot.scala
@@ -16,6 +16,8 @@ object EvilTracePlot {
   import com.cibo.evilplot.numeric.Point
   import com.cibo.evilplot.geometry.Extent
 
+  import scala.collection.Map
+
   /**
     * Render plots to disk as a PNG file
     *

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.2.3-rc1-SNAPSHOT"
+version in ThisBuild := "0.2.3-rc3-SNAPSHOT"


### PR DESCRIPTION
In the process of pulling in the latest Rainier I noticed some small issues with our latest changes that are reflected here. Upon landing this I'll publish `0.2.3-rc3` internally. Note that I already published `0.2.3-rc2` without the fixes in this PR so I think we have to skip an RC number.