### PR TITLE
add Prediction

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Categorical.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Categorical.scala
@@ -151,7 +151,6 @@ final case class Multinomial[T](pmf: Map[T, Real], k: Real)
           Real.eq(i, Real.zero, Real.zero, i * p.log)
         pTerm - Combinatorics.factorial(i)
     })
-
   def generator: Generator[Map[T, Long]] =
     Categorical(pmf).generator.repeat(k).map { seq =>
       seq.groupBy(identity).map { case (t, ts) => (t, ts.size.toLong) }

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Discrete.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Discrete.scala
@@ -1,6 +1,7 @@
 package com.stripe.rainier.core
 
 import com.stripe.rainier.compute._
+import com.stripe.rainier.unused
 
 trait Discrete extends Distribution[Long] { self: Discrete =>
   type V = Real

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Discrete.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Discrete.scala
@@ -1,7 +1,6 @@
 package com.stripe.rainier.core
 
 import com.stripe.rainier.compute._
-import com.stripe.rainier.unused
 
 trait Discrete extends Distribution[Long] { self: Discrete =>
   type V = Real

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Model.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Model.scala
@@ -5,8 +5,8 @@ import com.stripe.rainier.compute._
 case class Model(private val targets: Set[Target]) {
   def merge(other: Model) = Model(targets ++ other.targets)
 
-    def predict[T,U](value: T)(implicit tg: ToGenerator[T,U]): Prediction[U] =
-        Prediction(this, tg(value))
+  def predict[T, U](value: T)(implicit tg: ToGenerator[T, U]): Prediction[U] =
+    Prediction(this, tg(value))
 }
 
 object Model {

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Model.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Model.scala
@@ -4,6 +4,9 @@ import com.stripe.rainier.compute._
 
 case class Model(private val targets: Set[Target]) {
   def merge(other: Model) = Model(targets ++ other.targets)
+
+    def predict[T,U](value: T)(implicit tg: ToGenerator[T,U]): Prediction[U] =
+        Prediction(this, tg(value))
 }
 
 object Model {

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Prediction.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Prediction.scala
@@ -1,0 +1,9 @@
+package com.stripe.rainier.core
+
+case class Prediction[T](model: Model, generator: Generator[T]) {
+    def map[U](fn: T => U): Prediction[U] = Prediction(model, generator.map(fn))
+    def flatMap[U,V](fn: T => Generator[U]): Prediction[U] =
+        Prediction(model, generator.flatMap(fn))
+    def zip[U](other: Prediction[U]): Prediction[(T,U)] =
+        Prediction(model.merge(other.model), generator.zip(other.generator))
+}

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Prediction.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Prediction.scala
@@ -1,9 +1,9 @@
 package com.stripe.rainier.core
 
 case class Prediction[T](model: Model, generator: Generator[T]) {
-    def map[U](fn: T => U): Prediction[U] = Prediction(model, generator.map(fn))
-    def flatMap[U,V](fn: T => Generator[U]): Prediction[U] =
-        Prediction(model, generator.flatMap(fn))
-    def zip[U](other: Prediction[U]): Prediction[(T,U)] =
-        Prediction(model.merge(other.model), generator.zip(other.generator))
+  def map[U](fn: T => U): Prediction[U] = Prediction(model, generator.map(fn))
+  def flatMap[U, V](fn: T => Generator[U]): Prediction[U] =
+    Prediction(model, generator.flatMap(fn))
+  def zip[U](other: Prediction[U]): Prediction[(T, U)] =
+    Prediction(model.merge(other.model), generator.zip(other.generator))
 }


### PR DESCRIPTION
This is a very quick addition to the Model PR which fleshes out the next step: once you have a `Model` from doing an observation, you can `predict(v)` with it, where `v` is a `Real` or a `Map` of `Real`s or a `Generator`, etc. You then get an object that is the equivalent of an `RVG` - you can map/flatMap it as if it were a Generator, to refine your prediction, but it carries the `Model` state around with it to allow inference later.