### PR TITLE
Parameter

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Real.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Real.scala
@@ -86,7 +86,11 @@ object Real {
   }
 
   def variable(): Variable = new Placeholder()
-  def parameter(fn: Variable => Real): Variable = new Parameter(fn)
+  def parameter(fn: Variable => Real): Variable = {
+    val x = new Parameter(Real.zero)
+    x.density = fn(x)
+    x
+  }
 
   def eq(left: Real, right: Real, ifTrue: Real, ifFalse: Real): Real =
     lookupCompare(left, right, ifFalse, ifTrue, ifFalse)
@@ -129,9 +133,7 @@ sealed trait Variable extends NonConstant {
 }
 
 final private[rainier] class Placeholder extends Variable
-final private[rainier] class Parameter(fn: Variable => Real) extends Variable {
-  def density: Real = fn(this)
-}
+final private[rainier] class Parameter(var density: Real) extends Variable
 
 final private case class Unary(original: NonConstant, op: ir.UnaryOp)
     extends NonConstant

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Real.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Real.scala
@@ -86,6 +86,7 @@ object Real {
   }
 
   def variable(): Variable = new Placeholder()
+  def parameter(fn: Variable => Real): Variable = new Parameter(fn)
 
   def eq(left: Real, right: Real, ifTrue: Real, ifFalse: Real): Real =
     lookupCompare(left, right, ifFalse, ifTrue, ifFalse)
@@ -127,7 +128,10 @@ sealed trait Variable extends NonConstant {
   private[compute] val param = new ir.Parameter
 }
 
-final private class Placeholder extends Variable
+final private[rainier] class Placeholder extends Variable
+final private[rainier] class Parameter(fn: Variable => Real) extends Variable {
+  def density: Real = fn(this)
+}
 
 final private case class Unary(original: NonConstant, op: ir.UnaryOp)
     extends NonConstant

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala
@@ -23,6 +23,9 @@ trait Continuous extends Distribution[Double] {
   def scale(a: Real): Continuous = Scale(a).transform(this)
   def translate(b: Real): Continuous = Translate(b).transform(this)
   def exp: Continuous = Exp.transform(this)
+
+  //experimental
+  def parameter: Real
 }
 
 object Continuous {
@@ -42,6 +45,13 @@ private[rainier] trait StandardContinuous extends Continuous {
     val density = support.logJacobian(x) + logDensity(transformed)
 
     RandomVariable(transformed, density)
+  }
+
+  def parameter: Real = {
+    val x = Real.parameter{x =>
+      support.logJacobian(x) + logDensity(support.transform(x))
+    }
+    support.transform(x)
   }
 }
 
@@ -247,5 +257,12 @@ case class Mixture(components: Map[Continuous, Real]) extends Continuous {
     val density = support.logJacobian(x) + logDensity(transformed)
 
     RandomVariable(transformed, density)
+  }
+
+  def parameter: Real = {
+    val x = Real.parameter{x =>
+      support.logJacobian(x) + logDensity(support.transform(x))
+    }
+    support.transform(x)
   }
 }

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Injection.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Injection.scala
@@ -36,6 +36,7 @@ private[rainier] trait Injection { self =>
       }
 
     def param: RandomVariable[Real] = dist.param.map(forwards)
+    def parameter: Real = forwards(dist.parameter)
   }
 }
 


### PR DESCRIPTION
This is a follow up to https://github.com/stripe/rainier/pull/401 .

It introduces a new `Parameter` private subtype of `Variable`, which holds onto its own `density` function. These must be constructed via `Real.parameter{x => density(x)}`.

The intent here is to experiment with alternative APIs that don't need a `RandomVariable` wrapper.

This PR also adds `parameter` methods to `Continuous` which are equivalent to `param` but make use of `Parameter` to return a bare `Real` instead of a `RandomVariable[Real]` (however there's no way yet to sample a model built from this).