### PR TITLE
Fix step size adaptation

### DIFF
--- a/rainier-notebook/src/main/scala/com/stripe/rainier/notebook/HTMLProgress.scala
+++ b/rainier-notebook/src/main/scala/com/stripe/rainier/notebook/HTMLProgress.scala
@@ -74,11 +74,6 @@ case class HTMLProgress(kernel: JupyterApi, delay: Double) extends Progress {
       if (p.iterations > 10)
         f"E-BFMI: ${p.bfmi}%.2f"
       else ""
-    val mm = mass match {
-      case DiagonalMassMatrix(elements) =>
-        "Mass matrix: " + elements.toList.toString
-      case _ => ""
-    }
-    s"<div>$iteration</div> <div>$acceptance</div> <div>$bfmi</div> <div>$stepSize</div> <div>$mm</div> <div>$gradient</div> <div>$totalTime</div>"
+    s"<div>$iteration</div> <div>$acceptance</div> <div>$bfmi</div> <div>$stepSize</div> <div>$gradient</div> <div>$totalTime</div>"
   }
 }

--- a/rainier-notebook/src/main/scala/com/stripe/rainier/notebook/HTMLProgress.scala
+++ b/rainier-notebook/src/main/scala/com/stripe/rainier/notebook/HTMLProgress.scala
@@ -1,6 +1,8 @@
 package com.stripe.rainier.notebook
 
 import com.stripe.rainier.sampler._
+import com.stripe.rainier.unused
+
 import almond.api.JupyterApi
 
 case class HTMLProgress(kernel: JupyterApi, delay: Double) extends Progress {
@@ -48,7 +50,7 @@ case class HTMLProgress(kernel: JupyterApi, delay: Double) extends Progress {
       }
     }
 
-  private def render(p: Stats, mass: MassMatrix): String = {
+  private def render(p: Stats, @unused mass: MassMatrix): String = {
     val iteration =
       if (p.iterations > 0) {
         val itNum = s"Iteration: ${p.iterations}"

--- a/rainier-sampler/src/main/scala/com/stripe/rainier/sampler/Driver.scala
+++ b/rainier-sampler/src/main/scala/com/stripe/rainier/sampler/Driver.scala
@@ -66,8 +66,7 @@ object Driver {
 
     while (i < iterations) {
       val logAcceptProb = sampler.warmup(params, lf, stepSize, mass)
-      //if (i < 100 || i > 900)
-        stepSize = stepSizeTuner.update(logAcceptProb)
+      stepSize = stepSizeTuner.update(logAcceptProb)
 
       FINEST.log("Accept probability %f", Math.exp(logAcceptProb))
       FINEST.log("Adapted step size %f", stepSize)

--- a/rainier-sampler/src/main/scala/com/stripe/rainier/sampler/Driver.scala
+++ b/rainier-sampler/src/main/scala/com/stripe/rainier/sampler/Driver.scala
@@ -66,7 +66,7 @@ object Driver {
 
     while (i < iterations) {
       val logAcceptProb = sampler.warmup(params, lf, stepSize, mass)
-      if (i < 100 || i > 900)
+      //if (i < 100 || i > 900)
         stepSize = stepSizeTuner.update(logAcceptProb)
 
       FINEST.log("Accept probability %f", Math.exp(logAcceptProb))


### PR DESCRIPTION
I accidentally left in a hardcoded disabling of step size adaptation except at the start and end of a 1000 iteration warmup. This fixes that.

It also removes the spammy mass matrix output from the HTML progress.