### PR TITLE
Make Generator covariant in T

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Generator.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Generator.scala
@@ -6,7 +6,7 @@ import com.stripe.rainier.sampler.RNG
 /**
   * Generator trait, for posterior predictive distributions to be forwards sampled during sampling
   */
-sealed trait Generator[T] { self =>
+sealed trait Generator[+T] { self =>
   import Generator.{Const, From}
 
   def requirements: Set[Real]


### PR DESCRIPTION
This PR adds a `+` to the type parameter on Generator... I've got a few cases where I'd like to use items of type `Generator[MapState[A, R]]` as input to functions that call for `Generator[State[A, R]]`, and this is the solution.

I don't THINK anything else needs to change, here... let's see how the tests go.

(I goofed my branch name, as you can see. I can't keep these two concept (name)s straight...)