### PR TITLE
Add theme to the shade interface to allow customizing fill

### DIFF
--- a/rainier-plot/src/main/scala/com/stripe/rainier/plot/Jupyter.scala
+++ b/rainier-plot/src/main/scala/com/stripe/rainier/plot/Jupyter.scala
@@ -188,7 +188,8 @@ object Jupyter {
   }
 
   def shade[M, N](intervals: Seq[(M, (N, N))])(implicit mNum: Numeric[M],
-                                               nNum: Numeric[N]): Plot = {
+                                               nNum: Numeric[N],
+                                               theme: Theme): Plot = {
     val doubleTriples = intervals
       .map {
         case (m, (n1, n2)) =>
@@ -205,7 +206,7 @@ object Jupyter {
       Bounds(minX, maxX),
       Bounds(minY, maxY),
       new PlotRenderer {
-        def render(plot: Plot, plotExtent: Extent)(implicit theme: Theme) = {
+        def render(plot: Plot, plotExtent: Extent)(implicit _theme: Theme) = {
           val xtransformer = plot.xtransform(plot, plotExtent)
           val ytransformer = plot.ytransform(plot, plotExtent)
 


### PR DESCRIPTION
Using the plot theme for the color means we can't have multiple shaded regions with different colors. With this PR I was able to generate:
![image](https://user-images.githubusercontent.com/23081836/65558762-e230ae00-deec-11e9-8214-92cf326bf4fb.png)

