### PR TITLE
Turn Variable into a trait

### DIFF
--- a/docs/real.md
+++ b/docs/real.md
@@ -45,7 +45,7 @@ The other kind of `Real` you can create directly is a `Variable` (though if you'
 A `Variable` doesn't really need anything other than its own identity (they don't need explicit names, for example). So you create them like this:
 
 ```scala
-scala> val x = new Variable
+scala> val x = Real.variable()
 x: com.stripe.rainier.compute.Variable = com.stripe.rainier.compute.Variable@6896d488
 ```
 
@@ -78,7 +78,7 @@ res0: com.stripe.rainier.compute.Real = com.stripe.rainier.compute.Variable@6896
 We can also construct functions that depend on multiple variables, as you'd expect:
 
 ```scala
-scala> val y = new Variable
+scala> val y = Real.variable()
 y: com.stripe.rainier.compute.Variable = com.stripe.rainier.compute.Variable@5e3849b2
 
 scala> val xy = x * y

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Encoder.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Encoder.scala
@@ -17,7 +17,7 @@ object Encoder {
       type U = Real
       def wrap(t: N) = Real(t)
       def create(acc: List[Variable]) = {
-        val u = new Variable
+        val u = Real.variable()
         (u, u :: acc)
       }
       def extract(t: N, acc: List[Double]) =
@@ -70,7 +70,7 @@ object Encoder {
       def create(acc: List[Variable]): (Map[String, Real], List[Variable]) =
         toMap.fields.foldRight((Map[String, Real](), acc)) {
           case (field, (map, a)) =>
-            val v = new Variable
+            val v = Real.variable()
             (map + (field -> v), v :: a)
         }
 

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Real.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Real.scala
@@ -8,9 +8,9 @@ A Real is a DAG which represents a mathematical function
 from 0 or more real-valued input parameters to a single real-valued output.
 
 You can create new single-node DAGs either like `Real(2.0)`, for a constant,
-or with `new Variable` to introduce an input parameter. You can create more interesting DAGs
-by combining Reals using the standard mathematical operators, eg `(new Variable) + Real(2.0)`
-is the function f(x) = x+2, or `(new Variable) * (new Variable).log` is the function f(x,y) = xlog(y).
+or with `Real.variable` to introduce an input parameter. You can create more interesting DAGs
+by combining Reals using the standard mathematical operators, eg `Real.variable + Real(2.0)`
+is the function f(x) = x+2, or `Real.variable * Real.variable.log` is the function f(x,y) = xlog(y).
 Every such operation on Real results in a new Real.
 Apart from Variable and a simple ternary If expression, all of the subtypes of Real are private to this package.
 
@@ -85,6 +85,8 @@ object Real {
     summed.log + max
   }
 
+  def variable(): Variable = new Placeholder()
+
   def eq(left: Real, right: Real, ifTrue: Real, ifFalse: Real): Real =
     lookupCompare(left, right, ifFalse, ifTrue, ifFalse)
   def lt(left: Real, right: Real, ifTrue: Real, ifFalse: Real): Real =
@@ -121,9 +123,11 @@ final private[rainier] object NegInfinity extends Real
 
 sealed trait NonConstant extends Real
 
-final class Variable extends NonConstant {
+sealed trait Variable extends NonConstant {
   private[compute] val param = new ir.Parameter
 }
+
+final private class Placeholder extends Variable
 
 final private case class Unary(original: NonConstant, op: ir.UnaryOp)
     extends NonConstant

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Target.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Target.scala
@@ -66,7 +66,7 @@ class Target(val real: Real, val placeholders: Map[Variable, Array[Double]]) {
     0.until(1 << bit).foldLeft((emptyV, Real.zero)) {
       case ((v, r), _) =>
         val newVars = placeholderVariables.map { _ =>
-          new Variable
+          Real.variable()
         }
         val newReal =
           PartialEvaluator.inline(real, placeholderVariables.zip(newVars).toMap)
@@ -77,7 +77,7 @@ class Target(val real: Real, val placeholders: Map[Variable, Array[Double]]) {
 
   def updater: (Real, List[Variable]) = {
     val newVars = placeholderVariables.map { _ =>
-      new Variable
+      Real.variable()
     }
     val newReal =
       PartialEvaluator.inline(real, placeholderVariables.zip(newVars).toMap)

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Categorical.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Categorical.scala
@@ -65,7 +65,7 @@ final case class Categorical[T](pmf: Map[T, Real]) extends Distribution[T] {
     new Likelihood[T] {
       val choices = pmf.keys.toList
       val u = choices.map { k =>
-        k -> new Variable
+        k -> Real.variable()
       }
       val real = Categorical.logDensity(self, u)
       val placeholders = u.map(_._2)
@@ -135,7 +135,7 @@ final case class Multinomial[T](pmf: Map[T, Real], k: Real)
     new Likelihood[Map[T, Int]] {
       val choices = pmf.keys.toList
       val u = choices.map { k =>
-        k -> new Variable
+        k -> Real.variable()
       }
       val real = Multinomial.logDensity(self, u)
       val placeholders = u.map(_._2)

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala
@@ -11,7 +11,7 @@ trait Continuous extends Distribution[Double] {
   private[rainier] val support: Support
 
   def likelihood = new Likelihood[Double] {
-    val x = new Variable
+    val x = Real.variable()
     val placeholders = List(x)
     val real = logDensity(x)
     def extract(t: Double) = List(t)
@@ -35,7 +35,7 @@ object Continuous {
   */
 private[rainier] trait StandardContinuous extends Continuous {
   def param: RandomVariable[Real] = {
-    val x = new Variable
+    val x = Real.variable()
 
     val transformed = support.transform(x)
 
@@ -240,7 +240,7 @@ case class Mixture(components: Map[Continuous, Real]) extends Continuous {
       })
 
   def param: RandomVariable[Real] = {
-    val x = new Variable
+    val x = Real.variable()
 
     val transformed: Real = support.transform(x)
 

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Discrete.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Discrete.scala
@@ -4,7 +4,7 @@ import com.stripe.rainier.compute._
 
 trait Discrete extends Distribution[Int] { self: Discrete =>
   def likelihood = new Likelihood[Int] {
-    val x = new Variable
+    val x = Real.variable()
     val placeholders = List(x)
     val real = logDensity(x)
     def extract(t: Int) = List(t.toDouble)

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Predictor.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Predictor.scala
@@ -76,7 +76,7 @@ object Predictor {
         type U = Real
         def wrap(t: K) = map(t)
         def create(acc: List[Variable]): (Real, List[Variable]) = {
-          val v = new Variable
+          val v = Real.variable()
           val r = Lookup(v, keys.map { k =>
             map(k)
           })

--- a/rainier-docs/src/main/tut/real.md
+++ b/rainier-docs/src/main/tut/real.md
@@ -42,7 +42,7 @@ The other kind of `Real` you can create directly is a `Variable` (though if you'
 A `Variable` doesn't really need anything other than its own identity (they don't need explicit names, for example). So you create them like this:
 
 ```tut
-val x = new Variable
+val x = Real.variable()
 ```
 
 Taken by itself, `x` here represents a function that extracts a specific single parameter from the (conceptually infinite) parameter vector. We can denote that like this:
@@ -72,7 +72,7 @@ xTwo / 2
 We can also construct functions that depend on multiple variables, as you'd expect:
 
 ```tut
-val y = new Variable
+val y = Real.variable()
 val xy = x * y
 ```
 

--- a/rainier-tests/src/test/scala/com/stripe/rainier/compute/RealTest.scala
+++ b/rainier-tests/src/test/scala/com/stripe/rainier/compute/RealTest.scala
@@ -11,7 +11,7 @@ class RealTest extends FunSuite {
           derivable: Double => Boolean = _ => true,
           reference: Double => Double = null)(fn: Real => Real): Unit = {
     test(description) {
-      val x = new Variable
+      val x = Real.variable()
       val result = fn(x)
       val deriv = result.gradient.head
 


### PR DESCRIPTION
This is the first of a sequence of PRs to enable some experimentation with an alternative high-level API, while minimally disrupting what's already there. I'd like to introduce (in a later PR) a new type of `Variable` node; all this one does is turn `Variable` into a trait and introduce a single, private, concrete subclass, forcing creation to go through `Real.variable`.