### PR TITLE
Features for Statistical Rethinking 11.3

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala
@@ -105,6 +105,9 @@ object Gamma {
   def apply(shape: Real, scale: Real): Continuous =
     standard(shape).scale(scale)
 
+  def meanAndScale(mean: Real, scale: Real): Continuous =
+    Gamma(mean / scale, scale)
+
   def standard(shape: Real): StandardContinuous = new StandardContinuous {
     val support = BoundedBelowSupport(Real.zero)
 

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Discrete.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Discrete.scala
@@ -208,6 +208,11 @@ final case class BetaBinomial(a: Real, b: Real, k: Real) extends Discrete {
       Combinatorics.beta(a, b)
 }
 
+object BetaBinomial {
+  def meanAndPrecision(mean: Real, precision: Real, k: Real): BetaBinomial =
+    BetaBinomial(mean * precision, (Real.one - mean) * precision, k)
+}
+
 /**
   * Discrete Mixture Distribution
   *

--- a/rainier-plot/src/main/scala/com/stripe/rainier/plot/Jupyter.scala
+++ b/rainier-plot/src/main/scala/com/stripe/rainier/plot/Jupyter.scala
@@ -39,14 +39,18 @@ object Jupyter {
 
     val blue = default.copy(
       colors = default.colors.copy(
-        fill = blueColor
+        fill = blueColor,
+        trendLine = blueColor,
+        path = blueColor
       )
     )
 
     val gray = default.copy(
       colors = default.colors.copy(
         bar = grayColor,
-        point = grayColor
+        point = grayColor,
+        trendLine = grayColor,
+        path = grayColor
       )
     )
   }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.2.3"
+version in ThisBuild := "0.2.4-rc1-SNAPSHOT"


### PR DESCRIPTION
This makes a few changes for Statistical Rethinking 11.3:
* Implements constructors for BetaBinomial and Gamma based on the expectation. I tried to parallel the existing `Beta.meanAndPrecision` here rather than introducing the new `location` method we talked about.
* Added support for customizing line colors.
* Bumped the version to a new rc series.