### PR TITLE
Progress hook

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -98,6 +98,7 @@ lazy val rainierCore = project.
 
 lazy val rainierNotebook = project.
   in(file("rainier-notebook")).
+  dependsOn(rainierSampler).
   settings(name := "rainier-notebook").
   settings(commonSettings).
   settings(

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Model.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Model.scala
@@ -11,7 +11,8 @@ case class Model(private[rainier] val likelihoods: List[Real],
     Model(likelihoods ++ other.likelihoods, track ++ other.track)
 
   def sample(sampler: Sampler, nChains: Int = 4)(implicit rng: RNG,
-                                                 progress: Progress = SilentProgress): Trace = {
+                                                 progress: Progress =
+                                                   SilentProgress): Trace = {
     val states = progress.init(nChains)
     val chains = states.map { s =>
       sampler.sample(density(), s)

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Model.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Model.scala
@@ -11,9 +11,8 @@ case class Model(private[rainier] val likelihoods: List[Real],
     Model(likelihoods ++ other.likelihoods, track ++ other.track)
 
   def sample(sampler: Sampler, nChains: Int = 4)(implicit rng: RNG,
-                                                 progress: Option[Progress] =
-                                                   None): Trace = {
-    val states = progress.getOrElse(SilentProgress).init(nChains)
+                                                 progress: Progress = SilentProgress): Trace = {
+    val states = progress.init(nChains)
     val chains = states.map { s =>
       sampler.sample(density(), s)
     }.toList
@@ -54,7 +53,7 @@ object Model {
   def sample[T, U](t: T, sampler: Sampler = Sampler.default)(
       implicit toGen: ToGenerator[T, U],
       rng: RNG,
-      progress: Option[Progress] = None): List[U] = {
+      progress: Progress = SilentProgress): List[U] = {
     val gen = toGen(t)
     val model = Model.track(gen.requirements)
     val trace = model.sample(sampler, 1)

--- a/rainier-core/src/main/scala/com/stripe/rainier/core/Model.scala
+++ b/rainier-core/src/main/scala/com/stripe/rainier/core/Model.scala
@@ -10,10 +10,12 @@ case class Model(private[rainier] val likelihoods: List[Real],
   def merge(other: Model) =
     Model(likelihoods ++ other.likelihoods, track ++ other.track)
 
-  def sample(sampler: Sampler, nChains: Int = 4)(implicit rng: RNG): Trace = {
-    val range = 1.to(nChains)
-    val chains = range.map { _ =>
-      sampler.sample(density())
+  def sample(sampler: Sampler, nChains: Int = 4)(implicit rng: RNG,
+                                                 progress: Option[Progress] =
+                                                   None): Trace = {
+    val states = progress.getOrElse(SilentProgress).init(nChains)
+    val chains = states.map { s =>
+      sampler.sample(density(), s)
     }.toList
     Trace(chains, this)
   }
@@ -51,7 +53,8 @@ object Model {
 
   def sample[T, U](t: T, sampler: Sampler = Sampler.default)(
       implicit toGen: ToGenerator[T, U],
-      rng: RNG): List[U] = {
+      rng: RNG,
+      progress: Option[Progress] = None): List[U] = {
     val gen = toGen(t)
     val model = Model.track(gen.requirements)
     val trace = model.sample(sampler, 1)

--- a/rainier-notebook/src/main/scala/com/stripe/rainier/notebook/HTMLProgress.scala
+++ b/rainier-notebook/src/main/scala/com/stripe/rainier/notebook/HTMLProgress.scala
@@ -1,0 +1,21 @@
+package com.stripe.rainier.notebook
+
+import com.stripe.rainier.sampler._
+import almond.api.JupyterApi
+
+case class HTMLProgress(kernel: JupyterApi, delay: Double) extends Progress {
+  def init(n: Int) = {
+    val id = java.util.UUID.randomUUID().toString
+    1.to(n).toList.map { i =>
+      val idN = id + "-" + i
+      kernel.publish.html("Starting", idN)
+      ProgressState(delay, { p =>
+        render(p, idN)
+      })
+    }
+  }
+
+  def render(p: ProgressState, id: String): Unit = {
+    kernel.publish.updateHtml("Going", id)
+  }
+}

--- a/rainier-notebook/src/main/scala/com/stripe/rainier/notebook/HTMLProgress.scala
+++ b/rainier-notebook/src/main/scala/com/stripe/rainier/notebook/HTMLProgress.scala
@@ -8,14 +8,55 @@ case class HTMLProgress(kernel: JupyterApi, delay: Double) extends Progress {
     val id = java.util.UUID.randomUUID().toString
     1.to(n).toList.map { i =>
       val idN = id + "-" + i
-      kernel.publish.html("Starting", idN)
-      ProgressState(delay, { p =>
-        render(p, idN)
+      val chain = s"<b>Chain $i/$n</b>"
+      kernel.publish.html(chain, idN)
+      ProgressState(0.01, { p =>
+        kernel.publish.updateHtml(chain + ": " + render(p), idN)
       })
     }
   }
 
-  def render(p: ProgressState, id: String): Unit = {
-    kernel.publish.updateHtml("Going", id)
+  def renderTime(nanos: Long): String =
+    if (nanos < 1000)
+      s"${nanos}ns"
+    else if (nanos < 1e6)
+      f"${nanos / 1000}us"
+    else if (nanos < 1e9)
+      f"${nanos / 1000000}ms"
+    else {
+      val totalSeconds = nanos / 1000000000
+      if (totalSeconds < 60)
+        totalSeconds.toString + "s"
+      else {
+        val totalMinutes = totalSeconds / 60
+        val hours = totalMinutes / 60
+        val minutes = totalMinutes % 60
+        val seconds = totalSeconds % 60
+        f"${hours}%2d:${minutes}%2d:${seconds}%2d"
+      }
+    }
+
+  def render(p: ProgressState): String = {
+    val t = System.nanoTime()
+    val iteration =
+      if (p.phaseIterations > 0) {
+        val itNum = s"Iteration: ${p.currentIteration}/${p.phaseIterations}"
+        if (p.currentIteration > 0) {
+          val itTime = renderTime((t - p.phaseStartTime) / p.currentIteration)
+          s"$itNum ($itTime)"
+        } else
+          itNum
+      } else
+        ""
+    val stepSize = f"Step size: ${p.stepSize}%.5f"
+    val phaseTime = renderTime(t - p.phaseStartTime)
+    val totalTime = "Total time elapsed: " + renderTime(t - p.startTime)
+    val gradientTime =
+      if (p.gradientEvaluations > 0)
+        "(" + renderTime(p.gradientTime / p.gradientEvaluations) + ")"
+      else ""
+    val gradient =
+      f"Total gradient evaluations: ${p.gradientEvaluations.toDouble}%.1g $gradientTime"
+    s"${p.currentPhase} ($phaseTime) <div>$iteration</div> <div>$stepSize</div> <div>$gradient</div> <div>$totalTime</div>"
   }
 }

--- a/rainier-notebook/src/main/scala/com/stripe/rainier/notebook/HTMLProgress.scala
+++ b/rainier-notebook/src/main/scala/com/stripe/rainier/notebook/HTMLProgress.scala
@@ -10,7 +10,7 @@ case class HTMLProgress(kernel: JupyterApi, delay: Double) extends Progress {
       val idN = id + "-" + i
       val chain = s"<b>Chain $i/$n</b>"
       kernel.publish.html(chain, idN)
-      ProgressState(0.01, { p =>
+      ProgressState(0.1, { p =>
         kernel.publish.updateHtml(chain + ": " + render(p), idN)
       })
     }
@@ -57,6 +57,14 @@ case class HTMLProgress(kernel: JupyterApi, delay: Double) extends Progress {
       else ""
     val gradient =
       f"Total gradient evaluations: ${p.gradientEvaluations.toDouble}%.1g $gradientTime"
-    s"${p.currentPhase} ($phaseTime) <div>$iteration</div> <div>$stepSize</div> <div>$gradient</div> <div>$totalTime</div>"
+    val acceptance =
+      if (p.phaseIterations > 0)
+        f"Acceptance rate: ${p.phaseAcceptance / p.currentIteration}%.2f"
+      else ""
+    val pathLength =
+      if (p.phaseIterations > 0)
+        f"Mean path length: ${p.phasePathLength.toDouble / p.currentIteration}%.1f"
+      else ""
+    s"${p.currentPhase} ($phaseTime) <div>$iteration</div> <div>$acceptance</div> <div>$pathLength</div> <div>$stepSize</div> <div>$gradient</div> <div>$totalTime</div>"
   }
 }

--- a/rainier-notebook/src/main/scala/com/stripe/rainier/notebook/package.scala
+++ b/rainier-notebook/src/main/scala/com/stripe/rainier/notebook/package.scala
@@ -7,8 +7,11 @@ import com.cibo.evilplot.colors._
 import com.cibo.evilplot.plot.renderers._
 import com.cibo.evilplot.plot.aesthetics._
 import almond.display.Image
+import com.stripe.rainier.sampler._
 
 package object notebook {
+
+  import almond.api.JupyterApi
   object PlotThemes {
     private val blueColor = HSLA(211, 38, 48, 0.5)
     private val grayColor = HSLA(210, 100, 0, 0.2)
@@ -465,4 +468,7 @@ package object notebook {
 
   private def leftPad(s: String, len: Int, elem: Char): String =
     s.reverse.padTo(len, elem).reverse
+
+  implicit def progress(implicit kernel: JupyterApi): Progress =
+    HTMLProgress(kernel, 0.5)
 }

--- a/rainier-sampler/src/main/scala/com/stripe/rainier/sampler/EHMC.scala
+++ b/rainier-sampler/src/main/scala/com/stripe/rainier/sampler/EHMC.scala
@@ -15,12 +15,12 @@ final case class EHMC(warmupIterations: Int,
                       l0: Int = 10,
                       k: Int = 1000)
     extends Sampler {
-  def sample(density: DensityFunction)(
+  def sample(density: DensityFunction, progress: ProgressState)(
       implicit rng: RNG): List[Array[Double]] = {
     if (density.nVars == 0)
       return List.fill(iterations)(Array.empty[Double])
 
-    val lf = LeapFrog(density)
+    val lf = LeapFrog(density, progress)
     val params = lf.initialize
 
     FINE.log("Finding reasonable initial step size")

--- a/rainier-sampler/src/main/scala/com/stripe/rainier/sampler/EHMC.scala
+++ b/rainier-sampler/src/main/scala/com/stripe/rainier/sampler/EHMC.scala
@@ -1,8 +1,6 @@
 package com.stripe.rainier.sampler
 
 import scala.collection.mutable.ListBuffer
-import Log._
-import java.util.concurrent.TimeUnit._
 
 /**
   * Empirical HMC - automated tuning of step size and number of leapfrog steps
@@ -41,13 +39,11 @@ final case class EHMC(warmupIterations: Int,
     val empiricalL = Vector.fill(k) {
       lf.longestBatchStep(params, l0, stepSize)._2
     }
-    val sorted = empiricalL.toList.sorted
 
     if (stepSize == 0.0) {
       progress.finish()
       List(lf.variables(params))
-    }
-    else {
+    } else {
       val buf = new ListBuffer[Array[Double]]
       var i = 0
 
@@ -55,8 +51,7 @@ final case class EHMC(warmupIterations: Int,
       while (i < iterations) {
         val j = rng.int(k)
         val nSteps = empiricalL(j)
-        val logAccept = lf.step(params, nSteps, stepSize)
-        acceptSum += Math.exp(logAccept)
+        lf.step(params, nSteps, stepSize)
         buf += lf.variables(params)
         i += 1
       }

--- a/rainier-sampler/src/main/scala/com/stripe/rainier/sampler/EHMC.scala
+++ b/rainier-sampler/src/main/scala/com/stripe/rainier/sampler/EHMC.scala
@@ -23,51 +23,44 @@ final case class EHMC(warmupIterations: Int,
     val lf = LeapFrog(density, progress)
     val params = lf.initialize
 
-    FINE.log("Finding reasonable initial step size")
+    progress.start()
+    progress.startPhase("Finding reasonable initial step size", 0)
     val stepSize0 = DualAvg.findReasonableStepSize(lf, params)
-    FINE.log("Found initial step size of %f", stepSize0)
+    progress.updateStepSize(stepSize0)
 
-    FINE.log("Warming up for %d iterations", warmupIterations)
+    progress.startPhase("Finding step size using dual averaging",
+                        warmupIterations)
     val stepSize =
       DualAvg.findStepSize(0.65, stepSize0, warmupIterations) { ss =>
+        progress.updateStepSize(ss)
         lf.step(params, 1, ss)
       }
-    FINE.log("Found step size of %f", stepSize)
+    progress.updateStepSize(stepSize)
 
-    FINE.log("Sampling %d path lengths", k)
+    progress.startPhase("Sampling path lengths", k)
     val empiricalL = Vector.fill(k) {
       lf.longestBatchStep(params, l0, stepSize)._2
     }
     val sorted = empiricalL.toList.sorted
-    FINE.log("Using a range of %d to %d steps", sorted.head, sorted.last)
 
-    if (stepSize == 0.0)
+    if (stepSize == 0.0) {
+      progress.finish()
       List(lf.variables(params))
+    }
     else {
       val buf = new ListBuffer[Array[Double]]
       var i = 0
 
-      FINE.log("Sampling for %d iterations", iterations)
-
-      var acceptSum = 0.0
+      progress.startPhase("Sampling", iterations)
       while (i < iterations) {
         val j = rng.int(k)
         val nSteps = empiricalL(j)
-
-        FINER
-          .atMostEvery(1, SECONDS)
-          .log("Sampling iteration %d of %d for %d steps, acceptance rate %f",
-               i,
-               iterations,
-               nSteps,
-               (acceptSum / i))
-
         val logAccept = lf.step(params, nSteps, stepSize)
         acceptSum += Math.exp(logAccept)
         buf += lf.variables(params)
         i += 1
       }
-      FINE.log("Finished sampling, acceptance rate %f", (acceptSum / i))
+      progress.finish()
       buf.toList
     }
   }

--- a/rainier-sampler/src/main/scala/com/stripe/rainier/sampler/HMC.scala
+++ b/rainier-sampler/src/main/scala/com/stripe/rainier/sampler/HMC.scala
@@ -29,6 +29,7 @@ final case class HMC(warmupIterations: Int, iterations: Int, nSteps: Int)
 
     if (stepSize == 0.0) {
       WARNING.log("Found step size of 0.0, aborting!")
+      progress.finish()
       List(lf.variables(params))
     } else {
       val buf = new ListBuffer[Array[Double]]
@@ -41,6 +42,7 @@ final case class HMC(warmupIterations: Int, iterations: Int, nSteps: Int)
         i += 1
       }
 
+      progress.finish()
       buf.toList
     }
   }

--- a/rainier-sampler/src/main/scala/com/stripe/rainier/sampler/LeapFrog.scala
+++ b/rainier-sampler/src/main/scala/com/stripe/rainier/sampler/LeapFrog.scala
@@ -175,6 +175,7 @@ private[sampler] case class LeapFrog(density: DensityFunction,
     finalHalfStep(stepSize)
     val p = logAcceptanceProb(params, pqBuf)
     progress.trackIteration(Math.exp(p), 1)
+    p
   }
 
   //attempt to take N steps

--- a/rainier-sampler/src/main/scala/com/stripe/rainier/sampler/LeapFrog.scala
+++ b/rainier-sampler/src/main/scala/com/stripe/rainier/sampler/LeapFrog.scala
@@ -3,7 +3,8 @@ package com.stripe.rainier.sampler
 import Log._
 import java.util.concurrent.TimeUnit._
 
-private[sampler] case class LeapFrog(density: DensityFunction) {
+private[sampler] case class LeapFrog(density: DensityFunction,
+                                     progress: ProgressState) {
   /*
   Params layout:
   array(0..(n-1)) == ps

--- a/rainier-sampler/src/main/scala/com/stripe/rainier/sampler/Progress.scala
+++ b/rainier-sampler/src/main/scala/com/stripe/rainier/sampler/Progress.scala
@@ -1,3 +1,67 @@
 package com.stripe.rainier.sampler
 
-trait Progress {}
+trait Progress {
+  def init(chains: Int): List[ProgressState]
+}
+
+object SilentProgress extends Progress {
+  def init(chains: Int): List[ProgressState] =
+    List.fill(chains)(ProgressState(1e6, { _ =>
+      ()
+    }))
+}
+
+case class ProgressState(outputEverySeconds: Double,
+                         fn: ProgressState => Unit) {
+  var startTime = 0L
+  var phaseStartTime = 0L
+  var currentPhase = ""
+  var currentIteration = 0
+  var phaseIterations = 0
+  var gradientEvaluations = 0
+  var gradientTime = 0L
+  var lastGradientTime = 0L
+  var phaseAcceptance = 0.0
+  var phasePathLength = 0L
+  var stepSize = 0.0
+  var lastOutputTime = 0L
+
+  def start() = {
+    startTime = System.nanoTime()
+  }
+
+  def startPhase(phase: String, iterations: Int) = {
+    currentPhase = phase
+    phaseStartTime = System.nanoTime()
+    phaseAcceptance = 0.0
+    phasePathLength = 0L
+    phaseIterations = iterations
+  }
+
+  def startGradient(): Unit = {
+    lastGradientTime = System.nanoTime()
+  }
+
+  def endGradient(): Unit = {
+    gradientTime += (System.nanoTime() - lastGradientTime)
+    gradientEvaluations += 1
+  }
+
+  def trackIteration(accept: Double, pathLength: Int): Unit = {
+    phaseAcceptance += accept
+    phasePathLength += pathLength
+    currentIteration += 1
+  }
+
+  def updateStepSize(n: Double): Unit = {
+    stepSize = n
+  }
+
+  def checkOutput() = {
+    val t = System.nanoTime()
+    if (t - lastOutputTime > 5e8) { //0.5s
+      fn(this)
+      lastOutputTime = t
+    }
+  }
+}

--- a/rainier-sampler/src/main/scala/com/stripe/rainier/sampler/Progress.scala
+++ b/rainier-sampler/src/main/scala/com/stripe/rainier/sampler/Progress.scala
@@ -28,7 +28,7 @@ case class ProgressState(outputEverySeconds: Double,
 
   def start(): Unit = {
     startTime = System.nanoTime()
-    lastOutputTime = System.nanoTime
+    lastOutputTime = System.nanoTime()
   }
 
   def finish(): Unit = {

--- a/rainier-sampler/src/main/scala/com/stripe/rainier/sampler/Progress.scala
+++ b/rainier-sampler/src/main/scala/com/stripe/rainier/sampler/Progress.scala
@@ -63,7 +63,7 @@ case class ProgressState(outputEverySeconds: Double,
 
   def checkOutput() = {
     val t = System.nanoTime()
-    if (t - lastOutputTime > outputEverySeconds) {
+    if ((t - lastOutputTime).toDouble / 1e9 > outputEverySeconds) {
       fn(this)
       lastOutputTime = t
     }

--- a/rainier-sampler/src/main/scala/com/stripe/rainier/sampler/Progress.scala
+++ b/rainier-sampler/src/main/scala/com/stripe/rainier/sampler/Progress.scala
@@ -1,0 +1,3 @@
+package com.stripe.rainier.sampler
+
+trait Progress {}

--- a/rainier-sampler/src/main/scala/com/stripe/rainier/sampler/Progress.scala
+++ b/rainier-sampler/src/main/scala/com/stripe/rainier/sampler/Progress.scala
@@ -28,6 +28,7 @@ case class ProgressState(outputEverySeconds: Double,
 
   def start(): Unit = {
     startTime = System.nanoTime()
+    lastOutputTime = System.nanoTime()
   }
 
   def finish(): Unit = {

--- a/rainier-sampler/src/main/scala/com/stripe/rainier/sampler/Progress.scala
+++ b/rainier-sampler/src/main/scala/com/stripe/rainier/sampler/Progress.scala
@@ -28,7 +28,7 @@ case class ProgressState(outputEverySeconds: Double,
 
   def start(): Unit = {
     startTime = System.nanoTime()
-    lastOutputTime = System.nanoTime()
+    lastOutputTime = System.nanoTime
   }
 
   def finish(): Unit = {
@@ -41,32 +41,37 @@ case class ProgressState(outputEverySeconds: Double,
     phaseAcceptance = 0.0
     phasePathLength = 0L
     phaseIterations = iterations
+    checkOutput()
   }
 
   def startGradient(): Unit = {
     lastGradientTime = System.nanoTime()
+    checkOutput()
   }
 
   def endGradient(): Unit = {
     gradientTime += (System.nanoTime() - lastGradientTime)
     gradientEvaluations += 1
+    checkOutput()
   }
 
   def trackIteration(accept: Double, pathLength: Int): Unit = {
     phaseAcceptance += accept
     phasePathLength += pathLength
     currentIteration += 1
+    checkOutput()
   }
 
   def updateStepSize(n: Double): Unit = {
     stepSize = n
+    checkOutput()
   }
 
-  def checkOutput() = {
+  def checkOutput(): Unit = {
     val t = System.nanoTime()
-    //if ((t - lastOutputTime).toDouble / 1e9 > outputEverySeconds) {
+    if ((t - lastOutputTime).toDouble / 1e9 > outputEverySeconds) {
       fn(this)
       lastOutputTime = t
-    //}
+    }
   }
 }

--- a/rainier-sampler/src/main/scala/com/stripe/rainier/sampler/Progress.scala
+++ b/rainier-sampler/src/main/scala/com/stripe/rainier/sampler/Progress.scala
@@ -64,9 +64,9 @@ case class ProgressState(outputEverySeconds: Double,
 
   def checkOutput() = {
     val t = System.nanoTime()
-    if ((t - lastOutputTime).toDouble / 1e9 > outputEverySeconds) {
+    //if ((t - lastOutputTime).toDouble / 1e9 > outputEverySeconds) {
       fn(this)
       lastOutputTime = t
-    }
+    //}
   }
 }

--- a/rainier-sampler/src/main/scala/com/stripe/rainier/sampler/Progress.scala
+++ b/rainier-sampler/src/main/scala/com/stripe/rainier/sampler/Progress.scala
@@ -63,7 +63,7 @@ case class ProgressState(outputEverySeconds: Double,
 
   def checkOutput() = {
     val t = System.nanoTime()
-    if (t - lastOutputTime > 5e8) { //0.5s
+    if (t - lastOutputTime > outputEverySeconds) {
       fn(this)
       lastOutputTime = t
     }

--- a/rainier-sampler/src/main/scala/com/stripe/rainier/sampler/Progress.scala
+++ b/rainier-sampler/src/main/scala/com/stripe/rainier/sampler/Progress.scala
@@ -26,11 +26,15 @@ case class ProgressState(outputEverySeconds: Double,
   var stepSize = 0.0
   var lastOutputTime = 0L
 
-  def start() = {
+  def start(): Unit = {
     startTime = System.nanoTime()
   }
 
-  def startPhase(phase: String, iterations: Int) = {
+  def finish(): Unit = {
+    fn(this)
+  }
+
+  def startPhase(phase: String, iterations: Int): Unit = {
     currentPhase = phase
     phaseStartTime = System.nanoTime()
     phaseAcceptance = 0.0

--- a/rainier-sampler/src/main/scala/com/stripe/rainier/sampler/Progress.scala
+++ b/rainier-sampler/src/main/scala/com/stripe/rainier/sampler/Progress.scala
@@ -41,6 +41,7 @@ case class ProgressState(outputEverySeconds: Double,
     phaseAcceptance = 0.0
     phasePathLength = 0L
     phaseIterations = iterations
+    currentIteration = 0
     checkOutput()
   }
 

--- a/rainier-sampler/src/main/scala/com/stripe/rainier/sampler/Sampler.scala
+++ b/rainier-sampler/src/main/scala/com/stripe/rainier/sampler/Sampler.scala
@@ -1,7 +1,8 @@
 package com.stripe.rainier.sampler
 
 trait Sampler {
-  def sample(density: DensityFunction)(implicit rng: RNG): List[Array[Double]]
+  def sample(density: DensityFunction, progress: ProgressState)(
+      implicit rng: RNG): List[Array[Double]]
 }
 
 object Sampler {


### PR DESCRIPTION
This closes #465 by providing a hook for displaying progress during HMC sampling.
It also provides a Jupyter progress implementation in rainier-notebook:

<img width="511" alt="Screen Shot 2020-02-13 at 10 40 36 AM" src="https://user-images.githubusercontent.com/9892/74467121-585a9080-4e4d-11ea-9e5f-73f9ec12266e.png">

@ColCarroll, this one's for you.