### PR TITLE
optimize() and precis() with collection.Map

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/core/RandomVariable.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/RandomVariable.scala
@@ -84,7 +84,7 @@ class RandomVariable[+T](val value: T, val targets: Set[Target]) {
       }
   }
 
-  def optimize[V](implicit rng: RNG, tg: ToGenerator[T, V]): V = {
+  def optimize[V]()(implicit rng: RNG, tg: ToGenerator[T, V]): V = {
     val array = Optimizer.lbfgs(density)
     tg(value).prepare(targetGroup.variables).apply(array)
   }

--- a/rainier-core/src/main/scala/com/stripe/rainier/repl/package.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/repl/package.scala
@@ -2,6 +2,7 @@ package com.stripe.rainier
 
 import com.stripe.rainier.sampler._
 import java.io._
+import scala.collection.Map
 
 package object repl {
   def plot1D[N](seq: Seq[N])(implicit num: Numeric[N]): Unit = {


### PR DESCRIPTION
Bunding together two tiny changes:

* use collection.Map in the repl package
* force/allow `optimize()` to be called with parens, as a stylistic issue