### PR TITLE
Track bounds for Real

### DIFF
--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Bounds.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Bounds.scala
@@ -1,6 +1,9 @@
 package com.stripe.rainier.compute
 
-case class Bounds(lower: Double, upper: Double)
+case class Bounds(lower: Double, upper: Double) {
+  def isPositive = lower >= 0.0
+  def betweenZeroAndOne = isPositive && (upper <= 1.0)
+}
 
 object Bounds {
   def apply(value: BigDecimal): Bounds = Bounds(value.toDouble, value.toDouble)

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Bounds.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Bounds.scala
@@ -1,0 +1,94 @@
+package com.stripe.rainier.compute
+
+case class Bounds(lower: Double, upper: Double)
+
+object Bounds {
+  def apply(value: BigDecimal): Bounds = Bounds(value.toDouble, value.toDouble)
+
+  def or(seq: Seq[Bounds]): Bounds =
+    Bounds(seq.map(_.lower).min, seq.map(_.upper).max)
+
+  def sum(seq: Seq[Bounds]): Bounds =
+    Bounds(seq.map(_.lower).sum, seq.map(_.upper).sum)
+
+  def multiply(left: Bounds, right: Bounds): Bounds = {
+    val options =
+      List(left.lower * right.lower,
+           left.lower * right.upper,
+           left.upper * right.lower,
+           left.upper * right.upper)
+    Bounds(options.min, options.max)
+  }
+
+  def pow(x: Bounds, y: Bounds): Bounds = {
+    if (y.lower >= 0.0)
+      positivePow(x, y)
+    else if (y.upper <= 0.0)
+      negativePow(x, y)
+    else {
+      or(
+        List(
+          negativePow(x, Bounds(y.lower, 0.0)),
+          positivePow(x, Bounds(0.0, y.upper))
+        ))
+    }
+  }
+
+  private def positivePow(x: Bounds, y: Bounds): Bounds = {
+    if (x.lower >= 0.0)
+      positivePositivePow(x, y)
+    else if (x.upper <= 0.0)
+      negativePositivePow(x, y)
+    else {
+      or(
+        List(
+          negativePositivePow(Bounds(x.lower, 0.0), y),
+          positivePositivePow(Bounds(0.0, x.upper), y)
+        ))
+    }
+  }
+
+  private def negativePow(x: Bounds, y: Bounds): Bounds =
+    reciprocal(positivePow(x, Bounds(y.lower * -1, y.upper * -1)))
+
+  private def positivePositivePow(x: Bounds, y: Bounds): Bounds = {
+    val options = List(
+      Math.pow(x.lower, y.lower),
+      Math.pow(x.lower, y.upper),
+      Math.pow(x.upper, y.lower),
+      Math.pow(x.upper, y.upper)
+    )
+    Bounds(options.min, options.max)
+  }
+
+  private def negativePositivePow(x: Bounds, y: Bounds): Bounds = {
+    if (y.lower == y.upper && y.lower.isValidInt) {
+      val options = List(
+        Math.pow(x.lower, y.lower),
+        Math.pow(x.upper, y.lower)
+      )
+      Bounds(options.min, options.max)
+    } else {
+      Bounds(Double.NegativeInfinity, Double.PositiveInfinity)
+    }
+  }
+
+  def reciprocal(x: Bounds): Bounds = {
+    val options = List(
+      1.0 / x.lower,
+      1.0 / x.upper
+    )
+    Bounds(options.min, options.max)
+  }
+
+  def abs(x: Bounds) =
+    if (x.lower <= 0.0 && x.upper >= 0.0)
+      Bounds(0.0, Math.abs(x.lower).max(x.upper))
+    else {
+      val options = List(Math.abs(x.lower), Math.abs(x.upper))
+      Bounds(options.min, options.max)
+    }
+
+  def log(x: Bounds) = Bounds(Math.log(x.lower), Math.log(x.upper))
+  def exp(x: Bounds) = Bounds(Math.exp(x.lower), Math.exp(x.upper))
+}

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Real.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Real.scala
@@ -241,9 +241,10 @@ Evaluates to the (index-low)'th element of table.
  */
 private final class Lookup(val index: NonConstant,
                            val table: Array[Real],
-                           val low: Int,
-                           val bounds: Bounds)
-    extends NonConstant
+                           val low: Int)
+    extends NonConstant  {
+      val bounds = Bounds.or(table.map(_.bounds))
+  }
 
 object Lookup {
   def apply(table: Seq[Real]): Real => Real =
@@ -259,7 +260,7 @@ object Lookup {
         else
           throw new ArithmeticException("Cannot lookup a non-integral number")
       case nc: NonConstant =>
-        new Lookup(nc, table.toArray, low, Bounds.or(table.map(_.bounds)))
+        new Lookup(nc, table.toArray, low)
     }
 }
 

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Real.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Real.scala
@@ -17,14 +17,6 @@ You can also automatically derive the gradient of a Real with respect to its var
  */
 sealed trait Real {
   def bounds: Bounds
-  def mustBePositive(): Unit = {
-    //this may be too aggressive; we could warn instead
-    assert(bounds.lower >= 0)
-  }
-  def mustBeZeroToOne(): Unit = {
-    mustBePositive()
-    assert(bounds.upper <= 1)
-  }
 
   def +(other: Real): Real = RealOps.add(this, other)
   def *(other: Real): Real = RealOps.multiply(this, other)

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Real.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Real.scala
@@ -156,14 +156,14 @@ final private[rainier] class Parameter(var density: Real) extends Variable
 final private case class Unary(original: NonConstant, op: ir.UnaryOp)
     extends NonConstant {
   val bounds = op match {
-    case ir.NoOp => original.bounds
+    case ir.NoOp  => original.bounds
     case ir.AbsOp => Bounds.abs(original.bounds)
     case ir.ExpOp => Bounds.exp(original.bounds)
     case ir.LogOp => Bounds.log(original.bounds)
     //todo: narrow bounds for trig
-    case ir.SinOp | ir.CosOp => Bounds(-1,1)
-    case ir.TanOp => Bounds(Double.NegativeInfinity, Double.PositiveInfinity)
-    case ir.AsinOp | ir.AcosOp | ir.AtanOp => Bounds(0, Math.PI/2.0)
+    case ir.SinOp | ir.CosOp               => Bounds(-1, 1)
+    case ir.TanOp                          => Bounds(Double.NegativeInfinity, Double.PositiveInfinity)
+    case ir.AsinOp | ir.AcosOp | ir.AtanOp => Bounds(0, Math.PI / 2.0)
   }
 }
 
@@ -242,9 +242,9 @@ Evaluates to the (index-low)'th element of table.
 private final class Lookup(val index: NonConstant,
                            val table: Array[Real],
                            val low: Int)
-    extends NonConstant  {
-      val bounds = Bounds.or(table.map(_.bounds))
-  }
+    extends NonConstant {
+  val bounds = Bounds.or(table.map(_.bounds))
+}
 
 object Lookup {
   def apply(table: Seq[Real]): Real => Real =

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Model.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Model.scala
@@ -18,30 +18,29 @@ case class Model(private[rainier] val targets: Set[Target]) {
     Sample(chains, this)
   }
 
-  def writeGraph(path: String, gradient: Boolean = false): Unit = {	
-    val gradVars = if (gradient) targetGroup.variables else Nil	
-    val tuples = ("base", targetGroup.base, Map.empty[Variable, Array[Double]]) ::	
-      targetGroup.batched.zipWithIndex.map {	
-      case (b, i) =>	
-        (s"target$i", b.real, b.placeholders)	
-    }	
-    RealViz(tuples, gradVars).write(path)	
-  }	
-
-  def writeIRGraph(path: String,	
-                   gradient: Boolean = false,	
-                   methodSizeLimit: Option[Int] = None): Unit = {	
-    val tuples =	
-      (("base", targetGroup.base) ::	
-        targetGroup.batched.zipWithIndex.map {	
-        case (b, i) => (s"target$i" -> b.real)	
-      })	
-
-    RealViz	
-      .ir(tuples, targetGroup.variables, gradient, methodSizeLimit)	
-      .write(path)	
+  def writeGraph(path: String, gradient: Boolean = false): Unit = {
+    val gradVars = if (gradient) targetGroup.variables else Nil
+    val tuples = ("base", targetGroup.base, Map.empty[Variable, Array[Double]]) ::
+      targetGroup.batched.zipWithIndex.map {
+      case (b, i) =>
+        (s"target$i", b.real, b.placeholders)
+    }
+    RealViz(tuples, gradVars).write(path)
   }
 
+  def writeIRGraph(path: String,
+                   gradient: Boolean = false,
+                   methodSizeLimit: Option[Int] = None): Unit = {
+    val tuples =
+      (("base", targetGroup.base) ::
+        targetGroup.batched.zipWithIndex.map {
+        case (b, i) => (s"target$i" -> b.real)
+      })
+
+    RealViz
+      .ir(tuples, targetGroup.variables, gradient, methodSizeLimit)
+      .write(path)
+  }
 
   def optimize(): Estimate =
     Estimate(Optimizer.lbfgs(density()), this)
@@ -49,7 +48,7 @@ case class Model(private[rainier] val targets: Set[Target]) {
   lazy val targetGroup = TargetGroup(targets, 500)
   lazy val dataFn =
     Compiler.default.compileTargets(targetGroup, true, 4)
-    
+
   private[rainier] def variables: List[Variable] = targetGroup.variables
   private[rainier] def density(): DensityFunction =
     new DensityFunction {

--- a/rainier-plot/src/main/scala/com/stripe/rainier/plot/Jupyter.scala
+++ b/rainier-plot/src/main/scala/com/stripe/rainier/plot/Jupyter.scala
@@ -58,24 +58,24 @@ object Jupyter {
   implicit val extent: Extent = Extent(400, 400)
   implicit val theme: Theme = PlotThemes.default
 
-  def trace(sample: Sample)(implicit	
-                               theme: Theme,	
-                               oh: OutputHandler): Unit = {	
-    val nVariables = sample.model.variables.size	
-    val lines =	
-      0.until(nVariables).toList.map { v =>	
-        sample.chains.zipWithIndex.map {	
-          case (c, n) =>	
-            line(c.zipWithIndex.map { case (a, i) => i -> a(v) })	
-              .xAxis()	
-              .yAxis()	
-              .frame()	
-              .xLabel("chain " + (n + 1))	
-              .yLabel("param " + (v + 1))	
-        }	
-      }	
-    show(Facets(lines))(Extent(800, 800), theme, oh)	
-  }	
+  def trace(sample: Sample)(implicit
+                            theme: Theme,
+                            oh: OutputHandler): Unit = {
+    val nVariables = sample.model.variables.size
+    val lines =
+      0.until(nVariables).toList.map { v =>
+        sample.chains.zipWithIndex.map {
+          case (c, n) =>
+            line(c.zipWithIndex.map { case (a, i) => i -> a(v) })
+              .xAxis()
+              .yAxis()
+              .frame()
+              .xLabel("chain " + (n + 1))
+              .yLabel("param " + (v + 1))
+        }
+      }
+    show(Facets(lines))(Extent(800, 800), theme, oh)
+  }
 
   def density[N](seq: Seq[N], minX: Double, maxX: Double)(
       implicit num: Numeric[N],


### PR DESCRIPTION
This tracks a (lower,upper) bound (as a double) for any `Real`, by starting each `Variable` at (-inf,inf), and starting each `Constant(k)` at (k,k), and then doing interval arithmetic to transform the bounds for any operations.

It works surprisingly well - eg `Exponential(3).param.logistic.bounds` gives `Bounds(0.5,1.0)`.

The idea is then to have assertions in the constructors for distributions that enforce bounds like stddev has to be positive. This acts a bit like type checking for your models.

Before this is useful, we'll need to also add accurate bounds to `Placeholder` that are computed during `Model.observe`, otherwise we'll likely get assertion failures every time we use `Fn`. (We also need to add in the actual assertions).