### PR TITLE
Introduce Model

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Encoder.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Encoder.scala
@@ -9,9 +9,11 @@ trait Encoder[T] {
   def extract(t: T, acc: List[Double]): List[Double]
   def columns(ts: Seq[T]): List[Array[Double]] = {
     val first = extract(ts.head, Nil)
-    val buffers = first.map{v => ArrayBuffer(v)}
-    ts.tail.foreach{t =>
-      buffers.zip(extract(t, Nil)).foreach{
+    val buffers = first.map { v =>
+      ArrayBuffer(v)
+    }
+    ts.tail.foreach { t =>
+      buffers.zip(extract(t, Nil)).foreach {
         case (buf, v) => buf += v
       }
     }

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Encoder.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Encoder.scala
@@ -1,10 +1,22 @@
 package com.stripe.rainier.compute
 
+import scala.collection.mutable.ArrayBuffer
+
 trait Encoder[T] {
   type U
   def wrap(t: T): U
   def create(acc: List[Variable]): (U, List[Variable])
   def extract(t: T, acc: List[Double]): List[Double]
+  def columns(ts: Seq[T]): List[Array[Double]] = {
+    val first = extract(ts.head, Nil)
+    val buffers = first.map{v => ArrayBuffer(v)}
+    ts.tail.foreach{t =>
+      buffers.zip(extract(t, Nil)).foreach{
+        case (buf, v) => buf += v
+      }
+    }
+    buffers.map(_.toArray)
+  }
 }
 
 object Encoder {

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Real.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Real.scala
@@ -91,7 +91,7 @@ object Real {
     x.density = fn(x)
     x
   }
-  
+
   def eq(left: Real, right: Real, ifTrue: Real, ifFalse: Real): Real =
     lookupCompare(left, right, ifFalse, ifTrue, ifFalse)
   def lt(left: Real, right: Real, ifTrue: Real, ifFalse: Real): Real =

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Categorical.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Categorical.scala
@@ -53,7 +53,7 @@ final case class Categorical[T](pmf: Map[T, Real]) extends Distribution[T] {
     }
   }
 
-  def toMixture[V](implicit ev: T <:< Continuous): Mixture =
+  def toMixture[U](implicit ev: T <:< Continuous): Mixture =
     Mixture(pmf.map { case (k, v) => (ev(k), v) })
 }
 

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala
@@ -10,7 +10,8 @@ import scala.annotation.tailrec
 trait Continuous extends Distribution[Double] {
   private[rainier] val support: Support
 
-  def logDensity(v: Real): Real
+  type V = Real
+  def encoder(seq: Seq[Double]) = Encoder.numeric[Double]
 
   def scale(a: Real): Continuous = Scale(a).transform(this)
   def translate(b: Real): Continuous = Translate(b).transform(this)

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala
@@ -30,11 +30,11 @@ object Continuous {
   */
 private[rainier] trait StandardContinuous extends Continuous {
   def param: Real = {
-    val x = Real.parameter{x =>
+    val x = Real.parameter { x =>
       support.logJacobian(x) + logDensity(support.transform(x))
     }
     support.transform(x)
-  }  
+  }
 }
 
 /**
@@ -229,7 +229,7 @@ case class Mixture(components: Map[Continuous, Real]) extends Continuous {
       })
 
   def param: Real = {
-    val x = Real.parameter{x =>
+    val x = Real.parameter { x =>
       support.logJacobian(x) + logDensity(support.transform(x))
     }
     support.transform(x)

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala
@@ -11,7 +11,7 @@ trait Continuous extends Distribution[Double] {
   private[rainier] val support: Support
 
   type V = Real
-  def encoder(seq: Seq[Double]) = Encoder.numeric[Double]
+  val encoder = Encoder.numeric[Double]
 
   def scale(a: Real): Continuous = Scale(a).transform(this)
   def translate(b: Real): Continuous = Translate(b).transform(this)

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Discrete.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Discrete.scala
@@ -1,9 +1,11 @@
 package com.stripe.rainier.core
 
 import com.stripe.rainier.compute._
+import com.stripe.rainier.unused
 
 trait Discrete extends Distribution[Long] { self: Discrete =>
-  def logDensity(v: Real): Real
+  type V = Real
+  def encoder(@unused seq: Seq[Long]) = Encoder.numeric[Long]
 
   def zeroInflated(psi: Real): DiscreteMixture =
     constantInflated(0.0, psi)

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Discrete.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Discrete.scala
@@ -184,7 +184,7 @@ final case class Binomial(p: Real, k: Real) extends Discrete {
   }
 
   def logDensity(v: Real): Real =
-    Multinomial.logDensity(multi, List((true -> v), (false -> (k - v))))
+    multi.logDensity(List((true -> v), (false -> (k - v))))
 }
 
 /**

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Discrete.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Discrete.scala
@@ -1,11 +1,10 @@
 package com.stripe.rainier.core
 
 import com.stripe.rainier.compute._
-import com.stripe.rainier.unused
 
 trait Discrete extends Distribution[Long] { self: Discrete =>
   type V = Real
-  def encoder(@unused seq: Seq[Long]) = Encoder.numeric[Long]
+  val encoder = Encoder.numeric[Long]
 
   def zeroInflated(psi: Real): DiscreteMixture =
     constantInflated(0.0, psi)

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Distribution.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Distribution.scala
@@ -4,11 +4,11 @@ import com.stripe.rainier.compute._
 
 trait Distribution[T] {
   type V
-  private[core] def encoder(seq: Seq[T]): Encoder.Aux[T,V]
+  private[core] def encoder: Encoder.Aux[T,V]
   private[core] def logDensity(v: V): Real
 
   private[core] def target(ts: Seq[T]): Target = {
-    val enc = encoder(ts)
+    val enc = encoder
     val (v, vars) = enc.create(Nil)
     val lh = logDensity(v)
     val cols = enc.columns(ts)
@@ -16,7 +16,7 @@ trait Distribution[T] {
   }
 
   private[core] def target(t: T): Target = {
-    val enc = encoder(List(t))
+    val enc = encoder
     val v = enc.wrap(t)
     val lh = logDensity(v)
     Target(lh)    

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Distribution.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Distribution.scala
@@ -4,8 +4,24 @@ import com.stripe.rainier.compute._
 
 trait Distribution[T] {
   type V
-  def encoder(seq: Seq[T]): Encoder.Aux[T,V]
-  def logDensity(v: V): Real
+  private[core] def encoder(seq: Seq[T]): Encoder.Aux[T,V]
+  private[core] def logDensity(v: V): Real
+
+  private[core] def target(ts: Seq[T]): Target = {
+    val enc = encoder(ts)
+    val (v, vars) = enc.create(Nil)
+    val lh = logDensity(v)
+    val cols = enc.columns(ts)
+    new Target(lh, vars.zip(cols).toMap)
+  }
+
+  private[core] def target(t: T): Target = {
+    val enc = encoder(List(t))
+    val v = enc.wrap(t)
+    val lh = logDensity(v)
+    Target(lh)    
+  }
+
   def generator: Generator[T]
 }
 

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Distribution.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Distribution.scala
@@ -5,7 +5,7 @@ import com.stripe.rainier.compute._
 trait Distribution[T] {
   type V
   private[core] def encoder: Encoder.Aux[T, V]
-  private[core] def logDensity(v: V): Real
+  def logDensity(v: V): Real
 
   private[core] def target(ts: Seq[T]): Target = {
     val enc = encoder

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Distribution.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Distribution.scala
@@ -4,7 +4,7 @@ import com.stripe.rainier.compute._
 
 trait Distribution[T] {
   type V
-  private[core] def encoder: Encoder.Aux[T,V]
+  private[core] def encoder: Encoder.Aux[T, V]
   private[core] def logDensity(v: V): Real
 
   private[core] def target(ts: Seq[T]): Target = {
@@ -19,7 +19,7 @@ trait Distribution[T] {
     val enc = encoder
     val v = enc.wrap(t)
     val lh = logDensity(v)
-    Target(lh)    
+    Target(lh)
   }
 
   def generator: Generator[T]

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Distribution.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Distribution.scala
@@ -1,10 +1,17 @@
 package com.stripe.rainier.core
 
+import com.stripe.rainier.compute._
+
 trait Distribution[T] {
+  type V
+  def encoder(seq: Seq[T]): Encoder.Aux[T,V]
+  def logDensity(v: V): Real
   def generator: Generator[T]
 }
 
 object Distribution {
+  type Aux[X, Y] = Distribution[X] { type V = Y }
+
   def gen[D <: Distribution[T], T]: ToGenerator[D, T] =
     new ToGenerator[D, T] {
       def apply(d: D) = d.generator

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Fn.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Fn.scala
@@ -4,8 +4,8 @@ import com.stripe.rainier.compute._
 
 trait Fn[A, Y] { self =>
   type X
-  protected def encoder: Encoder[A] { type U = X }
-  protected def xy(x: X): Y
+  private[core] def encoder: Encoder[A] { type U = X }
+  private[core] def xy(x: X): Y
 
   def apply(a: A): Y = xy(encoder.wrap(a))
 

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Model.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Model.scala
@@ -3,29 +3,33 @@ package com.stripe.rainier.core
 import com.stripe.rainier.compute._
 
 case class Model(targets: List[Target]) {
-    def merge(other: Model) = Model(targets ++ other.targets)
+  def merge(other: Model) = Model(targets ++ other.targets)
 }
 
 object Model {
-    def observe[Y](ys: Seq[Y], dist: Distribution[Y]): Model =  {
-        val target = dist.target(ys)
-        Model(List(target))
+  def observe[Y](ys: Seq[Y], dist: Distribution[Y]): Model = {
+    val target = dist.target(ys)
+    Model(List(target))
+  }
+
+  def observe[X, Y](xs: Seq[X], ys: Seq[Y])(fn: X => Distribution[Y]): Model = {
+    val targets = (xs.zip(ys)).map {
+      case (x, y) => fn(x).target(y)
     }
 
-    def observe[X,Y](xs: Seq[X], ys: Seq[Y])(fn: X => Distribution[Y]): Model =  {
-        val targets = (xs.zip(ys)).map{
-            case (x,y) => fn(x).target(y)
-        }
+    Model(targets.toList)
+  }
 
-        Model(targets.toList)
-    }
-
-    def observe[X,Y](xs: Seq[X], ys: Seq[Y], fn: Fn[X,Distribution[Y]]): Model = {
-        val enc = fn.encoder
-        val (v, vars) = enc.create(Nil)
-        val dist = fn.xy(v)
-        val target = dist.target(ys)
-        val cols = enc.columns(xs)
-        Model(List(new Target(target.real, target.placeholders ++ vars.zip(cols).toMap)))
-    }
+  def observe[X, Y](xs: Seq[X],
+                    ys: Seq[Y],
+                    fn: Fn[X, Distribution[Y]]): Model = {
+    val enc = fn.encoder
+    val (v, vars) = enc.create(Nil)
+    val dist = fn.xy(v)
+    val target = dist.target(ys)
+    val cols = enc.columns(xs)
+    Model(
+      List(
+        new Target(target.real, target.placeholders ++ vars.zip(cols).toMap)))
+  }
 }

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Model.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Model.scala
@@ -7,7 +7,7 @@ case class Model(targets: List[Target]) {
 }
 
 object Model {
-    def observe[X,Y](ys: Seq[Y], dist: Distribution[Y]): Model =  {
+    def observe[Y](ys: Seq[Y], dist: Distribution[Y]): Model =  {
         val target = dist.target(ys)
         Model(List(target))
     }

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Model.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Model.scala
@@ -29,7 +29,6 @@ object Model {
     val target = dist.target(ys)
     val cols = enc.columns(xs)
     Model(
-      Set(
-        new Target(target.real, target.placeholders ++ vars.zip(cols).toMap)))
+      Set(new Target(target.real, target.placeholders ++ vars.zip(cols).toMap)))
   }
 }

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Model.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Model.scala
@@ -2,14 +2,14 @@ package com.stripe.rainier.core
 
 import com.stripe.rainier.compute._
 
-case class Model(targets: List[Target]) {
+case class Model(private val targets: Set[Target]) {
   def merge(other: Model) = Model(targets ++ other.targets)
 }
 
 object Model {
   def observe[Y](ys: Seq[Y], dist: Distribution[Y]): Model = {
     val target = dist.target(ys)
-    Model(List(target))
+    Model(Set(target))
   }
 
   def observe[X, Y](xs: Seq[X], ys: Seq[Y])(fn: X => Distribution[Y]): Model = {
@@ -17,7 +17,7 @@ object Model {
       case (x, y) => fn(x).target(y)
     }
 
-    Model(targets.toList)
+    Model(targets.toSet)
   }
 
   def observe[X, Y](xs: Seq[X],
@@ -29,7 +29,7 @@ object Model {
     val target = dist.target(ys)
     val cols = enc.columns(xs)
     Model(
-      List(
+      Set(
         new Target(target.real, target.placeholders ++ vars.zip(cols).toMap)))
   }
 }

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Model.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Model.scala
@@ -1,0 +1,21 @@
+package com.stripe.rainier.core
+
+import com.stripe.rainier.compute._
+
+case class Model(targets: List[Target]) {
+    def ++(other: Model) = Model(targets ++ other.targets)
+}
+
+object Model {
+    def observe[X,Y](ys: Seq[Y], dist: Distribution[Y]): Model =  {
+        ???
+    }
+
+    def observe[X,Y](xs: Seq[X], ys: Seq[Y])(fn: X => Distribution[Y]): Model =  {
+        ???
+    }
+
+    def observe[X,Y](xs: Seq[X], ys: Seq[Y], fn: Fn[X,Distribution[Y]]): Model = {
+        ???
+    }
+}

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Model.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Model.scala
@@ -3,19 +3,29 @@ package com.stripe.rainier.core
 import com.stripe.rainier.compute._
 
 case class Model(targets: List[Target]) {
-    def ++(other: Model) = Model(targets ++ other.targets)
+    def merge(other: Model) = Model(targets ++ other.targets)
 }
 
 object Model {
     def observe[X,Y](ys: Seq[Y], dist: Distribution[Y]): Model =  {
-        ???
+        val target = dist.target(ys)
+        Model(List(target))
     }
 
     def observe[X,Y](xs: Seq[X], ys: Seq[Y])(fn: X => Distribution[Y]): Model =  {
-        ???
+        val targets = (xs.zip(ys)).map{
+            case (x,y) => fn(x).target(y)
+        }
+
+        Model(targets.toList)
     }
 
     def observe[X,Y](xs: Seq[X], ys: Seq[Y], fn: Fn[X,Distribution[Y]]): Model = {
-        ???
+        val enc = fn.encoder
+        val (v, vars) = enc.create(Nil)
+        val dist = fn.xy(v)
+        val target = dist.target(ys)
+        val cols = enc.columns(xs)
+        Model(List(new Target(target.real, target.placeholders ++ vars.zip(cols).toMap)))
     }
 }


### PR DESCRIPTION
This PR introduces a `Model` object, with creation methods that parallel the old `Events.observe`. To support those methods, we also reintroduce the logic that used to be in `ToLikelihood` typeclasses, but simplified to be directly on `Distribution`; this makes it more straightforward to add more Distribution subtypes.

