### PR TITLE
Basic PPrint support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -56,6 +56,7 @@ lazy val V = new {
   val shadedAsm = "0.2.1"
   val scalameta = "4.2.3"
   val mdoc = "2.1.1"
+  val amm = "2.0.4"
 }
 
 // primary modules
@@ -111,8 +112,10 @@ lazy val rainierNotebook = project.
         "com.cibo" %% "evilplot" % V.evilplot,
         "org.scalameta" %% "scalameta" % V.scalameta,
         "org.scalameta" %% "mdoc" % V.mdoc,
+        "com.lihaoyi" % "ammonite-repl_2.12.10" % V.amm,
         "sh.almond" %% "jupyter-api" % V.almond)
   )
+
 
 lazy val rainierBenchmark = project.
   in(file("rainier-benchmark")).

--- a/build.sbt
+++ b/build.sbt
@@ -98,6 +98,7 @@ lazy val rainierCore = project.
 
 lazy val rainierNotebook = project.
   in(file("rainier-notebook")).
+  dependsOn(rainierCompute, rainierCore).
   settings(name := "rainier-notebook").
   settings(commonSettings).
   settings(

--- a/docs/posteriors.md
+++ b/docs/posteriors.md
@@ -31,12 +31,12 @@ Now, it's decision time. Which feed should the farmer go with?
 
 As we did [once before](likelihoods.md), we'd like to sample this model to get a `Trace` we can make predictions from, and then check the diagnostics on the trace.
 
-```scala mdoc:to-string
+```scala mdoc:pprint
 val sampler = EHMC(warmupIterations = 5000, iterations = 5000)
 val eggTrace = vecModel.sample(sampler)
 ```
 
-```scala mdoc
+```scala mdoc:pprint
 eggTrace.diagnostics
 ```
 
@@ -50,14 +50,14 @@ This kind of uncertainty is modeled in Rainier by the `Generator[T]` type. `Gene
 
 One way to construct a `Generator[T]` is from a `Distribution[T]`. For example, we can predict daily values from a single type of feed like this:
 
-```scala mdoc:to-string
+```scala mdoc:pprint
 val gen0 = Generator(Poisson(feeds(0)))
 eggTrace.predict(gen0).take(5)
 ```
 
 It might be more interesting to compare two different feeds. For example, here we are sampling the _difference_ between feed 0 and feed 2:
 
-```scala mdoc:to-string
+```scala mdoc:pprint
 val pairGen = Generator((Poisson(feeds(0)), Poisson(feeds(2))))
 val diffGen = pairGen.map{
     case (n0, n2) => n2 - n0
@@ -101,7 +101,7 @@ def profit(eggCount: Long, feed: Int): Double =
 
 Then we can construct a generator that produces the daily profit for each decision:
 
-```scala mdoc:to-string
+```scala mdoc:pprint
 val profitGen = Generator(feeds.map{rate => Poisson(rate)}).map{counts =>
     counts.zipWithIndex.map{case (n, i) => profit(n, i)}
 }
@@ -109,7 +109,7 @@ val profitGen = Generator(feeds.map{rate => Poisson(rate)}).map{counts =>
 
 Finally, we can sample from and then average over the posterior for that generator.
 
-```scala mdoc:to-string
+```scala mdoc:pprint
 def average(predictions: Seq[Seq[Double]]): Seq[Double] =
     predictions.reduce{(left, right) => 
         left.zip(right).map{case (l,r) => l + r}
@@ -124,7 +124,7 @@ However, that's a very simple utility function. (In fact, so simple that we coul
 
 For example, imagine that cashflow on the farm is very tight, and that if there's ever a day where the egg sales don't cover the feed, that can cause problems. You might decide to penalize that ever happening with a "cost" equivalent to $20:
 
-```scala mdoc:to-string
+```scala mdoc:pprint
 def utility(eggCount: Long, feed: Int): Double = {
     val net = profit(eggCount, feed)
     if(net < 0)

--- a/docs/priors.md
+++ b/docs/priors.md
@@ -4,7 +4,7 @@ title: Priors and Random Variables
 ---
 
 Let's start by importing these two packages, which  contain all of the types we will use:
-```scala mdoc
+```scala mdoc:silent
 import com.stripe.rainier.core._
 import com.stripe.rainier.compute._
 ```
@@ -14,7 +14,7 @@ The most fundamental data type in Rainier is the `Real`, which represents a real
 
 To construct a `Real`, we very often start with a `Distribution` object. For example, here we first construct a `Uniform(0,1)` distribution, and then use `latent` to create a new latent random variable, `a`, with that distribution as its prior.
 
-```scala mdoc:to-string
+```scala mdoc:pprint
 val a = Uniform(0,1).latent
 val b = a + 1
 ```
@@ -23,7 +23,7 @@ Although we don't know the exact value, you can see in the output that Rainier i
 
 You can combine `Real`s using normal arithmetic operations, and they support a wide range of unary operators like `abs`, `exp`, `log`, and `logit`. You can also use a `Real` for any parameter of a `Distribution`. So, for example, we can use our `b` and `a` as the mean and standard deviation of a new `Normal` latent variable.
 
-```scala mdoc:to-string
+```scala mdoc:pprint
 val c = Normal(b, a).latent
 ```
 
@@ -33,7 +33,7 @@ The bounds for `c` are not that helpful: *in theory*, it can take on any real va
 
 We'll see a more thorough treatment of sampling later on, but for now, we can use a simple convenience method that's perfect for this kind of exploratory work.
 
-```scala mdoc
+```scala mdoc:pprint
 Model.sample((a,c)).take(10)
 ```
 
@@ -47,7 +47,7 @@ _NOTE: this currently is only supported for Scala 2.12._
 
 Importing the package exposes all of the plotting methods:
 
-```scala mdoc
+```scala mdoc:silent
 import com.stripe.rainier.notebook._
 ```
 

--- a/rainier-compute/src/main/scala/com/stripe/rainier/compute/Real.scala
+++ b/rainier-compute/src/main/scala/com/stripe/rainier/compute/Real.scala
@@ -7,11 +7,6 @@ A Real is a DAG which represents a mathematical function
 from 0 or more real-valued input parameters to a single real-valued output.
  */
 sealed trait Real {
-  override def toString =
-    if (bounds.lower == bounds.upper)
-      f"Real(${bounds.lower}%.3g)"
-    else
-      f"Real(${bounds.lower}%.3g, ${bounds.upper}%.3g)"
   def bounds: Bounds
 
   def +(other: Real): Real = RealOps.add(this, other)

--- a/rainier-compute/src/main/scala/com/stripe/rainier/compute/Vec.scala
+++ b/rainier-compute/src/main/scala/com/stripe/rainier/compute/Vec.scala
@@ -41,8 +41,6 @@ sealed trait Vec[+T] {
     Real.sum(0.until(size).map { i =>
       apply(i) * other(i)
     })
-
-  override def toString = "Vec" + toList.toString.drop(4)
 }
 
 object Vec {

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Distribution.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Distribution.scala
@@ -5,5 +5,4 @@ import com.stripe.rainier.compute._
 trait Distribution[T] {
   def logDensity(seq: Seq[T]): Real
   def generator: Generator[T]
-  override def toString = "Distribution()"
 }

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Generator.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Generator.scala
@@ -92,8 +92,6 @@ sealed trait Generator[+T] { self =>
         }
     }
   }
-
-  override def toString = "Generator()"
 }
 
 /**

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Model.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Model.scala
@@ -42,8 +42,6 @@ case class Model(private[rainier] val likelihoods: List[Real],
       def density = outputs(0)
       def gradient(index: Int) = outputs(index + 1)
     }
-
-  override def toString = s"Model[${parameters.size}]"
 }
 
 object Model {

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Trace.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Trace.scala
@@ -37,9 +37,6 @@ case class Trace(chains: List[List[Array[Double]]], model: Model)(
       }
     }
   }
-
-  override def toString =
-    s"Trace[${chains.size}][${chains.head.size}][${chains.head.head.size}]"
 }
 
 /**

--- a/rainier-notebook/src/main/resources/META-INF/services/mdoc.PostModifier
+++ b/rainier-notebook/src/main/resources/META-INF/services/mdoc.PostModifier
@@ -1,1 +1,2 @@
 com.stripe.rainier.notebook.ImageModifier
+com.stripe.rainier.notebook.PrettyPrintModifier

--- a/rainier-notebook/src/main/scala/com/stripe/rainier/notebook/PrettyPrint.scala
+++ b/rainier-notebook/src/main/scala/com/stripe/rainier/notebook/PrettyPrint.scala
@@ -2,10 +2,17 @@ package com.stripe.rainier.notebook
 
 import com.stripe.rainier.compute._
 import com.stripe.rainier.core._
-import pprint.Tree
+import pprint._
 import ammonite.repl.FullReplAPI
 
 object PrettyPrint {
+  def pprint(): PPrinter = {
+    val p = PPrinter.BlackWhite
+    def treeify(x: Any): Tree =
+      handlers(treeify).lift(x).getOrElse(p.treeify(x))
+    p.copy(additionalHandlers = handlers(treeify))
+  }
+
   def register(repl: FullReplAPI): Unit = {
     val p = repl.pprinter()
 

--- a/rainier-notebook/src/main/scala/com/stripe/rainier/notebook/PrettyPrint.scala
+++ b/rainier-notebook/src/main/scala/com/stripe/rainier/notebook/PrettyPrint.scala
@@ -1,7 +1,7 @@
 package com.stripe.rainier.notebook
 
 import com.stripe.rainier.compute._
-//import com.stripe.rainier.core._
+import com.stripe.rainier.core._
 import pprint.Tree
 import ammonite.repl.FullReplAPI
 
@@ -14,7 +14,7 @@ object PrettyPrint {
 
     repl.pprinter.bind(
       p.copy(
-        additionalHandlers = p.additionalHandlers.orElse(handlers(treeify)) 
+        additionalHandlers = p.additionalHandlers.orElse(handlers(treeify))
       ))
     ()
   }
@@ -26,10 +26,18 @@ object PrettyPrint {
       f"${b.lower}%.3g, ${b.upper}%.3g"
 
   def handlers(treeify: Any => Tree): PartialFunction[Any, Tree] = {
-    case r: Real            => Tree.Literal("Real(" + bounds(r.bounds) + ")")
+    case r: Real => Tree.Literal("Real(" + bounds(r.bounds) + ")")
+    case _: Distribution[_] =>
+      Tree.Literal("Distribution()")
+    case _: Generator[_] =>
+      Tree.Literal("Generator()")
     case v: Vec[_] =>
       Tree.Apply("Vec", v.toList.iterator.map { el =>
         treeify(el)
       })
+    case m: Model =>
+      Tree.Literal(s"Model[${m.parameters.size}]")
+    case t: Trace =>
+      Tree.Literal(s"Trace[${t.chains.size}][${t.chains.head.size}][${t.chains.head.head.size}]")
   }
 }

--- a/rainier-notebook/src/main/scala/com/stripe/rainier/notebook/PrettyPrint.scala
+++ b/rainier-notebook/src/main/scala/com/stripe/rainier/notebook/PrettyPrint.scala
@@ -1,0 +1,35 @@
+package com.stripe.rainier.notebook
+
+import com.stripe.rainier.compute._
+import com.stripe.rainier.core._
+import pprint.Tree
+import ammonite.repl.FullReplAPI
+
+object PrettyPrint {
+  def register(repl: FullReplAPI): Unit {
+      val p = repl.pprinter()
+      
+      p = p.copy(
+        additionalHandlers = p.additionalHandlers.orElse(handlers(p.treeify(_)) {
+        case f: Foo =>
+            pprint.Tree.Lazy(_ => Iterator(fansi.Color.Yellow(s"foo: ${f.x}").render))
+        }
+    )
+    repl.pprinter() = {
+    
+}
+  }
+
+  def bounds(b: Bounds): String =
+    if (b.lower == b.upper)
+      f"${b.lower}%.3g"
+    else
+      f"${b.lower}%.3g, ${b.upper}%.3g"
+
+  def handlers(treeify: Any => Tree): PartialFunction[Any,Tree] = {
+    case r: Real         => ???
+    case m: Model        => ???
+    case d: Distribution[_] => ???
+    case v: Vec[_] => Tree.Apply("Vec", v.toList.iterator.map{el => treeify(el)})
+  }
+}

--- a/rainier-notebook/src/main/scala/com/stripe/rainier/notebook/PrettyPrint.scala
+++ b/rainier-notebook/src/main/scala/com/stripe/rainier/notebook/PrettyPrint.scala
@@ -38,6 +38,7 @@ object PrettyPrint {
     case m: Model =>
       Tree.Literal(s"Model[${m.parameters.size}]")
     case t: Trace =>
-      Tree.Literal(s"Trace[${t.chains.size}][${t.chains.head.size}][${t.chains.head.head.size}]")
+      Tree.Literal(
+        s"Trace[${t.chains.size}][${t.chains.head.size}][${t.chains.head.head.size}]")
   }
 }

--- a/rainier-notebook/src/main/scala/com/stripe/rainier/notebook/PrettyPrintModifier.scala
+++ b/rainier-notebook/src/main/scala/com/stripe/rainier/notebook/PrettyPrintModifier.scala
@@ -1,0 +1,17 @@
+package com.stripe.rainier.notebook
+
+import mdoc._
+
+class PrettyPrintModifier extends PostModifier {
+  val name = "pprint"
+  val pprint = PrettyPrint.pprint()
+  def process(ctx: PostModifierContext): String = {
+    val variables = ctx.variables
+      .map { v =>
+        val pp = pprint(v.runtimeValue)
+        s"${v.name}: ${v.staticType} = $pp"
+      }
+      .mkString("\n")
+    s"```scala \n${ctx.originalCode.text}\n\n/*\n$variables\n*/\n```"
+  }
+}

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -46,6 +46,9 @@
       "real": {
         "title": "Real"
       },
+      "roadmap": {
+        "title": "Roadmap"
+      },
       "samplers": {
         "title": "Samplers"
       },


### PR DESCRIPTION
This replaces the simple `toString` overrides on Real, etc, with a mechanism for registering `PPrint` handlers with the `repl`; this works in Jupyter and ammonite, and should also work in mdoc.