### PR TITLE
E-BFMI

### DIFF
--- a/rainier-notebook/src/main/scala/com/stripe/rainier/notebook/HTMLProgress.scala
+++ b/rainier-notebook/src/main/scala/com/stripe/rainier/notebook/HTMLProgress.scala
@@ -7,22 +7,24 @@ case class HTMLProgress(kernel: JupyterApi, delay: Double) extends Progress {
   val id = java.util.UUID.randomUUID().toString
 
   val outputEverySeconds = 0.1
+  var startTime: Long = _
 
-  def start(chain: Int, stats: Stats) = {
+  def start(chain: Int, message: String, stats: Stats) = {
+    startTime = System.nanoTime()
     val idN = id + "-" + chain
     val chainStr = s"<b>Chain ${chain}</b>"
     kernel.publish.html(chainStr, idN)
   }
 
-  def refresh(chain: Int, stats: Stats) = {
+  def refresh(chain: Int, message: String, stats: Stats) = {
     val idN = id + "-" + chain
-    val chainStr = s"<b>Chain ${chain}</b>"
+    val chainStr = s"<b>Chain ${chain} ${message}</b>"
     kernel.publish.updateHtml(chainStr + ": " + render(stats), idN)
   }
 
-  def finish(chain: Int, stats: Stats) = {
+  def finish(chain: Int, message: String, stats: Stats) = {
     val idN = id + "-" + chain
-    val chainStr = s"<b>Chain ${chain} complete</b>"
+    val chainStr = s"<b>Chain ${chain} ${message}</b>"
     kernel.publish.updateHtml(chainStr + ": " + render(stats), idN)
   }
 
@@ -66,6 +68,13 @@ case class HTMLProgress(kernel: JupyterApi, delay: Double) extends Progress {
       if (p.iterations > 0)
         f"Acceptance rate: ${p.acceptanceRates.mean}%.2f"
       else ""
-    s"<div>$iteration</div> <div>$acceptance</div> <div>$stepSize</div> <div>$gradient</div>"
+    val totalTime =
+      s"Total time: ${renderTime(System.nanoTime() - startTime)}"
+    val bfmi =
+      if (p.iterations > 10)
+        f"E-BFMI: ${p.bfmi}%.2f"
+      else ""
+
+    s"<div>$iteration</div> <div>$acceptance</div> <div>$bfmi</div> <div>$stepSize</div> <div>$gradient</div> <div>$totalTime</div>"
   }
 }

--- a/rainier-sampler/src/main/scala/com/stripe/rainier/sampler/Driver.scala
+++ b/rainier-sampler/src/main/scala/com/stripe/rainier/sampler/Driver.scala
@@ -13,9 +13,9 @@ object Driver {
     val stepSizeTuner = config.stepSizeTuner()
     val metricTuner = config.metricTuner()
 
-    val lf = new LeapFrog(density)
+    val lf = new LeapFrog(density, config.statsWindow)
 
-    progress.start(chain, lf.stats)
+    progress.start(chain, "Initializing", lf.stats)
 
     FINE.log("Starting warmup")
     val params = warmup(chain,
@@ -25,7 +25,7 @@ object Driver {
                         metricTuner,
                         config.warmupIterations,
                         progress)
-
+    lf.resetStats()
     FINE.log("Starting sampling")
     val samples = collectSamples(chain,
                                  params,
@@ -38,7 +38,7 @@ object Driver {
 
     FINE.log("Finished sampling")
 
-    progress.finish(chain, lf.stats)
+    progress.finish(chain, "Complete", lf.stats)
     samples
   }
 
@@ -76,7 +76,7 @@ object Driver {
         case None => ()
       }
       if (System.nanoTime() > nextOutputTime) {
-        progress.refresh(chain, lf.stats)
+        progress.refresh(chain, "Warmup", lf.stats)
         nextOutputTime = System
           .nanoTime() + (progress.outputEverySeconds * 1e9).toLong
       }
@@ -105,7 +105,7 @@ object Driver {
       buf += output
 
       if (System.nanoTime() > nextOutputTime) {
-        progress.refresh(chain, lf.stats)
+        progress.refresh(chain, "Sampling", lf.stats)
         nextOutputTime = System
           .nanoTime() + (progress.outputEverySeconds * 1e9).toLong
       }

--- a/rainier-sampler/src/main/scala/com/stripe/rainier/sampler/EHMC.scala
+++ b/rainier-sampler/src/main/scala/com/stripe/rainier/sampler/EHMC.scala
@@ -13,7 +13,7 @@ class EHMCSampler(minSteps: Int, maxSteps: Int, numLengths: Int, pCount: Double)
              lf: LeapFrog,
              stepSize: Double,
              metric: Metric)(implicit rng: RNG): Double = {
-    lf.startIteration(params)
+    lf.startIteration(params, metric)
     if (shouldCountSteps())
       countSteps(params, lf, stepSize, metric)
     else
@@ -48,7 +48,7 @@ class EHMCSampler(minSteps: Int, maxSteps: Int, numLengths: Int, pCount: Double)
           lf: LeapFrog,
           stepSize: Double,
           metric: Metric)(implicit rng: RNG): Unit = {
-    lf.startIteration(params)
+    lf.startIteration(params, metric)
     lf.takeSteps(nSteps(stepSize), stepSize, metric)
     lf.finishIteration(params, metric)
     ()
@@ -68,6 +68,7 @@ object EHMC {
     new SamplerConfig {
       val warmupIterations = warmIt
       val iterations = it
+      val statsWindow = 100
       def sampler() = new EHMCSampler(minSteps, 32, numLengths, 0.1)
       def stepSizeTuner() = new DualAvgTuner(0.65)
       def metricTuner() = new StandardMetricTuner()

--- a/rainier-sampler/src/main/scala/com/stripe/rainier/sampler/HMC.scala
+++ b/rainier-sampler/src/main/scala/com/stripe/rainier/sampler/HMC.scala
@@ -7,7 +7,7 @@ class HMCSampler(nSteps: Int) extends Sampler {
              lf: LeapFrog,
              stepSize: Double,
              metric: Metric)(implicit rng: RNG): Double = {
-    lf.startIteration(params)
+    lf.startIteration(params, metric)
     lf.takeSteps(nSteps, stepSize, metric)
     lf.finishIteration(params, metric)
   }
@@ -16,7 +16,7 @@ class HMCSampler(nSteps: Int) extends Sampler {
           lf: LeapFrog,
           stepSize: Double,
           metric: Metric)(implicit rng: RNG): Unit = {
-    lf.startIteration(params)
+    lf.startIteration(params, metric)
     lf.takeSteps(nSteps, stepSize, metric)
     lf.finishIteration(params, metric)
     ()
@@ -28,6 +28,7 @@ object HMC {
     new SamplerConfig {
       val warmupIterations = warmIt
       val iterations = it
+      val statsWindow = 100
       def sampler() = new HMCSampler(nSteps)
       def stepSizeTuner() = new DualAvgTuner(0.65)
       def metricTuner() = new StandardMetricTuner()

--- a/rainier-sampler/src/main/scala/com/stripe/rainier/sampler/Progress.scala
+++ b/rainier-sampler/src/main/scala/com/stripe/rainier/sampler/Progress.scala
@@ -1,24 +1,24 @@
 package com.stripe.rainier.sampler
 
 trait Progress {
-  def start(chain: Int, stats: Stats): Unit
-  def refresh(chain: Int, stats: Stats): Unit
-  def finish(chain: Int, stats: Stats): Unit
+  def start(chain: Int, message: String, stats: Stats): Unit
+  def refresh(chain: Int, message: String, stats: Stats): Unit
+  def finish(chain: Int, message: String, stats: Stats): Unit
   def outputEverySeconds: Double
 }
 
 object SilentProgress extends Progress {
-  def start(chain: Int, stats: Stats): Unit = ()
-  def refresh(chain: Int, stats: Stats): Unit = ()
-  def finish(chain: Int, stats: Stats): Unit = ()
+  def start(chain: Int, message: String, stats: Stats): Unit = ()
+  def refresh(chain: Int, message: String, stats: Stats): Unit = ()
+  def finish(chain: Int, message: String, stats: Stats): Unit = ()
   val outputEverySeconds = 1e100
 }
 
 object ConsoleProgress extends Progress {
-  def start(chain: Int, stats: Stats): Unit = ()
-  def refresh(chain: Int, stats: Stats): Unit =
-    println(s"Chain ${chain}: Iteration ${stats.iterations}")
-  def finish(chain: Int, stats: Stats): Unit =
-    refresh(chain, stats)
+  def start(chain: Int, message: String, stats: Stats): Unit = ()
+  def refresh(chain: Int, message: String, stats: Stats): Unit =
+    println(s"Chain ${chain} ${message}: Iteration ${stats.iterations}")
+  def finish(chain: Int, message: String, stats: Stats): Unit =
+    refresh(chain, message, stats)
   val outputEverySeconds = 0.5
 }

--- a/rainier-sampler/src/main/scala/com/stripe/rainier/sampler/Sampler.scala
+++ b/rainier-sampler/src/main/scala/com/stripe/rainier/sampler/Sampler.scala
@@ -3,6 +3,7 @@ package com.stripe.rainier.sampler
 trait SamplerConfig {
   def iterations: Int
   def warmupIterations: Int
+  def statsWindow: Int
 
   def stepSizeTuner(): StepSizeTuner
   def metricTuner(): MetricTuner

--- a/rainier-sampler/src/main/scala/com/stripe/rainier/sampler/Stats.scala
+++ b/rainier-sampler/src/main/scala/com/stripe/rainier/sampler/Stats.scala
@@ -1,13 +1,19 @@
 package com.stripe.rainier.sampler
 
 class Stats(n: Int) {
-  var gradientEvaluations = 0
+  var gradientEvaluations = 0L
   var iterations = 0
+  var divergences = 0
 
   val gradientTimes = new RingBuffer(n)
   val iterationTimes = new RingBuffer(n)
   val stepSizes = new RingBuffer(n)
   val acceptanceRates = new RingBuffer(n)
+  val gradsPerIteration = new RingBuffer(n)
+
+  val energyVariance = new VarianceEstimator(1)
+  var energyTransitions2 = 0.0
+  def bfmi = energyTransitions2 / energyVariance.raw(0)
 }
 
 class RingBuffer(size: Int) {

--- a/rainier-sampler/src/main/scala/com/stripe/rainier/sampler/VarianceEstimator.scala
+++ b/rainier-sampler/src/main/scala/com/stripe/rainier/sampler/VarianceEstimator.scala
@@ -1,0 +1,61 @@
+package com.stripe.rainier.sampler
+
+class VarianceEstimator(size: Int) {
+  var samples = 0
+  val mean = new Array[Double](size)
+  val raw = new Array[Double](size)
+
+  val oldDiff = new Array[Double](size)
+  val newDiff = new Array[Double](size)
+
+  def reset() = {
+    var i = 0
+    while (i < size) {
+      mean(i) = 0.0
+      raw(i) = 0.0
+      i += 1
+    }
+  }
+
+  def update(sample: Array[Double]): Unit = {
+    samples += 1
+    diff(sample, oldDiff)
+    var i = 0
+    while (i < size) {
+      mean(i) += (oldDiff(i) / samples.toDouble)
+      i += 1
+    }
+    diff(sample, newDiff)
+
+    var j = 0
+    while (j < size) {
+      raw(j) += oldDiff(j) * newDiff(j)
+      j += 1
+    }
+  }
+
+  //special case used for size=1
+  val buf1D = Array(0.0)
+  def update(sample: Double): Unit = {
+    buf1D(0) = sample
+    update(buf1D)
+  }
+
+  def variance(): Array[Double] = {
+    val elements = new Array[Double](size)
+    var i = 0
+    while (i < size) {
+      elements(i) = raw(i) / samples.toDouble
+      i += 1
+    }
+    elements
+  }
+
+  private def diff(sample: Array[Double], buf: Array[Double]): Unit = {
+    var i = 0
+    while (i < size) {
+      buf(i) = sample(i) - mean(i)
+      i += 1
+    }
+  }
+}


### PR DESCRIPTION
This adds online computation of the E-BFMI metric, that can be displayed along with other progress information to give a more nuanced view than acceptance rate of how a sampler is doing.

Because BFMI is not a windowed computation, this adds an explicit reset of the stats between the warmup and sampling stages, along with extending Progress to show a message for the current stage.

