### PR TITLE
add contramap implementation to ToReal

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/ToReal.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/ToReal.scala
@@ -5,8 +5,12 @@ package com.stripe.rainier.compute
   * implicit conversions to real which we might
   * otherwise reach for in RandomVariable
   */
-sealed abstract class ToReal[A] {
+sealed abstract class ToReal[A] { self =>
   def apply(a: A): Real
+
+  def contramap[B](f: B => A): ToReal[B] = new ToReal[B] {
+    def apply(b: B): Real = self.apply(f(b))
+  }
 }
 
 trait LowPriToReal {


### PR DESCRIPTION
This PR adds a `contramap` implementation; this lets me get instances of `ToReal[B]` for types where I can extract something numeric, say, but for which I can't actually define a `Numeric[B]` instance.

I'm using this with algebird's `AveragedValue`. I'd like to be able to have the `ToReal` implicit handle the conversion rather than explicitly taking a function from `T => Double`, in this case. With this PR I can write:

```scala
  implicit val avToReal: ToReal[AveragedValue] =
    implicitly[ToReal[Double]].contramap(_.value)
```