### PR TITLE
Fix mdoc resolution issues in TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: scala
 
 scala:
-  - 2.12.8
+  - 2.12.10
 
 jdk:
   - openjdk8

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.7
+sbt.version=1.2.8


### PR DESCRIPTION
Hoping this fixes the unresolved `sbt-mdoc` issue in Travis:
```
[warn] Note: Unresolved dependencies path:
[warn] 	org.scalameta:sbt-mdoc:2.1.1 (scalaVersion=2.12, sbtVersion=1.0) (/home/travis/build/stripe/rainier/project/plugins.sbt#L1-2)
[warn] 	+- default:rainier-build:0.1.0-SNAPSHOT (scalaVersion=2.12, sbtVersion=1.0)
[error] sbt.librarymanagement.ResolveException: unresolved dependency: org.scalameta#sbt-mdoc;2.1.1: not found
```