### PR TITLE
add Sample and trace

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Sample.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Sample.scala
@@ -1,0 +1,29 @@
+package com.stripe.rainier.core
+
+import com.stripe.rainier.compute._
+import com.stripe.rainier.sampler._
+
+case class Sample[+T](chains: List[List[Array[Double]]],
+                      targets: Set[Target],
+                      variables: List[Variable],
+                      value: T) {
+  def map[U](fn: T => U) = Sample(chains, targets, variables, fn(value))
+
+  def diagnostics = Sampler.diagnostics(chains)
+
+  def waic =
+    targets
+      .map { t =>
+        WAIC(chains.flatten, variables, t)
+      }
+      .reduce(_ + _)
+
+  def toList[V](implicit tg: ToGenerator[T, V], rng: RNG): List[V] = {
+    val fn = tg(value).prepare(variables)
+    chains.flatMap { c =>
+      c.map { a =>
+        fn(a)
+      }
+    }
+  }
+}

--- a/rainier-core/src/main/scala/com/stripe/rainier/repl/package.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/repl/package.scala
@@ -83,7 +83,8 @@ package object repl {
     }
   }
 
-  def precis(samples: Seq[Traversable[(String, Double)]], corr: Boolean = false): Unit = {
+  def precis(samples: Seq[Traversable[(String, Double)]],
+             corr: Boolean = false): Unit = {
     val sampleSeqs = samples.map(_.toSeq)
     val meansSDs = computeParamStats(sampleSeqs)
     val keys = meansSDs.map(_._1)
@@ -205,7 +206,7 @@ package object repl {
     val waics = models
       .map {
         case (s, m) =>
-          s -> m.waic(sampler, warmupIterations, iterations, keepEvery)
+          s -> m.toSample(sampler, warmupIterations, iterations, keepEvery).waic
       }
       .sortBy(_._2.value)
     val minWaic = waics.head._2.value

--- a/rainier-core/src/main/scala/com/stripe/rainier/repl/package.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/repl/package.scala
@@ -195,7 +195,7 @@ package object repl {
       models,
       Sampler.Default.sampler,
       Sampler.Default.warmupIterations,
-      Sampler.Default.iterations,
+      Sampler.Default.iterations
     )
 
   def compare(models: Seq[(String, RandomVariable[_])],

--- a/rainier-plot/src/main/scala/com/stripe/rainier/plot/Jupyter.scala
+++ b/rainier-plot/src/main/scala/com/stripe/rainier/plot/Jupyter.scala
@@ -8,6 +8,7 @@ import com.cibo.evilplot.colors._
 import com.cibo.evilplot.plot.renderers._
 import com.cibo.evilplot.plot.aesthetics._
 
+import com.stripe.rainier.core.Sample
 import com.stripe.rainier.repl.{hdpi, mean}
 
 object Jupyter {
@@ -242,6 +243,25 @@ object Jupyter {
         }
       }
     )
+  }
+
+  def trace(sample: Sample[_])(implicit
+                               theme: Theme,
+                               oh: OutputHandler): Unit = {
+    val nVariables = sample.variables.size
+    val lines =
+      0.until(nVariables).toList.map { v =>
+        sample.chains.zipWithIndex.map {
+          case (c, n) =>
+            line(c.zipWithIndex.map { case (a, i) => i -> a(v) })
+              .xAxis()
+              .yAxis()
+              .frame()
+              .xLabel("chain " + (n + 1))
+              .yLabel("param " + (v + 1))
+        }
+      }
+    show(Facets(lines))(Extent(800, 800), theme, oh)
   }
 
   def show(xLabel: String, yLabel: String, title: String, plots: Plot*)(


### PR DESCRIPTION
This introduces a `Sample` case class which encapsulates the raw parameter samples from a `RandomVariable`, and can either produce the predictive samples from them, or diagnostics. There are new `toSample` methods on RV, and `waic` has been moved to `Sample`. In the future more will be moved to the `Sample` class.

This also adds a `trace` method for use with Jupyter which takes a `Sample` and produces plots like this:

<img width="930" alt="Screen Shot 2019-10-09 at 8 34 04 AM" src="https://user-images.githubusercontent.com/23175169/66496528-ef62a680-ea6f-11e9-98a7-2dacef82fae4.png">
