### PR TITLE
drop Numeric[Real]

### DIFF
--- a/rainier-benchmark/src/main/scala/com/stripe/rainier/bench/misc/CategoricalBenchmark.scala
+++ b/rainier-benchmark/src/main/scala/com/stripe/rainier/bench/misc/CategoricalBenchmark.scala
@@ -16,7 +16,7 @@ import com.stripe.rainier.sampler._
 @State(Scope.Benchmark)
 class CategoricalBenchmark {
   implicit val rng: RNG = RNG.default
-  implicit val eval: Numeric[Real] = new Evaluator(Map.empty)
+  implicit val eval: Evaluator = new Evaluator(Map.empty)
 
   @Benchmark
   def run(): Unit = {

--- a/rainier-compute/src/main/scala/com/stripe/rainier/compute/Evaluator.scala
+++ b/rainier-compute/src/main/scala/com/stripe/rainier/compute/Evaluator.scala
@@ -1,10 +1,6 @@
 package com.stripe.rainier.compute
 
-class Evaluator(var cache: Map[Real, Double]) extends Numeric[Real] {
-
-  def parseString(str: String): Option[Real] =
-    (try { Some(str.toDouble) } catch { case _: Throwable => None })
-      .map(Real(_))
+class Evaluator(var cache: Map[Real, Double]) {
 
   def toDouble(x: Real): Double = x match {
     case c: Constant => c.getDouble
@@ -22,9 +18,9 @@ class Evaluator(var cache: Map[Real, Double]) extends Numeric[Real] {
   private def eval(real: Real): Double = real match {
     case c: Constant => c.getDouble
     case l: Line =>
-      l.ax.toList.map { case (r, d) => toDouble(r) * d.toDouble }.sum + l.b.toDouble
+      l.ax.toList.map { case (r, d) => toDouble(r) * d.getDouble }.sum + l.b.getDouble
     case l: LogLine =>
-      l.ax.toList.map { case (r, d) => Math.pow(toDouble(r), d.toDouble) }.product
+      l.ax.toList.map { case (r, d) => Math.pow(toDouble(r), d.getDouble) }.product
     case Unary(original, op) =>
       // must use Real(_) constructor since Constant(_) constructor would result in undesirable errors
       // at infinities and unhelpful NumberFormatException on NaN, all due to conversion to Decimal

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Generator.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Generator.scala
@@ -12,7 +12,7 @@ sealed trait Generator[+T] { self =>
 
   def requirements: Set[Real]
 
-  def get(implicit r: RNG, n: Numeric[Real]): T
+  def get(implicit r: RNG, n: Evaluator): T
 
   def map[U](fn: T => U): Generator[U] = self match {
     case Const(reqs, t)     => Const(reqs, fn(t))
@@ -105,24 +105,24 @@ object Generator {
     gen(l)
 
   case class Const[T](requirements: Set[Real], t: T) extends Generator[T] {
-    def get(implicit r: RNG, n: Numeric[Real]): T = t
+    def get(implicit r: RNG, n: Evaluator): T = t
   }
 
-  case class From[T](requirements: Set[Real], fn: (RNG, Numeric[Real]) => T)
+  case class From[T](requirements: Set[Real], fn: (RNG, Evaluator) => T)
       extends Generator[T] {
-    def get(implicit r: RNG, n: Numeric[Real]): T = fn(r, n)
+    def get(implicit r: RNG, n: Evaluator): T = fn(r, n)
   }
 
   def constant[T](t: T): Generator[T] = Const(Set.empty, t)
 
-  def from[T](fn: (RNG, Numeric[Real]) => T): Generator[T] = From(Set.empty, fn)
+  def from[T](fn: (RNG, Evaluator) => T): Generator[T] = From(Set.empty, fn)
 
   def real(x: Real): Generator[Double] =
     From(Set(x), { (_, n) =>
       n.toDouble(x)
     })
 
-  def require[T](reqs: Set[Real])(fn: (RNG, Numeric[Real]) => T): Generator[T] =
+  def require[T](reqs: Set[Real])(fn: (RNG, Evaluator) => T): Generator[T] =
     From(reqs, fn)
 
   def vector[T](v: Vector[T]) = from((r, _) => v(r.int(v.size)))

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Injection.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Injection.scala
@@ -8,7 +8,7 @@ import com.stripe.rainier.unused
   */
 private[rainier] trait Injection { self =>
   def forwards(x: Real): Real
-  def fastForwards(x: Double)(implicit n: Numeric[Real]): Double =
+  def fastForwards(x: Double, n: Evaluator): Double =
     n.toDouble(forwards(Real(x)))
   def backwards(y: Real): Real
   def whenDefinedAt(@unused y: Real,
@@ -32,7 +32,7 @@ private[rainier] trait Injection { self =>
 
     val generator: Generator[Double] =
       Generator.require(self.requirements) { (r, n) =>
-        fastForwards(dist.generator.get(r, n))(n)
+        fastForwards(dist.generator.get(r, n), n)
       }
 
     def param: Real = forwards(dist.param)
@@ -46,7 +46,7 @@ private[rainier] trait Injection { self =>
 final case class Scale(a: Real) extends Injection {
   private val lj = a.log * -1
   def forwards(x: Real): Real = x * a
-  override def fastForwards(x: Double)(implicit n: Numeric[Real]) =
+  override def fastForwards(x: Double, n: Evaluator) =
     x * n.toDouble(a)
   def backwards(y: Real): Real = y / a
   def logJacobian(y: Real): Real = lj
@@ -66,7 +66,7 @@ final case class Scale(a: Real) extends Injection {
   */
 final case class Translate(b: Real) extends Injection {
   def forwards(x: Real): Real = x + b
-  override def fastForwards(x: Double)(implicit n: Numeric[Real]) =
+  override def fastForwards(x: Double, n: Evaluator) =
     x + n.toDouble(b)
   def backwards(y: Real): Real = y - b
   def logJacobian(y: Real): Real = Real.zero
@@ -85,7 +85,7 @@ final case class Translate(b: Real) extends Injection {
   */
 object Exp extends Injection {
   def forwards(x: Real): Real = x.exp
-  override def fastForwards(x: Double)(implicit n: Numeric[Real]) =
+  override def fastForwards(x: Double, n: Evaluator) =
     Math.exp(x)
   def backwards(y: Real): Real = y.log
   def logJacobian(y: Real): Real = y.log * -1


### PR DESCRIPTION
This drops the `Numeric[Real]` from `Evaluator` and changes the old references to `Numeric[Real]` to be direct references to `Evaluator`. This was always a bit overly cute and confusing, but the catalyst here is that 2.13 has extended `Numeric` to require parseString, which makes no sense for `Evaluator` to support.

cc @valencik 