### PR TITLE
Add a "vector" and "fromSet" method to Generator

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Generator.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Generator.scala
@@ -120,6 +120,10 @@ object Generator {
   def require[T](reqs: Set[Real])(fn: (RNG, Numeric[Real]) => T): Generator[T] =
     From(reqs, fn)
 
+  def vector[T](v: Vector[T]) = from((r, _) => v(r.int(v.size)))
+
+  def fromSet[T](items: Set[T]) = vector(items.to[Vector])
+
   def traverse[T, U](seq: Seq[T])(
       implicit toGen: ToGenerator[T, U]
   ): Generator[Seq[U]] =


### PR DESCRIPTION
These were two convenience methods I found useful in ScalaRL... not sure if they're too simple to include. I'm submitting them just in case.