### PR TITLE
Use Decimal inside Placeholder

### DIFF
--- a/rainier-benchmark/src/main/scala/com/stripe/rainier/bench/stan/GLMMPoisson2.scala
+++ b/rainier-benchmark/src/main/scala/com/stripe/rainier/bench/stan/GLMMPoisson2.scala
@@ -45,7 +45,7 @@ class GLMMPoisson2 extends ModelBenchmark {
       Model.observe(
         yearSite,
         C,
-        Fn.numeric[Int].zip(Fn.numeric[Int]).map {
+        Fn.int.zip(Fn.int).map {
           case (year, site) =>
             val logLambda = Lookup(year, yearBetas) + Lookup(site, alphas)
             Poisson(logLambda.exp)

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Compiler.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Compiler.scala
@@ -13,8 +13,8 @@ final case class Compiler(methodSizeLimit: Int, classSizeLimit: Int) {
 
   def compileTargets(targets: TargetGroup, gradient: Boolean): DataFunction = {
     val data = targets.batched.map { target =>
-      target.placeholderVariables.map { v =>
-        target.placeholders(v)
+      target.placeholders.map { v =>
+        v.values.map(_.toDouble).toArray
       }.toArray
     }.toArray
 

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Decimal.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Decimal.scala
@@ -46,11 +46,13 @@ object NegInfinity extends Decimal {
 
 class DoubleDecimal(val toDouble: Double) extends Decimal {
   override lazy val hashCode = toDouble.hashCode
+  override def toString = toDouble.toString
 }
 
-class FractionDecimal(val n: Long, val d: Long) extends Decimal {
-  lazy val toDouble = n.toDouble / d.toDouble
+class FractionDecimal(val n: Double, val d: Double) extends Decimal {
+  lazy val toDouble = n / d
   override lazy val hashCode = toDouble.hashCode
+  override def toString = s"$n/$d"
 }
 
 object Decimal {
@@ -64,8 +66,8 @@ object Decimal {
     else
       new DoubleDecimal(value)
 
-  def apply(value: Int): Decimal = new FractionDecimal(value.toLong, 1L)
-  def apply(value: Long): Decimal = new FractionDecimal(value, 1L)
+  def apply(value: Int): Decimal = new FractionDecimal(value.toDouble, 1.0)
+  def apply(value: Long): Decimal = new FractionDecimal(value.toDouble, 1.0)
 
   val Zero = Decimal(0)
   val One = Decimal(1)

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/DecimalOps.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/DecimalOps.scala
@@ -146,8 +146,8 @@ object DecimalOps {
     case d: DoubleDecimal => Decimal(Math.pow(d.toDouble, y.toDouble))
     case f: FractionDecimal =>
       val yabs = Math.abs(y).toDouble
-      val n2 = Math.pow(f.n.toDouble, yabs).toLong
-      val d2 = Math.pow(f.d.toDouble, yabs).toLong
+      val n2 = Math.pow(f.n.toDouble, yabs)
+      val d2 = Math.pow(f.d.toDouble, yabs)
       if (y >= 0)
         new FractionDecimal(n2, d2)
       else
@@ -248,12 +248,12 @@ object DecimalOps {
       Decimal(-1)
   }
 
-  private def lcm(x: Long, y: Long): Long = {
+  private def lcm(x: Double, y: Double): Double = {
     (x * y) / gcd(x, y)
   }
 
   @tailrec
-  private def gcd(x: Long, y: Long): Long = {
+  private def gcd(x: Double, y: Double): Double = {
     if (y == 0)
       x.abs
     else

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Fn.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Fn.scala
@@ -71,16 +71,42 @@ trait Fn[-A, +Y] { self =>
 }
 
 object Fn {
-  def numeric[N](implicit n: Numeric[N]): Fn[N, Real] =
-    new Fn[N, Real] {
+  def double: Fn[Double, Real] =
+    new Fn[Double, Real] {
       type X = Real
-      def wrap(a: N) = Real(a)
+      def wrap(a: Double) = Real(a)
       def create(columns: List[Array[Double]]) = {
-        val x = Real.placeholder(columns.head)
+        val x = Real.doubles(columns.head)
         (x, columns.tail)
       }
-      def extract(a: N, acc: List[Double]) =
-        n.toDouble(a) :: acc
+      def extract(a: Double, acc: List[Double]) =
+        a :: acc
+      def xy(x: Real) = x
+    }
+
+  def int: Fn[Int, Real] =
+    new Fn[Int, Real] {
+      type X = Real
+      def wrap(a: Int) = Real(a)
+      def create(columns: List[Array[Double]]) = {
+        val x = Real.longs(columns.head.map(_.toLong))
+        (x, columns.tail)
+      }
+      def extract(a: Int, acc: List[Double]) =
+        a.toDouble :: acc
+      def xy(x: Real) = x
+    }
+
+  def long: Fn[Long, Real] =
+    new Fn[Long, Real] {
+      type X = Real
+      def wrap(a: Long) = Real(a)
+      def create(columns: List[Array[Double]]) = {
+        val x = Real.longs(columns.head.map(_.toLong))
+        (x, columns.tail)
+      }
+      def extract(a: Long, acc: List[Double]) =
+        a.toDouble :: acc
       def xy(x: Real) = x
     }
 
@@ -93,7 +119,7 @@ object Fn {
       def create(columns: List[Array[Double]]) = {
         choices.foldLeft((List.empty[(T, Real)], columns)) {
           case ((acc, cols), k) =>
-            ((k, Real.placeholder(cols.head)) :: acc, cols.tail)
+            ((k, Real.doubles(cols.head)) :: acc, cols.tail)
         }
       }
       def extract(a: T, acc: List[Double]) =

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Real.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Real.scala
@@ -63,7 +63,15 @@ object Real {
     summed.log + max
   }
 
-  def placeholder(values: Array[Double]): Placeholder = new Placeholder(values)
+  def doubles(values: Seq[Double]): Placeholder =
+    new Placeholder(values.toList.map { x =>
+      Decimal(x)
+    })
+
+  def longs(values: Seq[Long]): Placeholder =
+    new Placeholder(values.toList.map { x =>
+      Decimal(x)
+    })
 
   def parameter(): Parameter = new Parameter(Real.zero)
   def parameter(fn: Parameter => Real): Parameter = {
@@ -110,9 +118,10 @@ sealed trait Variable extends NonConstant {
   private[compute] val param = new ir.Parameter
 }
 
-final private[rainier] class Placeholder(val values: Array[Double])
+final private[rainier] class Placeholder(val values: List[Decimal])
     extends Variable {
-  val bounds = Bounds(values.min, values.max)
+  lazy val bounds =
+    Bounds(values.map(_.toDouble).min, values.map(_.toDouble).max)
 }
 
 final private[rainier] class Parameter(var density: Real) extends Variable {

--- a/rainier-core/src/main/scala/com/stripe/rainier/compute/Target.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/compute/Target.scala
@@ -2,16 +2,15 @@ package com.stripe.rainier.compute
 
 import Log._
 
-class Target(val real: Real,
-             val placeholders: Map[Variable, Array[Double]],
-             tryInline: Boolean) {
-  val nRows: Int =
+class Target(val real: Real, tryInline: Boolean) {
+  def nRows: Int =
     if (placeholders.isEmpty)
       0
     else
-      placeholders.head._2.size
+      placeholders.head.values.size
 
-  val placeholderVariables: List[Variable] = placeholders.keys.toList
+  val placeholders: List[Placeholder] =
+    RealOps.variables(real).collect { case v: Placeholder => v }.toList
   val parameters: Set[Parameter] =
     RealOps.variables(real).collect { case v: Parameter => v }
 
@@ -27,16 +26,12 @@ class Target(val real: Real,
     }
 
   def batched: (List[Variable], List[Real]) =
-    (placeholderVariables, List(real))
+    (placeholders, List(real))
 }
 
 object Target {
   def apply(real: Real, tryInline: Boolean = true): Target = {
-    val placeholders =
-      RealOps.variables(real).collect { case v: Placeholder => v }
-    new Target(real, placeholders.map { p =>
-      p -> p.values
-    }.toMap, tryInline)
+    new Target(real, tryInline)
   }
 
   val empty: Target = apply(Real.zero)

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Categorical.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Categorical.scala
@@ -103,7 +103,7 @@ final case class Multinomial[T](pmf: Map[T, Real], k: Real)
     extends Distribution[Map[T, Long]] { self =>
 
   val likelihoodFn =
-    Fn.numeric[Long]
+    Fn.long
       .keys(pmf.keys.toList)
       .map(logDensity)
 

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Continuous.scala
@@ -10,7 +10,7 @@ import scala.annotation.tailrec
 trait Continuous extends Distribution[Double] {
   private[rainier] val support: Support
 
-  val likelihoodFn = Fn.numeric[Double].map(logDensity)
+  val likelihoodFn = Fn.double.map(logDensity)
   def logDensity(x: Real): Real
 
   def scale(a: Real): Continuous = Scale(a).transform(this)

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Discrete.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Discrete.scala
@@ -3,7 +3,7 @@ package com.stripe.rainier.core
 import com.stripe.rainier.compute._
 
 trait Discrete extends Distribution[Long] { self: Discrete =>
-  val likelihoodFn = Fn.numeric[Long].map(logDensity)
+  val likelihoodFn = Fn.long.map(logDensity)
   def logDensity(x: Real): Real
 
   def zeroInflated(psi: Real): DiscreteMixture =

--- a/rainier-tests/src/main/scala/com/stripe/rainier/core/SBCModel.scala
+++ b/rainier-tests/src/main/scala/com/stripe/rainier/core/SBCModel.scala
@@ -21,6 +21,7 @@ trait SBCModel[T] {
   val (samples, trueValue) = {
     implicit val rng: RNG = ScalaRNG(1528673302081L)
     val (values, trueValue) = sbc.synthesize(syntheticSamples)
+    println((trueValue, values))
     val (model, real) = sbc.fit(values)
     val samples =
       model.sample(sampler, warmupIterations, goldset.size).predict(real)

--- a/rainier-tests/src/main/scala/com/stripe/rainier/core/SBCModel.scala
+++ b/rainier-tests/src/main/scala/com/stripe/rainier/core/SBCModel.scala
@@ -21,7 +21,6 @@ trait SBCModel[T] {
   val (samples, trueValue) = {
     implicit val rng: RNG = ScalaRNG(1528673302081L)
     val (values, trueValue) = sbc.synthesize(syntheticSamples)
-    println((trueValue, values))
     val (model, real) = sbc.fit(values)
     val samples =
       model.sample(sampler, warmupIterations, goldset.size).predict(real)

--- a/rainier-tests/src/test/scala/com/stripe/rainier/compute/FnTest.scala
+++ b/rainier-tests/src/test/scala/com/stripe/rainier/compute/FnTest.scala
@@ -12,10 +12,9 @@ class FnTest extends FunSuite {
     }
   }
 
-  val fDouble = Fn.numeric[Double]
-  val fLong = Fn.numeric[Long]
-  val fMap = Fn
-    .numeric[Double]
+  val fDouble = Fn.double
+  val fLong = Fn.long
+  val fMap = Fn.double
     .keys(List("a", "b"))
     .map { m =>
       m("a") * 2 + m("b")

--- a/rainier-tests/src/test/scala/com/stripe/rainier/core/SBCTest.scala
+++ b/rainier-tests/src/test/scala/com/stripe/rainier/core/SBCTest.scala
@@ -10,7 +10,7 @@ class SBCTest extends FunSuite {
       sbcModel.samples.zip(sbcModel.goldset).foreach {
         case (a, b) =>
           val err = Math.abs((a - b) / b)
-        assert(err < Epsilon)
+          assert(err < Epsilon)
       }
     }
   }


### PR DESCRIPTION
The big win here is that we can have special `int` vs `double` constructors for `Fn`, which means we can use `Real(1)` semantics instead of `Real(1.0)` for data.

Doing this exposed a weakness in `FractionDecimal` where you can overflow `Long` too easily; we switched to `Double` for the numerator and denominator so that you just lose precision vs overflow when this happens.