### PR TITLE
tweak the Events API

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala
@@ -27,9 +27,7 @@ trait Continuous extends Distribution[Double] {
 
 object Continuous {
   implicit def gen[C <: Continuous]: ToGenerator[C, Double] =
-    new ToGenerator[C, Double] {
-      def apply(c: C) = c.generator
-    }
+    Distribution.gen[C, Double]
 }
 
 /**

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Discrete.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Discrete.scala
@@ -21,9 +21,7 @@ trait Discrete extends Distribution[Int] { self: Discrete =>
 
 object Discrete {
   implicit def gen[D <: Discrete]: ToGenerator[D, Int] =
-    new ToGenerator[D, Int] {
-      def apply(d: D) = d.generator
-    }
+    Distribution.gen[D, Int]
 }
 
 /**

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Distribution.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Distribution.scala
@@ -17,4 +17,8 @@ object Distribution {
     new ToLikelihood[D, T] {
       def apply(d: D) = d.likelihood
     }
+
+  def gen[D <: Distribution[T], T] = new ToGenerator[D, T] {
+    def apply(d: D) = d.generator
+  }
 }

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Events.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Events.scala
@@ -1,15 +1,5 @@
 package com.stripe.rainier.core
 
-case class Events[X, Y, D <: Distribution[Y]](fn: X => D) {
-  def apply(x: X): D = fn(x)
-  def simulate(seq: Seq[X]): Generator[Seq[(X, Y)]] =
-    Generator.traverse(seq.map { x =>
-      fn(x).generator.map { y =>
-        (x, y)
-      }
-    })
-}
-
 object Events {
   def observe[T, D <: Distribution[T]](seq: Seq[T],
                                        dist: D): RandomVariable[D] =
@@ -17,20 +7,38 @@ object Events {
       dist
     }
 
+  def observe[X, Y, D <: Distribution[Y]](xs: Seq[X], ys: Seq[Y])(
+      fn: X => D): RandomVariable[X => D] =
+    observe(xs.zip(ys))(fn)
+
   def observe[X, Y, D <: Distribution[Y]](seq: Seq[(X, Y)])(
-      fn: X => D): RandomVariable[Events[X, Y, D]] = {
+      fn: X => D): RandomVariable[X => D] = {
     val rvs = seq.map { case (x, z) => fn(x).fit(z) }
     RandomVariable.traverse(rvs).map { _ =>
-      Events(fn)
+      fn
     }
   }
 
   def observe[X, Y, D <: Distribution[Y]](
+      xs: Seq[X],
+      ys: Seq[Y],
+      fn: Fn[X, D]): RandomVariable[X => D] =
+    observe(xs.zip(ys), fn)
+
+  def observe[X, Y, D <: Distribution[Y]](
       seq: Seq[(X, Y)],
-      fn: Fn[X, D]): RandomVariable[Events[X, Y, D]] = {
+      fn: Fn[X, D]): RandomVariable[X => D] = {
     val lh = Fn.toLikelihood[X, D, Y](implicitly[ToLikelihood[D, Y]])(fn)
     lh.fit(seq).map { _ =>
-      Events(fn(_))
+      fn(_)
     }
   }
+
+  def simulate[X, Y, D](seq: Seq[X])(fn: X => D)(
+      implicit tg: ToGenerator[D, Y]): Generator[Seq[(X, Y)]] =
+    Generator.traverse(seq.map { x =>
+      tg(fn(x)).map { y =>
+        (x, y)
+      }
+    })
 }

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Events.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Events.scala
@@ -41,4 +41,8 @@ object Events {
         (x, y)
       }
     })
+
+  def simulate[X, Y, D](seq: Seq[X], fn: Fn[X,D])(
+      implicit tg: ToGenerator[D, Y]): Generator[Seq[(X, Y)]] =
+    simulate(seq)(fn(_))
 }


### PR DESCRIPTION
These are changes that were suggested by working on the Ch 5.1 notebook. Specifically:

* I've brought back the convenience methods that separate out a Seq[X] and Seq[Y]; these turn out to be a lot more readable IMO.
* `Events.simulate` has been moved to an object method that works with any X=>Generator[T], not just X=>Distribution[Y]. This is useful when you want to visualize counterfactual or predictive posteriors on functions that don't match the data's (X,Y) format, ie when you want (X,mu) in a regression.
* `observe` now just always returns the bare `X => Distribution[Y]` function rather than a case class wrapper