### PR TITLE
Coefficient(x, 0.0) should be Empty

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Coefficients.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Coefficients.scala
@@ -17,7 +17,11 @@ sealed trait Coefficients {
 
 object Coefficients {
   def apply(pair: (NonConstant, BigDecimal)): Coefficients =
-    One(pair._1, pair._2)
+    if (pair._2 == Real.BigZero)
+      Empty
+    else
+      One(pair._1, pair._2)
+
   def apply(seq: Seq[(NonConstant, BigDecimal)]): Coefficients = {
     val filtered = seq.filter(_._2 != Real.BigZero)
     if (filtered.isEmpty)

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/LogLineOps.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/LogLineOps.scala
@@ -41,7 +41,7 @@ private[compute] object LogLineOps {
       common with something in t (or some later thing we will add s+t to), and we can combine the constants
    */
   val DistributeToMaxTerms = 20
-  def distribute(line: LogLine): Option[Line] = {
+  def distribute(line: LogLine): Option[(Coefficients, BigDecimal)] = {
 
     def nTerms(l: Line): Int =
       if (l.b == 0.0)
@@ -73,7 +73,7 @@ private[compute] object LogLineOps {
 
     terms.map { l =>
       if (factors.isEmpty)
-        l
+        (l.ax, l.b)
       else {
         val ll = LogLine(Coefficients(factors))
         val (newAx, newB) =
@@ -87,7 +87,7 @@ private[compute] object LogLineOps {
                   (nAx.merge(Coefficients(nc -> a)), nB)
               }
           }
-        Line(newAx, newB)
+        (newAx, newB)
       }
     }
   }

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Real.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Real.scala
@@ -142,21 +142,11 @@ for an example.
 private final class Line private (val ax: Coefficients, val b: BigDecimal)
     extends NonConstant
 
-private object Line {
+private[compute] object Line {
   def apply(ax: Coefficients, b: BigDecimal): Line = {
     require(!ax.isEmpty)
     new Line(ax, b)
   }
-
-  def apply(nc: NonConstant): Line =
-    nc match {
-      case l: Line => l
-      case l: LogLine =>
-        LogLineOps
-          .distribute(l)
-          .getOrElse(Line(Coefficients(l -> Real.BigOne), Real.BigZero))
-      case _ => Line(Coefficients(nc -> Real.BigOne), Real.BigZero)
-    }
 }
 
 /*

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/RealOps.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/RealOps.scala
@@ -105,10 +105,10 @@ private[compute] object RealOps {
       case (_, Constant(Real.BigZero))    => left
       case (Constant(Real.BigZero), _)    => right
       case (Constant(x), Constant(y))     => Real(x + y)
-      case (Constant(x), nc: NonConstant) => LineOps.translate(Line(nc), x)
-      case (nc: NonConstant, Constant(x)) => LineOps.translate(Line(nc), x)
+      case (Constant(x), nc: NonConstant) => LineOps.translate(nc, x)
+      case (nc: NonConstant, Constant(x)) => LineOps.translate(nc, x)
       case (nc1: NonConstant, nc2: NonConstant) =>
-        LineOps.sum(Line(nc1), Line(nc2))
+        LineOps.sum(nc1, nc2)
     }
 
   def multiply(left: Real, right: Real): Real =
@@ -131,8 +131,8 @@ private[compute] object RealOps {
       case (_, Constant(Real.BigOne))     => left
       case (Constant(Real.BigOne), _)     => right
       case (Constant(x), Constant(y))     => Real(x * y)
-      case (Constant(x), nc: NonConstant) => LineOps.scale(Line(nc), x)
-      case (nc: NonConstant, Constant(x)) => LineOps.scale(Line(nc), x)
+      case (Constant(x), nc: NonConstant) => LineOps.scale(nc, x)
+      case (nc: NonConstant, Constant(x)) => LineOps.scale(nc, x)
       case (nc1: NonConstant, nc2: NonConstant) =>
         LogLineOps.multiply(LogLine(nc1), LogLine(nc2))
     }

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Translator.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Translator.scala
@@ -54,8 +54,8 @@ private class Translator {
   }
 
   private def lineExpr(line: Line): Expr = {
-    val (y, k) = LineOps.factor(line)
-    factoredSumLine(y.ax, y.b, k.toDouble)
+    val (ax, b, k) = LineOps.factor(line)
+    factoredSumLine(ax, b, k.toDouble)
   }
 
   private def logLineExpr(line: LogLine): Expr = {

--- a/rainier-tests/src/test/scala/com/stripe/rainier/compute/RealTest.scala
+++ b/rainier-tests/src/test/scala/com/stripe/rainier/compute/RealTest.scala
@@ -194,8 +194,9 @@ class RealTest extends FunSuite {
     }
   }
 
-  run("cancelling x^2 then distributing") { x =>
-    (x.pow(2) * 2) / (x.pow(2)) + 1
+  run("cancelling x^2 then distributing", defined = x => x != 0 && x.isValidInt) {
+    x =>
+      (x.pow(2) * 2) / (x.pow(2)) + x
   }
 
   run("pow", defined = _ >= 0) { x =>

--- a/rainier-tests/src/test/scala/com/stripe/rainier/compute/RealTest.scala
+++ b/rainier-tests/src/test/scala/com/stripe/rainier/compute/RealTest.scala
@@ -194,6 +194,10 @@ class RealTest extends FunSuite {
     }
   }
 
+  run("cancelling x^2 then distributing") { x =>
+    (x.pow(2) * 2) / (x.pow(2)) + 1
+  }
+
   run("pow", defined = _ >= 0) { x =>
     x.pow(x)
   }


### PR DESCRIPTION
This is a minor fix to `Coefficient` but it exposes a problem in `distribute` when all the terms cancel and we're left with a `Constant` not a `Line`.