### PR TITLE
Fix WAIC bug with identical targets

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/core/RandomVariable.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/RandomVariable.scala
@@ -76,7 +76,7 @@ class RandomVariable[+T](val value: T, val targets: Set[Target]) {
           .sample(density(), sampler, warmupIterations, iterations, keepEvery)
       }.toList
 
-    Sample(chains, targets, targetGroup.variables, value)
+    Sample(chains, targets.toList, targetGroup.variables, value)
   }
 
   def sample[V]()(implicit rng: RNG, tg: ToGenerator[T, V]): List[V] =

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Sample.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Sample.scala
@@ -4,7 +4,7 @@ import com.stripe.rainier.compute._
 import com.stripe.rainier.sampler._
 
 case class Sample[+T](chains: List[List[Array[Double]]],
-                      targets: Set[Target],
+                      targets: List[Target],
                       variables: List[Variable],
                       value: T) {
   def map[U](fn: T => U) = Sample(chains, targets, variables, fn(value))

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.2.3-rc8-SNAPSHOT"
+version in ThisBuild := "0.2.3"


### PR DESCRIPTION
Before this fix, these two equivalent models would have different WAIC:

```
val x12 = List(1.0, 2.0)
val a = Events.observe(x12, x12){x => Normal(x, 1)}
val b = Events.observe(x12, x12, Fn.encode[Double].map{x => Normal(x,1)})
compare("a" -> a, "b" -> b)
```

The bug was that `Sample` was mapping over a `Set[Target]` to get a `WAIC` for each of them, resulting in a `Set[WAIC]` which would only retain one instance of any groups of identical `WAIC` values. This fix forces a change to `List[Target]` within `Sample`, avoiding the issue.