### PR TITLE
Categorical Monad implementation

### DIFF
--- a/rainier-cats/src/main/scala/com/stripe/rainier/cats/package.scala
+++ b/rainier-cats/src/main/scala/com/stripe/rainier/cats/package.scala
@@ -17,7 +17,7 @@ import scala.collection.immutable.Queue
 
 object `package` extends LowPriorityInstances with EqInstances {
   implicit val rainierMonadCategorical: Monad[Categorical] =
-    new MonadCategorical
+    MonadCategorical
   implicit val rainierMonadGenerator: Monad[Generator] = new MonadGenerator
   implicit val rainierMonadRandomVariable: Monad[RandomVariable] =
     new MonadRandomVariable
@@ -41,7 +41,7 @@ private[cats] sealed abstract class LowPriorityInstances {
     }
 }
 
-private[cats] class MonadCategorical extends Monad[Categorical] {
+private[cats] object MonadCategorical extends Monad[Categorical] {
   def pure[A](x: A): Categorical[A] = Categorical(Map(x -> Real.one))
 
   override def map[A, B](fa: Categorical[A])(f: A => B): Categorical[B] =

--- a/rainier-cats/src/main/scala/com/stripe/rainier/cats/package.scala
+++ b/rainier-cats/src/main/scala/com/stripe/rainier/cats/package.scala
@@ -2,7 +2,12 @@ package com.stripe.rainier
 package cats
 
 import com.stripe.rainier.compute.{Constant, Infinity, NegInfinity, Real}
-import com.stripe.rainier.core.{Categorical, Generator, RandomVariable}
+import com.stripe.rainier.core.{
+  updateMap,
+  Categorical,
+  Generator,
+  RandomVariable
+}
 import com.stripe.rainier.sampler.RNG
 import _root_.cats.{Eq, Monad}
 import _root_.cats.kernel.instances.map._
@@ -44,7 +49,7 @@ private[cats] class MonadCategorical extends Monad[Categorical] {
           case (Left(a), r) =>
             run(acc, queue.tail ++ f(a).pmf.mapValues(_ * r))
           case (Right(b), r) =>
-            run(acc.updated(b, acc.getOrElse(b, Real.zero) + r), queue.tail)
+            run(updateMap(acc, b, r)(Real.zero)(_ + _), queue.tail)
         }
       }
     val pmf = run(Map.empty, f(a).pmf.to[Queue])

--- a/rainier-cats/src/main/scala/com/stripe/rainier/cats/package.scala
+++ b/rainier-cats/src/main/scala/com/stripe/rainier/cats/package.scala
@@ -142,7 +142,10 @@ private[cats] trait EqInstances {
       (left, right) match {
         case (Infinity, Infinity) | (NegInfinity, NegInfinity) => true
         case (Constant(a), Constant(b))                        => bde.eqv(a, b)
-        case _                                                 => false
+        // TODO - the Eq instance returned here doesn't test for full
+        // DAG equality; this final case needs to be expanded to
+        // compare the various NonConstant options.
+        case (a, b) => a == b
       }
     }
   }
@@ -160,5 +163,8 @@ private[cats] trait EqInstances {
       n: Numeric[Real]
   ): Eq[Generator[A]] = Eq.by(_.get)
 
+  // TODO - Comparing RandomVariable instances by value alone isn't
+  // sound; a proper Eq instance needs to take density into account as
+  // well.
   implicit def eqRandomVariable[A: Eq]: Eq[RandomVariable[A]] = Eq.by(_.value)
 }

--- a/rainier-cats/src/main/scala/com/stripe/rainier/cats/package.scala
+++ b/rainier-cats/src/main/scala/com/stripe/rainier/cats/package.scala
@@ -1,17 +1,53 @@
 package com.stripe.rainier.cats
 
 import com.stripe.rainier.compute.Real
-import com.stripe.rainier.core.Generator
-import com.stripe.rainier.core.RandomVariable
+import com.stripe.rainier.core.{Categorical, Generator, RandomVariable}
 import com.stripe.rainier.sampler.RNG
-import _root_.cats.Monad
+import _root_.cats.{Monad, StackSafeMonad}
 
 import scala.annotation.tailrec
 
 object `package` {
+  implicit val rainierMonadCategorical: Monad[Categorical] =
+    new MonadCategorical
   implicit val rainierMonadGenerator: Monad[Generator] = new MonadGenerator
   implicit val rainierMonadRandomVariable: Monad[RandomVariable] =
     new MonadRandomVariable
+}
+
+private[cats] class MonadCategorical extends StackSafeMonad[Categorical] {
+  def pure[A](x: A): Categorical[A] = Categorical(Map(x -> Real.one))
+
+  override def map[A, B](fa: Categorical[A])(f: A => B): Categorical[B] =
+    fa.map(f)
+
+  override def product[A, B](
+      fa: Categorical[A],
+      fb: Categorical[B]
+  ): Categorical[(A, B)] = fa.zip(fb)
+
+  override def flatMap[A, B](fa: Categorical[A])(
+      f: A => Categorical[B]): Categorical[B] =
+    fa.flatMap(f)
+
+  // override def tailRecM[A, B](a: A)(
+  //     f: A => Categorical[Either[A, B]]): Categorical[B] = ???
+
+  // def tailRecM[A, B](a: A)(f: A => Categorical[Either[A, B]]): Categorical[B] = {
+  //   @tailrec
+  //   def run(g: Categorical[Either[A, B]], r: RNG, n: Numeric[Real]): B =
+  //     g match {
+  //       case Categorical.Const(_, Left(a))  => run(f(a), r, n)
+  //       case Categorical.Const(_, Right(b)) => b
+  //       case Categorical.From(_, fromFn) =>
+  //         fromFn(r, n) match {
+  //           case Left(a)  => run(f(a), r, n)
+  //           case Right(b) => b
+  //         }
+  //     }
+  //   val step = f(a)
+  //   Categorical.require(step.requirements)(run(step, _, _))
+  // }
 }
 
 private[cats] class MonadGenerator extends Monad[Generator] {

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Real.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Real.scala
@@ -1,4 +1,5 @@
-package com.stripe.rainier.compute
+package com.stripe.rainier
+package compute
 
 import com.stripe.rainier.ir
 
@@ -114,9 +115,9 @@ object Real {
   val negInfinity: Real = NegInfinity
 }
 
-final private case class Constant(value: BigDecimal) extends Real
-final private object Infinity extends Real
-final private object NegInfinity extends Real
+final private[rainier] case class Constant(value: BigDecimal) extends Real
+final private[rainier] object Infinity extends Real
+final private[rainier] object NegInfinity extends Real
 
 sealed trait NonConstant extends Real
 

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Categorical.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Categorical.scala
@@ -1,4 +1,5 @@
-package com.stripe.rainier.core
+package com.stripe.rainier
+package core
 
 import com.stripe.rainier.compute._
 
@@ -9,21 +10,25 @@ import com.stripe.rainier.compute._
   */
 final case class Categorical[T](pmf: Map[T, Real]) extends Distribution[T] {
   self =>
+
   def map[U](fn: T => U): Categorical[U] =
-    flatMap { t =>
-      Categorical(Map(fn(t) -> Real.one))
-    }
+    Categorical(
+      pmf.foldLeft(Map.empty[U, Real]) {
+        case (acc, (t, p)) =>
+          updateMap(acc, fn(t), p)(Real.zero)(_ + _)
+      }
+    )
 
   def flatMap[U](fn: T => Categorical[U]): Categorical[U] =
     Categorical(
-      pmf.toList
-        .flatMap {
-          case (t, p) =>
-            fn(t).pmf.toList.map { case (u, p2) => (u, p * p2) }
-        }
-        .groupBy(_._1)
-        .map { case (u, ups) => u -> Real.sum(ups.map(_._2)) }
-        .toMap)
+      (for {
+        (t, p) <- pmf.iterator
+        (u, p2) <- fn(t).pmf.iterator
+      } yield (u, p * p2)).foldLeft(Map.empty[U, Real]) {
+        case (acc, (u, p)) =>
+          updateMap(acc, u, p)(Real.zero)(_ + _)
+      }
+    )
 
   def zip[U](other: Categorical[U]): Categorical[(T, U)] =
     for {

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Categorical.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Categorical.scala
@@ -96,9 +96,6 @@ object Categorical {
       Real(l.size)
     })
 
-  def fromSet[T](ts: Set[T]): Categorical[T] =
-    normalize(ts.foldLeft(Map.empty[T, Real])((m, t) => m.updated(t, Real.one)))
-
   implicit def gen[T]: ToGenerator[Categorical[T], T] =
     new ToGenerator[Categorical[T], T] {
       def apply(c: Categorical[T]) = c.generator

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Categorical.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Categorical.scala
@@ -31,10 +31,12 @@ final case class Categorical[T](pmf: Map[T, Real]) extends Distribution[T] {
     )
 
   def zip[U](other: Categorical[U]): Categorical[(T, U)] =
-    for {
-      t <- this
-      u <- other
-    } yield (t, u)
+    Categorical(
+      for {
+        (t, p) <- pmf
+        (u, p2) <- other.pmf
+      } yield ((t, u), p * p2)
+    )
 
   def generator: Generator[T] = {
     val cdf =

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Events.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Events.scala
@@ -1,26 +1,16 @@
 package com.stripe.rainier.core
 
 object Events {
-  def observe[T, D <: Distribution[T]](seq: Seq[T],
-                                       dist: D): RandomVariable[D] =
-    dist.fit(seq).map { _ =>
-      dist
+    def observe[T,D <: Distribution[T]](seq: Seq[T], dist: D): RandomVariable[D] =
+        dist.fit(seq).map{_ => dist}
+
+    def observe[X,Y,D <: Distribution[Y]](seq: Seq[(X,Y)])(fn: X => D): RandomVariable[X => D] = {
+        val rvs = seq.map { case (x, z) => fn(x).fit(z)}
+        RandomVariable.traverse(rvs).map { _ => fn}
     }
 
-  def observe[X, Y, D <: Distribution[Y]](seq: Seq[(X, Y)])(
-      fn: X => D): RandomVariable[X => D] = {
-    val rvs = seq.map { case (x, z) => fn(x).fit(z) }
-    RandomVariable.traverse(rvs).map { _ =>
-      fn
+    def observe[X,Y,D <: Distribution[Y]](seq: Seq[(X,Y)], fn: Fn[X,D]): RandomVariable[Fn[X,D]] = {
+        val lh = Fn.toLikelihood[X,D,Y](implicitly[ToLikelihood[D,Y]])(fn)
+        lh.fit(seq).map{_ => fn}
     }
-  }
-
-  def observe[X, Y, D <: Distribution[Y]](
-      seq: Seq[(X, Y)],
-      fn: Fn[X, D]): RandomVariable[Fn[X, D]] = {
-    val lh = Fn.toLikelihood[X, D, Y](implicitly[ToLikelihood[D, Y]])(fn)
-    lh.fit(seq).map { _ =>
-      fn
-    }
-  }
 }

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Events.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Events.scala
@@ -1,16 +1,26 @@
 package com.stripe.rainier.core
 
 object Events {
-    def observe[T,D <: Distribution[T]](seq: Seq[T], dist: D): RandomVariable[D] =
-        dist.fit(seq).map{_ => dist}
-
-    def observe[X,Y,D <: Distribution[Y]](seq: Seq[(X,Y)])(fn: X => D): RandomVariable[X => D] = {
-        val rvs = seq.map { case (x, z) => fn(x).fit(z)}
-        RandomVariable.traverse(rvs).map { _ => fn}
+  def observe[T, D <: Distribution[T]](seq: Seq[T],
+                                       dist: D): RandomVariable[D] =
+    dist.fit(seq).map { _ =>
+      dist
     }
 
-    def observe[X,Y,D <: Distribution[Y]](seq: Seq[(X,Y)], fn: Fn[X,D]): RandomVariable[Fn[X,D]] = {
-        val lh = Fn.toLikelihood[X,D,Y](implicitly[ToLikelihood[D,Y]])(fn)
-        lh.fit(seq).map{_ => fn}
+  def observe[X, Y, D <: Distribution[Y]](seq: Seq[(X, Y)])(
+      fn: X => D): RandomVariable[X => D] = {
+    val rvs = seq.map { case (x, z) => fn(x).fit(z) }
+    RandomVariable.traverse(rvs).map { _ =>
+      fn
     }
+  }
+
+  def observe[X, Y, D <: Distribution[Y]](
+      seq: Seq[(X, Y)],
+      fn: Fn[X, D]): RandomVariable[Fn[X, D]] = {
+    val lh = Fn.toLikelihood[X, D, Y](implicitly[ToLikelihood[D, Y]])(fn)
+    lh.fit(seq).map { _ =>
+      fn
+    }
+  }
 }

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Generator.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Generator.scala
@@ -6,7 +6,7 @@ import com.stripe.rainier.sampler.RNG
 /**
   * Generator trait, for posterior predictive distributions to be forwards sampled during sampling
   */
-sealed trait Generator[T] { self =>
+sealed trait Generator[+T] { self =>
   import Generator.{Const, From}
 
   def requirements: Set[Real]

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Generator.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Generator.scala
@@ -169,6 +169,15 @@ object ToGenerator {
         })
     }
 
+  implicit def fromSet[T, U](
+      implicit tu: ToGenerator[T, U]): ToGenerator[Set[T], Set[U]] =
+    new ToGenerator[Set[T], Set[U]] {
+      def apply(t: Set[T]) =
+        Generator.traverse(t.map { x =>
+          tu(x)
+        })
+    }
+
   implicit def map[K, T, U](
       implicit tu: ToGenerator[T, U]): ToGenerator[Map[K, T], Map[K, U]] =
     new ToGenerator[Map[K, T], Map[K, U]] {

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Generator.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Generator.scala
@@ -169,15 +169,6 @@ object ToGenerator {
         })
     }
 
-  implicit def fromSet[T, U](
-      implicit tu: ToGenerator[T, U]): ToGenerator[Set[T], Set[U]] =
-    new ToGenerator[Set[T], Set[U]] {
-      def apply(t: Set[T]) =
-        Generator.traverse(t.map { x =>
-          tu(x)
-        })
-    }
-
   implicit def map[K, T, U](
       implicit tu: ToGenerator[T, U]): ToGenerator[Map[K, T], Map[K, U]] =
     new ToGenerator[Map[K, T], Map[K, U]] {

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/package.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/package.scala
@@ -1,0 +1,8 @@
+package com.stripe.rainier
+
+package object core {
+  def updateMap[K, V](m: Map[K, V], k: K, vDelta: V)(
+      default: => V
+  )(plus: (V, V) => V): Map[K, V] =
+    m.updated(k, plus(m.getOrElse(k, default), vDelta))
+}

--- a/rainier-scalacheck/src/main/scala/com/stripe/rainier/scalacheck/package.scala
+++ b/rainier-scalacheck/src/main/scala/com/stripe/rainier/scalacheck/package.scala
@@ -1,35 +1,27 @@
 package com.stripe.rainier.scalacheck
 
-import com.stripe.rainier.core.Generator
-import com.stripe.rainier.core.RandomVariable
+import com.stripe.rainier.core.{Categorical, Generator, RandomVariable}
 import com.stripe.rainier.compute.Real
-import com.stripe.rainier.sampler.RNG
-import com.stripe.rainier.sampler.ScalaRNG
-
-import org.scalacheck.Arbitrary
-import org.scalacheck.Arbitrary.arbitrary
-import org.scalacheck.Cogen
-import org.scalacheck.Gen
+import com.stripe.rainier.sampler.{RNG, ScalaRNG}
+import org.scalacheck.{Arbitrary, Cogen, Gen}
 
 object `package` {
-  implicit val arbitraryReal: Arbitrary[Real] =
-    Arbitrary(arbitrary[Double].map(Real(_)))
+  import Arbitrary.arbitrary
 
-  implicit def arbitraryGenerator[A: Arbitrary]: Arbitrary[Generator[A]] =
-    Arbitrary(genGenerator)
+  implicit val cogenRNG: Cogen[RNG] =
+    Cogen(_ match {
+      case ScalaRNG(seed) => seed
+      case other          => sys.error(s"$other RNG currently unsupported")
+    })
 
-  def genGenerator[A: Arbitrary]: Gen[Generator[A]] = {
-    implicit val cogenRNG: Cogen[RNG] =
-      Cogen(_ match {
-        case ScalaRNG(seed) => seed
-        case other          => sys.error(s"$other RNG currently unsupported")
-      })
+  // note: currently assuming all evaluators are pure and don't have
+  // internal state (other than caching)
+  implicit val cogenNumericReal: Cogen[Numeric[Real]] =
+    Cogen(_.getClass.hashCode.toLong)
 
-    // note: currently assuming all evaluators are pure and don't have
-    // internal state (other than caching)
-    implicit val cogenNumericReal: Cogen[Numeric[Real]] =
-      Cogen(_.getClass.hashCode.toLong)
+  implicit val genReal: Gen[Real] = arbitrary[Double].map(Real(_))
 
+  def genGenerator[A: Arbitrary]: Gen[Generator[A]] =
     Gen.oneOf(
       arbitrary[A].map(Generator.constant(_)),
       arbitrary[(RNG, Numeric[Real]) => A].map(Generator.from(_)),
@@ -38,14 +30,26 @@ object `package` {
         fn <- arbitrary[(RNG, Numeric[Real]) => A]
       } yield Generator.require(req)(fn)
     )
-  }
+
+  def genCategorical[A: Arbitrary]: Gen[Categorical[A]] =
+    arbitrary[Map[A, Real]].map(Categorical(_))
+
+  def genRandomVariable[A: Arbitrary]: Gen[RandomVariable[A]] =
+    for {
+      a <- arbitrary[A]
+      density <- arbitrary[Real]
+    } yield RandomVariable(a, density)
+
+  implicit def arbitraryReal: Arbitrary[Real] =
+    Arbitrary(genReal)
+
+  implicit def arbitraryGenerator[A: Arbitrary]: Arbitrary[Generator[A]] =
+    Arbitrary(genGenerator)
 
   implicit def arbitraryRandomVariable[A: Arbitrary]
     : Arbitrary[RandomVariable[A]] =
     Arbitrary(genRandomVariable[A])
 
-  def genRandomVariable[A: Arbitrary]: Gen[RandomVariable[A]] =
-    arbitrary[A].flatMap(a =>
-      arbitrary[Real].flatMap(density => RandomVariable(a, density)))
-
+  implicit def arbitraryCategorical[A: Arbitrary]: Arbitrary[Categorical[A]] =
+    Arbitrary(genCategorical)
 }

--- a/rainier-scalacheck/src/main/scala/com/stripe/rainier/scalacheck/package.scala
+++ b/rainier-scalacheck/src/main/scala/com/stripe/rainier/scalacheck/package.scala
@@ -12,7 +12,6 @@ import org.scalacheck.Cogen
 import org.scalacheck.Gen
 
 object `package` {
-
   implicit val arbitraryReal: Arbitrary[Real] =
     Arbitrary(arbitrary[Double].map(Real(_)))
 
@@ -20,7 +19,6 @@ object `package` {
     Arbitrary(genGenerator)
 
   def genGenerator[A: Arbitrary]: Gen[Generator[A]] = {
-
     implicit val cogenRNG: Cogen[RNG] =
       Cogen(_ match {
         case ScalaRNG(seed) => seed

--- a/rainier-tests/src/test/scala/com/stripe/rainier/cats/suites.scala
+++ b/rainier-tests/src/test/scala/com/stripe/rainier/cats/suites.scala
@@ -1,62 +1,26 @@
 package com.stripe.rainier
 package cats
 
-import com.stripe.rainier.compute.{Constant, Infinity, NegInfinity, Real}
 import com.stripe.rainier.core._
 import com.stripe.rainier.scalacheck._
 import com.stripe.rainier.sampler.RNG
 import com.stripe.rainier.compute.Evaluator
 
-import _root_.cats.Eq
-import _root_.cats.kernel.instances.MapInstances
 import _root_.cats.tests.CatsSuite
 import _root_.cats.laws.discipline._
 
-class CategoricalSuite extends CatsSuite with MapInstances {
-
-  implicit val rng: RNG = RNG.default
-  implicit val evaluator: Evaluator = new Evaluator(Map.empty)
-
-  def eqBigDecimal(epsilon: Double): Eq[BigDecimal] =
-    Eq.instance { (left, right) =>
-      ((left - right) / left) < epsilon && ((left - right) / right) < epsilon
-    }
-
-  implicit val eqReal: Eq[Real] = {
-    val bde = eqBigDecimal(1e-6)
-    Eq.instance { (left, right) =>
-      (left, right) match {
-        case (Infinity, Infinity) | (NegInfinity, NegInfinity) => true
-        case (Constant(a), Constant(b))                        => bde.eqv(a, b)
-        case _                                                 => false
-      }
-    }
-  }
-
-  implicit def eqCategorical[A: Eq]: Eq[Categorical[A]] = {
-    implicit val mapEq: Eq[Map[A, Real]] = catsKernelStdEqForMap[A, Real]
-    Eq.instance((x, y) => Eq.eqv(x.pmf, y.pmf)(mapEq))
-  }
-
+class CategoricalSuite extends CatsSuite {
   checkAll("Categorical[Int]", MonadTests[Categorical].monad[Int, Int, Int])
 }
 
 class GeneratorSuite extends CatsSuite {
-
   implicit val rng: RNG = RNG.default
   implicit val evaluator: Evaluator = new Evaluator(Map.empty)
-
-  implicit def eqGenerator[A](implicit EqA: Eq[A]): Eq[Generator[A]] =
-    Eq.instance((x, y) => EqA.eqv(x.get, y.get))
 
   checkAll("Generator[Int]", MonadTests[Generator].monad[Int, Int, Int])
 }
 
 class RandomVariableSuite extends CatsSuite {
-
-  implicit def eqRandomVariable[A](implicit EqA: Eq[A]): Eq[RandomVariable[A]] =
-    Eq.instance((x, y) => EqA.eqv(x.value, y.value))
-
   checkAll("RandomVariable[Int]",
            MonadTests[RandomVariable].monad[Int, Int, Int])
 }

--- a/rainier-tests/src/test/scala/com/stripe/rainier/cats/suites.scala
+++ b/rainier-tests/src/test/scala/com/stripe/rainier/cats/suites.scala
@@ -1,24 +1,42 @@
-package com.stripe.rainier.cats
+package com.stripe.rainier
+package cats
 
-import com.stripe.rainier.compute.Real
+import com.stripe.rainier.compute.{Constant, Infinity, NegInfinity, Real}
 import com.stripe.rainier.core._
 import com.stripe.rainier.scalacheck._
 import com.stripe.rainier.sampler.RNG
 import com.stripe.rainier.compute.Evaluator
 
-import cats.Eq
-import cats.tests.CatsSuite
-import cats.laws.discipline._
+import _root_.cats.Eq
+import _root_.cats.kernel.instances.MapInstances
+import _root_.cats.tests.CatsSuite
+import _root_.cats.laws.discipline._
 
-class CategoricalSuite extends CatsSuite {
+class CategoricalSuite extends CatsSuite with MapInstances {
 
   implicit val rng: RNG = RNG.default
   implicit val evaluator: Evaluator = new Evaluator(Map.empty)
-  implicit val realEq: Eq[Real] =
-    Eq.instance((x, y) => x == y)
 
-  implicit def eqGenerator[A: Eq]: Eq[Categorical[A]] =
-    Eq.instance((x, y) => Eq.eqv(x.pmf, y.pmf))
+  def eqBigDecimal(epsilon: Double): Eq[BigDecimal] =
+    Eq.instance { (left, right) =>
+      ((left - right) / left) < epsilon && ((left - right) / right) < epsilon
+    }
+
+  implicit val eqReal: Eq[Real] = {
+    val bde = eqBigDecimal(1e-6)
+    Eq.instance { (left, right) =>
+      (left, right) match {
+        case (Infinity, Infinity) | (NegInfinity, NegInfinity) => true
+        case (Constant(a), Constant(b))                        => bde.eqv(a, b)
+        case _                                                 => false
+      }
+    }
+  }
+
+  implicit def eqCategorical[A: Eq]: Eq[Categorical[A]] = {
+    implicit val mapEq: Eq[Map[A, Real]] = catsKernelStdEqForMap[A, Real]
+    Eq.instance((x, y) => Eq.eqv(x.pmf, y.pmf)(mapEq))
+  }
 
   checkAll("Categorical[Int]", MonadTests[Categorical].monad[Int, Int, Int])
 }

--- a/rainier-tests/src/test/scala/com/stripe/rainier/cats/suites.scala
+++ b/rainier-tests/src/test/scala/com/stripe/rainier/cats/suites.scala
@@ -1,5 +1,6 @@
 package com.stripe.rainier.cats
 
+import com.stripe.rainier.compute.Real
 import com.stripe.rainier.core._
 import com.stripe.rainier.scalacheck._
 import com.stripe.rainier.sampler.RNG
@@ -8,6 +9,19 @@ import com.stripe.rainier.compute.Evaluator
 import cats.Eq
 import cats.tests.CatsSuite
 import cats.laws.discipline._
+
+class CategoricalSuite extends CatsSuite {
+
+  implicit val rng: RNG = RNG.default
+  implicit val evaluator: Evaluator = new Evaluator(Map.empty)
+  implicit val realEq: Eq[Real] =
+    Eq.instance((x, y) => x == y)
+
+  implicit def eqGenerator[A: Eq]: Eq[Categorical[A]] =
+    Eq.instance((x, y) => Eq.eqv(x.pmf, y.pmf))
+
+  checkAll("Categorical[Int]", MonadTests[Categorical].monad[Int, Int, Int])
+}
 
 class GeneratorSuite extends CatsSuite {
 


### PR DESCRIPTION
This PR adds a `Monad[Categorical]` instance. I managed to get a stack safe implementation!

I also moved the Eq instances into the cats package, so I could get access to them outside Rainier.

It might make sense to add an implicit value for the BigDecimal epsilon with a default, so the user can override.

I also made `Generator` covariant in `T`, which required a few tweaks to how the scalacheck `Gen` and `Arbitrary` instances are defined. Their behavior is the same as before, of course.

I had to write some new testing components, and would love comments there... but this should be solid, thanks to the cats testing functions.